### PR TITLE
Migrate from `paritytech/ci-unified` to `useink/ci` docker image

### DIFF
--- a/.github/rust-info/action.yml
+++ b/.github/rust-info/action.yml
@@ -11,14 +11,5 @@ runs:
         cargo spellcheck --version
         bash --version
         substrate-contracts-node --version
-
-        # TODO: The installation of `cargo-contract` here can be removed after
-        # a new image of https://hub.docker.com/r/paritytech/ci-unified/tags has
-        # been published. At the time of this commit the Docker image is from
-        # Sep 11, 2024. This means that the `cargo-contract` binary in the image
-        # is also that old. There was a bug with `cargo-contract` erring on
-        # newer Rust versions (https://github.com/use-ink/cargo-contract/pull/1786),
-        # hence we make sure to use the latest `cargo-contract` here.
-        cargo install --git https://github.com/paritytech/cargo-contract --locked --branch master --force
         cargo-contract --version
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
       - 'FILE_HEADER'
 
 env:
-  IMAGE:                           paritytech/ci-unified:bullseye-1.81.0
+  IMAGE:                           useink/ci
   CARGO_TARGET_DIR:                /ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
   CARGO_INCREMENTAL:               0
   PURELY_STD_CRATES:               ink/codegen metadata engine e2e e2e/macro ink/ir
@@ -505,7 +505,7 @@ jobs:
         env:
           # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
           RUSTFLAGS:                     -Clink-arg=-z -Clink-arg=nostart-stop-gc
-        uses: docker://paritytech/ci-unified:bullseye-1.81.0
+        uses: docker://useink/ci
         with:
           # run all tests with --all-features, which will run the e2e-tests feature if present
           args: /bin/bash -c "scripts/for_all_contracts_exec.sh --path integration-tests --ignore public/static-buffer --partition ${{ matrix.partition }}/6 -- cargo test \

--- a/.github/workflows/measurements.yml
+++ b/.github/workflows/measurements.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: paritytech/ci-unified:bullseye-1.81.0
+      image: useink/ci
     strategy:
       fail-fast: false
       matrix:

--- a/crates/ink/tests/ui/storage_item/fail/collections_only_packed_1.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/collections_only_packed_1.stderr
@@ -23,6 +23,56 @@ error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
    = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
    = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
 
