### PR TITLE
Fix typos CODE_OF_CONDUCT.adoc

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,7 +24,7 @@ Examples of unacceptable behavior by participants include:
 
 === Facilitation, Not Strongarming
 
-We recognise that this software is merely a tool for users to create and maintain their blockchain of preference. We see that blockchains are naturally community platforms with users being the ultimate decision makers. We assert that good software will maximise user agency by facilitate user-expression on the network. As such:
+We recognize that this software is merely a tool for users to create and maintain their blockchain of preference. We see that blockchains are naturally community platforms with users being the ultimate decision makers. We assert that good software will maximize user agency by facilitate user-expression on the network. As such:
 
 * This project will strive to give users as much choice as is both reasonable and possible over what protocol they adhere to; but
 * use of the project's technical forums, commenting systems, pull requests and issue trackers as a means to express individual protocol preferences is forbidden.
@@ -33,7 +33,7 @@ We recognise that this software is merely a tool for users to create and maintai
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 == Scope
 


### PR DESCRIPTION
**1)Corrected typos:**
recognise → recognize.
maximise → maximize.

**2)Improved grammar and phrasing:**
Changed "aligned to" to "aligned with" for grammatical correctness.

**3)Maintained consistency in English style:**
Used American English for terms like "recognize" and "maximize" to match the majority of the document.