### PR TITLE
Fix a clippy warning

### DIFF
--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -270,7 +270,7 @@ impl EnvBackend for EnvInstance {
             enc_input,
             &mut &mut output[..],
         ))?;
-        let decoded = decode_to_result(&mut &output[..])?;
+        let decoded = decode_to_result(&output[..])?;
         Ok(decoded)
     }
 }


### PR DESCRIPTION
The `clippy` warning prevents our CI from building a new container ...