### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -33,7 +33,7 @@ workflows:
 help:
   text: |
     ink! uses the Zepter CLI to detect abnormalities in the feature configuration.
-    It looks like one more more checks failed; please check the console output. You can try to automatically address them by running `zepter`.
+    It looks like one more check failed; please check the console output. You can try to automatically address them by running `zepter`.
     Otherwise please ask directly in the Merge Request, GitHub Discussions or on Matrix Chat, thank you.
   links:
     - "https://github.com/paritytech/polkadot-sdk/issues/1831"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
           # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
           RUSTFLAGS:                     -Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
                                           -Clink-dead-code -Copt-level=0 -Coverflow-checks=off
-          # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
+          # The `cargo-tarpaulin` coverage reporting tool seems to have better code instrumentation and thus
           # produces better results for Rust codebases in general. However, unlike `grcov` it requires
           # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
           CODECOV_L_TOKEN:               ${{ secrets.CODECOV_L_TOKEN }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,4 +1,4 @@
-name: continuous-intergration/examples
+name: continuous-integration/examples
 
 on:
   push:


### PR DESCRIPTION
Corrected `one more more checks` to `one more check`
Corrected `taurpalin` to `tarpaulin`
Corrected `intergration` to `integration`