### PR TITLE
Fix port passing from node process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Restrict which `cfg` attributes can be used ‒ [#2313](https://github.com/use-ink/ink/pull/2313)
 
+## Fixed
+- [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)
+
 ## Version 5.1.0
 
 This is the first ink! release outside of Parity. ink! was started at Parity and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ to cross-contract calls, but can now execute cross-parachain calls.
 We added a contract example that demonstrates the usage:
 [`contract-xcm`](https://github.com/use-ink/ink-examples/tree/main/contract-xcm)
 
-We also added a new page on our documentation website: 
+We also added a new page on our documentation website:
 [https://use.ink/basics/xcm](https://use.ink/basics/xcm).
 
 You can view the Rust docs of the two functions here:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,6 +2792,7 @@ dependencies = [
  "pallet-contracts",
  "pallet-contracts-mock-network",
  "parity-scale-codec",
+ "regex",
  "scale-info",
  "serde",
  "serde_json",

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -47,6 +47,7 @@ sp-core = { workspace = true }
 sp-keyring = { workspace = true }
 sp-runtime = { workspace = true }
 sp-weights = { workspace = true }
+regex = "1.11.1"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`


### PR DESCRIPTION
Closes https://github.com/use-ink/ink/issues/2335.

I'll make sure the CI would have catched this in a follow-up PR. The solution there is to migrate to our own Docker image for the CI, the Parity one hasn't been updated in months.