### PR TITLE
fix(xcm): use single encoding for XCM messages

### DIFF
--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -735,8 +735,8 @@ impl TypedEnvBackend for EnvInstance {
     {
         let mut scope = self.scoped_buffer();
 
-        // Double encoding the message as the host fn expects an encoded message.
-        let enc_msg = scope.take_encoded(&scale::Encode::encode(msg));
+        let enc_msg = scope.take_encoded(msg);
+
         #[allow(deprecated)]
         ext::xcm_execute(enc_msg).map_err(Into::into)
     }
@@ -755,8 +755,7 @@ impl TypedEnvBackend for EnvInstance {
         scope.append_encoded(dest);
         let enc_dest = scope.take_appended();
 
-        // Double encoding the message as the host fn expects an encoded message.
-        scope.append_encoded(&scale::Encode::encode(msg));
+        scope.append_encoded(msg);
         let enc_msg = scope.take_appended();
         #[allow(deprecated)]
         ext::xcm_send(enc_dest, enc_msg, output.try_into().unwrap())?;


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes? -> kinda, see notes below.
- [y] y/n | Is it dependant on the specific version of `cargo-contract` or **`pallet-contracts`**?
<!--- Provide a general summary of your changes -->
A later release of `pallet-contracts` changes the expected XCM message format for `xcm_execute` and `xcm_send` from requiring a double encoded message, to a single encoded message. 

Compatible with `pallet-contracts` on `polkadot-v1.11.0` and greater.

## Description
<!--- Describe your changes in detail -->
ink!'s XCM support was originally merged on `polkadot-v1.10.0`, where XCM used `execute_blob` and `send_blob`. These accepted an encoded XCM message, which required that ink! double encode XCM messages. 

However,  in this commit [Revert execute_blob and send_blob (#4266) ](https://github.com/paritytech/polkadot-sdk/commit/4f3d43a0c4e75caf73c1034a85590f81a9ae3809#diff-742026ed87c0710683d2ef4263b463a3e6f0acfae3c8fad80f2f3d291088997fL308), `execute_blob` was replaced by `execute` which accepts a `VersionedXcm<RuntimeCall>` message. This requires that ink! single encodes the XCM message.
<img width="1322" alt="Screenshot 2024-08-27 at 3 59 26 PM" src="https://github.com/user-attachments/assets/0a21bc28-02bf-4b6f-b762-100cf6be0cfb">

XCM support in ink! has not had an official release, and remained in the master branch only. Additionally, since the initial support, `pallet-contracts` has stabilized the [XCM host fns](https://github.com/paritytech/polkadot-sdk/commit/b801d001e812778b1547352468d5f243b7070994).

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [n] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works -> 
- [y] Any dependent changes have been merged and published in downstream modules
