### PR TITLE
feat(e2e): add node `url` to `Client`

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -140,7 +140,7 @@ fn build_full_client(
                 let mut client = ::ink_e2e::Client::<
                     ::ink_e2e::PolkadotConfig,
                     #environment
-                >::new(node_rpc.rpc(), contracts).await?;
+                >::new(node_rpc.rpc(), contracts, node_rpc.url().to_string()).await?;
             }
         }
     }

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -111,6 +111,7 @@ where
 {
     api: ReviveApi<C, E>,
     contracts: ContractsRegistry,
+    url: String,
 }
 
 impl<C, E> Client<C, E>
@@ -133,10 +134,12 @@ where
     pub async fn new<P: Into<PathBuf>>(
         client: subxt::backend::rpc::RpcClient,
         contracts: impl IntoIterator<Item = P>,
+        url: String,
     ) -> Result<Self, subxt::Error> {
         Ok(Self {
             api: ReviveApi::new(client).await?,
             contracts: ContractsRegistry::new(contracts),
+            url,
         })
     }
 
@@ -311,6 +314,11 @@ where
         let dispatch_err_encoded = Encode::encode(&dispatch_error);
         DispatchError::decode_from(dispatch_err_encoded, self.api.client.metadata())
             .expect("failed to decode valid dispatch error")
+    }
+
+    /// Returns the URL of the running node.
+    pub fn url(&self) -> &str {
+        &self.url
     }
 }
 


### PR DESCRIPTION
Adds the running node URL to subxt `Client`. This allows e2e tests to access the URL for further use. 

This will be used to create an e2e test showcasing Solidity calling an ink! contract.