### PR TITLE
Limit `ink_eth_compatibility` crate keywords to five

### DIFF
--- a/crates/eth_compatibility/Cargo.toml
+++ b/crates/eth_compatibility/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/ink"
 documentation = "https://docs.rs/ink_eth_compatibility/"
 homepage = "https://www.parity.io/"
 description = "[ink!] Ethereum related stuff."
-keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl", "ethereum"]
+keywords = ["wasm", "parity", "webassembly", "blockchain", "ethereum"]
 categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 


### PR DESCRIPTION
Otherwise crates.io refrains from publishing:
```
invalid upload request: invalid length 6, expected at most 5 keywords per crate
```