### PR TITLE
error in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1831,7 +1831,7 @@ mod erc20 {
 }
 ```
 
-Calling the above `Erc20` explicitely through its trait implementation can be done just as if it was normal Rust code:
+Calling the above `Erc20` explicitly through its trait implementation can be done just as if it was normal Rust code:
 
 ```rust
 // --- Instantiating the ERC-20 contract:


### PR DESCRIPTION
### **Title**
Error in the CHANGELOG.md

---

### **Description**
This pull request fixes a typo in the `CHANGELOG.md` file. The word "explicitely" has been corrected to "explicitly" in the section describing the `Erc20` trait implementation.

#### **Changes Made**
- Corrected the typo in line 1831 of `CHANGELOG.md`.
- Replaced "explicitely" with "explicitly" for improved clarity and accuracy.

---

### **Additional Notes**
- The change is limited to documentation and does not affect any functionality.
- Ensures professional and polished project documentation.

---

### **Allow edits by maintainers**
Checked ✅
