### PR TITLE
More idiomatic return types for metadata getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Restrict which `cfg` attributes can be used ‒ [#2313](https://github.com/use-ink/ink/pull/2313)
+- More idiomatic return types for metadata getters - [#2398](https://github.com/use-ink/ink/pull/2398)
 
 ## Added
 - Add feature flag to compile contracts for `pallet-revive` ‒ [#2318](https://github.com/use-ink/ink/pull/2318)

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -123,8 +123,8 @@ impl InkProject {
     }
 
     /// Returns the metadata version used by the contract.
-    pub fn version(&self) -> &u64 {
-        &self.version
+    pub fn version(&self) -> u64 {
+        self.version
     }
 
     /// Returns a read-only registry of types in the contract.

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -431,8 +431,8 @@ where
     }
 
     /// Returns if the constructor is payable by the caller.
-    pub fn payable(&self) -> &bool {
-        &self.payable
+    pub fn payable(&self) -> bool {
+        self.payable
     }
 
     /// Returns the parameters of the deployment handler.
@@ -450,8 +450,8 @@ where
         &self.docs
     }
 
-    pub fn default(&self) -> &bool {
-        &self.default
+    pub fn default(&self) -> bool {
+        self.default
     }
 }
 
@@ -743,8 +743,8 @@ where
         &self.docs
     }
 
-    pub fn default(&self) -> &bool {
-        &self.default
+    pub fn default(&self) -> bool {
+        self.default
     }
 }
 


### PR DESCRIPTION
## Summary
Closes - N/A
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->
More idiomatic return types for some metadata getters that return references to types that are cheap to copy.

## Description
<!--- Describe your changes in detail -->
Changes a few metadata getter assoc fns that return `&T` when `T: Copy` to return `T` instead

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
