### PR TITLE
Improve documentation of `debug_print` macro

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -114,11 +114,11 @@ cfg_if::cfg_if! {
         pub use ink_prelude::format;
 
         /// Appends a formatted string to the `debug_message` buffer if message recording is
-        /// enabled in the contracts pallet and if the call is performed via RPC (*not* via an
+        /// enabled in the contracts pallet and if the call is performed via RPC (**not** via an
         /// extrinsic). The `debug_message` buffer will be:
         ///  - Returned to the RPC caller.
-        ///  - Logged as a `debug!` message on the substrate node, which will be printed to the
-        ///    node console's `stdout` when the log level is set to `debug`.
+        ///  - Logged as a `debug!` message on the Substrate node, which will be printed to the
+        ///    node console's `stdout` when the log level is set to `-lruntime::contracts=debug`.
         ///
         /// # Note
         ///


### PR DESCRIPTION
Debug message is not logged when a call is performed via an extrinsic