### PR TITLE
`[ink_e2e]` fix for contracts part of a virtual manifest

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -214,12 +214,7 @@ impl ContractManifests {
         let cmd = cargo_metadata::MetadataCommand::new();
         let metadata = cmd
             .exec()
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Error invoking `cargo metadata`: {}",
-                    err
-                )
-            });
+            .unwrap_or_else(|err| panic!("Error invoking `cargo metadata`: {}", err));
 
         fn maybe_contract_package(package: &cargo_metadata::Package) -> Option<String> {
             package


### PR DESCRIPTION
Fixes https://github.com/paritytech/ink/issues/1672