### PR TITLE
Fix Typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,7 +725,7 @@ The compatibility issues will be with `ChainExtension`'s and the functions menti
 
 ### Breaking Changes
 This release contains a few breaking changes. These are indicated with the :x: emoji.
-Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
+Most of these were initially introduced in `v3.1.0` and `v3.2.0` releases but
 compatibility was restored in `v3.3.0`.
 
 - As part of [#1224](https://github.com/use-ink/ink/pull/1224) the return type of `ink_env::set_contract_storage()` was changed to


### PR DESCRIPTION

## Pull Request: Fix Typo in CHANGELOG.md

### Summary of Changes:
This pull request addresses a typo in the `CHANGELOG.md` file. Below is the specific correction made:

---

### **CHANGELOG.md**

#### Original:
- "intitially" in the description of breaking changes.

#### Updated:
- Corrected "intitially" to "initially".

---

### Additional Information:
This update improves the readability and professionalism of the documentation. Thank you for reviewing this change!