+error[E0277]: the trait bound `Vec<NonPacked>: ink::parity_scale_codec::Decode` is not satisfied
+  --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
+   |
+10 | struct Contract {
+   |        ^^^^^^^^ the trait `ink::parity_scale_codec::Decode` is not implemented for `Vec<NonPacked>`, which is required by `Contract: Sized`
+   |
+   = help: the trait `ink::parity_scale_codec::Decode` is implemented for `Vec<T>`
+   = note: required for `Vec<NonPacked>` to implement `Packed`
+   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
+   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
+note: required because it appears within the type `Contract`
+  --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
+   |
+10 | struct Contract {
+   |        ^^^^^^^^
+note: required by a bound in `ink_storage::ink_storage_traits::StorableHint::Type`
+  --> $WORKSPACE/crates/storage/traits/src/storage.rs
+   |
+   |     type Type: Storable;
+   |     ^^^^^^^^^^^^^^^^^^^^ required by this bound in `StorableHint::Type`
+
+error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
+  --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
+   |
+10 | struct Contract {
+   |        ^^^^^^^^ the trait `Encode` is not implemented for `[NonPacked]`, which is required by `Contract: Sized`
+   |
+   = help: the following other types implement trait `Encode`:
+             [T; N]
+             [T]
+   = note: required for `Vec<NonPacked>` to implement `Encode`
+   = note: required for `Vec<NonPacked>` to implement `Packed`
+   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
+   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
+  = note: required for `Vec<NonPacked>` to implement `Packed`
+  = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
+  = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
+  = note: this error originates in the derive macro `::ink::storage::traits::Storable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NonPacked: WrapperTypeDecode` is not satisfied
+  --> tests/ui/storage_item/fail/collections_only_packed_1.rs:11:8
+   |
+11 |     a: Vec<NonPacked>,
+   |        ^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonPacked`, which is required by `Vec<NonPacked>: StorageLayout`
+   |
+   = help: the following other types implement trait `WrapperTypeDecode`:
+             Arc<T>
+             Box<T>
+             Rc<T>
+             sp_core::Bytes
    = note: required for `NonPacked` to implement `ink::parity_scale_codec::Decode`
    = note: required for `NonPacked` to implement `Packed`
    = note: required for `Vec<NonPacked>` to implement `StorageLayout`

--- a/crates/ink/tests/ui/storage_item/fail/collections_only_packed_1.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/collections_only_packed_1.stderr
@@ -49,14 +49,14 @@ error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
    |
 10 | struct Contract {
    |        ^^^^^^^^ the trait `Encode` is not implemented for `[NonPacked]`, which is required by `Contract: Sized`
-   |
-   = help: the following other types implement trait `Encode`:
-             [T; N]
-             [T]
-   = note: required for `Vec<NonPacked>` to implement `Encode`
-   = note: required for `Vec<NonPacked>` to implement `Packed`
-   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
+  |
+9 | #[ink::storage_item]
+  | ^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `[NonPacked]`, which is required by `Vec<NonPacked>: AutoStorableHint<ManualKey<453539032>>`
+  |
+  = help: the following other types implement trait `Encode`:
+            [T; N]
+            [T]
+  = note: required for `Vec<NonPacked>` to implement `Encode`
   = note: required for `Vec<NonPacked>` to implement `Packed`
   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`

--- a/crates/ink/tests/ui/storage_item/fail/collections_only_packed_2.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/collections_only_packed_2.stderr
@@ -20,19 +20,19 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfi
    = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
    = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
 
-error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: ink::parity_scale_codec::Decode` is not satisfied
-  --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
-   |
-10 | struct Contract {
-   |        ^^^^^^^^ the trait `ink::parity_scale_codec::Decode` is not implemented for `BTreeMap<u128, NonPacked>`, which is required by `Contract: Sized`
-   |
-   = help: the trait `ink::parity_scale_codec::Decode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
-note: required because it appears within the type `Contract`
-  --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
-   |
+error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfied
+ --> tests/ui/storage_item/fail/collections_only_packed_2.rs:9:1
+  |
+9 | #[ink::storage_item]
+  | ^^^^^^^^^^^^^^^^^^^^ the trait `ink::parity_scale_codec::Decode` is not implemented for `BTreeMap<u128, NonPacked>`, which is required by `BTreeMap<u128, NonPacked>: AutoStorableHint<ManualKey<453539032>>`
+  |
+  = help: the trait `ink::parity_scale_codec::Decode` is implemented for `BTreeMap<K, V>`
+  = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
+  = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
+  = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
+  = note: this error originates in the derive macro `::ink::storage::traits::Storable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfied
  --> tests/ui/storage_item/fail/collections_only_packed_2.rs:9:1
   |
 9 | #[ink::storage_item]

--- a/crates/ink/tests/ui/storage_item/fail/collections_only_packed_2.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/collections_only_packed_2.stderr
@@ -9,56 +9,6 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfi
    = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
    = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
 
-error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfied
-  --> tests/ui/storage_item/fail/collections_only_packed_2.rs:11:8
-   |
-11 |     a: BTreeMap<u128, NonPacked>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`, which is required by `BTreeMap<u128, NonPacked>: AutoStorableHint<ManualKey<453539032>>`
-   |
-   = help: the trait `Encode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
-
-error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfied
- --> tests/ui/storage_item/fail/collections_only_packed_2.rs:9:1
-  |
-9 | #[ink::storage_item]
-  | ^^^^^^^^^^^^^^^^^^^^ the trait `ink::parity_scale_codec::Decode` is not implemented for `BTreeMap<u128, NonPacked>`, which is required by `BTreeMap<u128, NonPacked>: AutoStorableHint<ManualKey<453539032>>`
-  |
-  = help: the trait `ink::parity_scale_codec::Decode` is implemented for `BTreeMap<K, V>`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
-  = note: this error originates in the derive macro `::ink::storage::traits::Storable` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Packed` is not satisfied
- --> tests/ui/storage_item/fail/collections_only_packed_2.rs:9:1
-  |
-9 | #[ink::storage_item]
-  | ^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`, which is required by `BTreeMap<u128, NonPacked>: AutoStorableHint<ManualKey<453539032>>`
-  |
-  = help: the trait `Encode` is implemented for `BTreeMap<K, V>`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-  = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<453539032>>`
-  = note: this error originates in the derive macro `::ink::storage::traits::Storable` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NonPacked: WrapperTypeDecode` is not satisfied
-  --> tests/ui/storage_item/fail/collections_only_packed_2.rs:11:8
-   |
-11 |     a: BTreeMap<u128, NonPacked>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonPacked`, which is required by `BTreeMap<u128, NonPacked>: StorageLayout`
-   |
-   = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
-             Box<T>
-             Rc<T>
-             sp_core::Bytes
-   = note: required for `NonPacked` to implement `ink::parity_scale_codec::Decode`
-   = note: required for `NonPacked` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorageLayout`
-
 error[E0277]: the trait bound `NonPacked: WrapperTypeEncode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:11:8
    |


### PR DESCRIPTION
Change the CI to use the image from https://github.com/use-ink/docker-images instead of the `paritytech` one.

The `paritytech` one is outdated (last update three months ago) and we don't have control to install e.g. a custom `substrate-contracts-node` branch.