### PR TITLE
Add Solidity compatible address and byte types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Add feature flag to compile contracts for `pallet-revive` ‒ [#2318](https://github.com/use-ink/ink/pull/2318)
 - Support for `caller_is_root` - [#2332] (https://github.com/use-ink/ink/pull/2332)
+- Add Solidity compatible `Address` and `Byte` types - [#2397](https://github.com/use-ink/ink/pull/2397)
 
 ## Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-derive_more = { workspace = true, features = ["from", "display"] }
+derive_more = { workspace = true, features = ["from", "display", "deref", "deref_mut"] }
 ink_prelude = { workspace = true }
 alloy-rlp = { workspace = true, features = ["derive"] }
 scale = { workspace = true, features = ["max-encoded-len"] }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -44,6 +44,8 @@ pub use self::{
     },
     types::{
         AccountId,
+        Address,
+        Byte,
         Clear,
         DepositLimit,
         Hash,

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -14,7 +14,11 @@
 
 use crate::arithmetic::AtLeast32BitUnsigned;
 use core::array::TryFromSliceError;
-use derive_more::From;
+use derive_more::{
+    Deref,
+    DerefMut,
+    From,
+};
 use primitive_types::{
     H160,
     U256,
@@ -440,3 +444,74 @@ pub enum Origin<E: Environment> {
     Root,
     Signed(E::AccountId),
 }
+
+/// A Solidity compatible `address` type.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Decode,
+    Encode,
+    MaxEncodedLen,
+    From,
+)]
+#[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
+pub struct Address(pub [u8; 20]);
+
+impl AsRef<[u8; 20]> for Address {
+    fn as_ref(&self) -> &[u8; 20] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8; 20]> for Address {
+    fn as_mut(&mut self) -> &mut [u8; 20] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Address {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl AsMut<[u8]> for Address {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Address {
+    type Error = TryFromSliceError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, TryFromSliceError> {
+        let address = <[u8; 20]>::try_from(bytes)?;
+        Ok(Self(address))
+    }
+}
+
+/// A Solidity compatible `byte` type.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Decode,
+    Encode,
+    MaxEncodedLen,
+    From,
+    Deref,
+    DerefMut,
+)]
+#[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
+pub struct Byte(pub u8);

--- a/crates/storage/traits/src/layout/impls.rs
+++ b/crates/storage/traits/src/layout/impls.rs
@@ -38,6 +38,8 @@ use ink_prelude::{
 };
 use ink_primitives::{
     AccountId,
+    Address,
+    Byte,
     Hash,
     Key,
     H160,
@@ -64,6 +66,7 @@ impl_storage_layout_for_primitives!(
     bool, char, (),
     u8, u16, u32, u64, u128,
     i8, i16, i32, i64, i128,
+    Address, Byte
 );
 
 macro_rules! impl_layout_for_tuple {


### PR DESCRIPTION
## Summary
Closes - N/A
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

Adds `Address` and `Byte` types that can be unambiguously mapped to Solidity's `address` and `bytes<N>` (and `bytes`) types.

## Description
<!--- Describe your changes in detail -->

See [this discussion](https://github.com/use-ink/cargo-contract/pull/1930#pullrequestreview-2597912123) for rationale and additional details.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
