### PR TITLE
Fix typos and grammatical errors

### DIFF
--- a/crates/e2e/sandbox/src/lib.rs
+++ b/crates/e2e/sandbox/src/lib.rs
@@ -127,7 +127,7 @@ pub trait Sandbox {
     /// Metadata of the runtime.
     fn get_metadata() -> RuntimeMetadataPrefixed;
 
-    /// Convert an account to an call origin.
+    /// Convert an account to a call origin.
     fn convert_account_to_origin(
         account: AccountIdFor<Self::Runtime>,
     ) -> <<Self::Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin;

--- a/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
@@ -213,8 +213,8 @@ impl CallBuilder<'_> {
                 fn forward_mut(&mut self) -> &mut Self::Forwarder {
                     // SAFETY:
                     //
-                    // We convert from a exclusive reference to a type that thinly wraps
-                    // only an `AccountId` to a exclusive reference to another type of which
+                    // We convert from an exclusive reference to a type that thinly wraps
+                    // only an `AccountId` to an exclusive reference to another type of which
                     // we know that it also thinly wraps an `AccountId`.
                     // Furthermore both types use `repr(transparent)`.
                     unsafe {

--- a/crates/ink/ir/src/ir/item/mod.rs
+++ b/crates/ink/ir/src/ir/item/mod.rs
@@ -118,7 +118,7 @@ impl Item {
         self.map_ink_item().is_some()
     }
 
-    /// Returns `true` if `self` is an normal Rust item.
+    /// Returns `true` if `self` is a normal Rust item.
     pub fn is_rust_item(&self) -> bool {
         self.map_rust_item().is_some()
     }

--- a/integration-tests/public/mapping/lib.rs
+++ b/integration-tests/public/mapping/lib.rs
@@ -41,7 +41,7 @@ mod mapping {
 
         /// Demonstrates the usage of `Mapping::get()`.
         ///
-        /// Returns the balance of a account, or `None` if the account is not in the
+        /// Returns the balance of an account, or `None` if the account is not in the
         /// `Mapping`.
         #[ink(message)]
         pub fn get_balance(&self) -> Option<Balance> {


### PR DESCRIPTION
This pull request addresses various typos and grammatical issues across multiple files in the project:

- Fixed the use of articles ("a" vs. "an") in relevant comments and docstrings.
- Corrected minor spelling and phrasing issues in comments.

Changes made include:
- **crates/e2e/sandbox/src/lib.rs:** Fixed a typo in the function description for converting an account to a call origin.
- **crates/ink/codegen/src/generator/as_dependency/call_builder.rs:** Corrected the article usage in the comment explaining the conversion from an exclusive reference.
- **crates/ink/ir/src/ir/item/mod.rs:** Fixed the use of "an" vs. "a" in a comment.
- **integration-tests/public/mapping/lib.rs:** Corrected the typo in a docstring related to the balance retrieval of an account.

### Checklist before requesting a review:
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
