### PR TITLE
Remove unnecessary `scale` + `scale-info` deps from contracts

### DIFF
--- a/integration-tests/public/complex-storage-structures/Cargo.toml
+++ b/integration-tests/public/complex-storage-structures/Cargo.toml
@@ -7,8 +7,6 @@ publish = false
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/Cargo.toml
+++ b/integration-tests/public/contract-invocation/Cargo.toml
@@ -24,12 +24,6 @@ e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 contract1 = { path = "./contract1", default-features = false, features = [
     "ink-as-dependency",
 ] }

--- a/integration-tests/public/contract-invocation/Cargo.toml
+++ b/integration-tests/public/contract-invocation/Cargo.toml
@@ -7,21 +7,6 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = [
-    "ink/std",
-    "scale/std",
-    "scale-info/std",
-    "contract1/std",
-    "contract2/std",
-    "virtual_contract/std",
-    "virtual_contract_ver1/std",
-    "virtual_contract_ver2/std",
-]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 contract1 = { path = "./contract1", default-features = false, features = [
@@ -42,6 +27,21 @@ virtual_contract_ver2 = { path = "./virtual_contract_ver2", default-features = f
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "contract1/std",
+    "contract2/std",
+    "virtual_contract/std",
+    "virtual_contract_ver1/std",
+    "virtual_contract_ver2/std",
+]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false

--- a/integration-tests/public/contract-invocation/contract1/Cargo.toml
+++ b/integration-tests/public/contract-invocation/contract1/Cargo.toml
@@ -9,18 +9,12 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = ["ink/std", "scale/std", "scale-info/std"]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/contract1/Cargo.toml
+++ b/integration-tests/public/contract-invocation/contract1/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = ["ink/std"]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = ["ink/std"]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false

--- a/integration-tests/public/contract-invocation/contract2/Cargo.toml
+++ b/integration-tests/public/contract-invocation/contract2/Cargo.toml
@@ -9,18 +9,12 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = ["ink/std", "scale/std", "scale-info/std"]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/contract2/Cargo.toml
+++ b/integration-tests/public/contract-invocation/contract2/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = ["ink/std"]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = ["ink/std"]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false

--- a/integration-tests/public/contract-invocation/virtual_contract/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract/Cargo.toml
@@ -9,18 +9,12 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = ["ink/std", "scale/std", "scale-info/std"]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/virtual_contract/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = ["ink/std"]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = ["ink/std"]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false

--- a/integration-tests/public/contract-invocation/virtual_contract_ver1/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract_ver1/Cargo.toml
@@ -9,18 +9,12 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = ["ink/std", "scale/std", "scale-info/std"]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/virtual_contract_ver1/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract_ver1/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = ["ink/std"]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = ["ink/std"]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false

--- a/integration-tests/public/contract-invocation/virtual_contract_ver2/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract_ver2/Cargo.toml
@@ -9,18 +9,12 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = ["ink/std", "scale/std", "scale-info/std"]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
-    "derive",
-] }
-scale-info = { version = "2.11.1", default-features = false, features = [
-    "derive",
-], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/virtual_contract_ver2/Cargo.toml
+++ b/integration-tests/public/contract-invocation/virtual_contract_ver2/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Víctor M. González <victor.gonzalez@coinfabrik.com>"]
 [lib]
 path = "lib.rs"
 
-[features]
-default = ["std"]
-std = ["ink/std"]
-ink-as-dependency = []
-e2e-tests = []
-
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }
+
+[features]
+default = ["std"]
+std = ["ink/std"]
+ink-as-dependency = []
+e2e-tests = []
 
 [profile.dev]
 overflow-checks = false


### PR DESCRIPTION
The `ink` umbrella crate re-exports them since a while (`ink::scale`, `ink::scale_info`). No need to depend on them from a contract.