### PR TITLE
Improve support for Solidity ABI calling conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Add feature flag to compile contracts for `pallet-revive` ‒ [#2318](https://github.com/use-ink/ink/pull/2318)
 - Support for `caller_is_root` - [#2332] (https://github.com/use-ink/ink/pull/2332)
+- Improve support for Solidity ABI calling conventions - [#2411](https://github.com/use-ink/ink/pull/2411)
 
 ## Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -3350,6 +3351,7 @@ name = "ink"
 version = "6.0.0-alpha"
 dependencies = [
  "alloy-sol-types",
+ "const_format",
  "derive_more 1.0.0",
  "ink_env",
  "ink_ir",
@@ -3358,6 +3360,7 @@ dependencies = [
  "ink_prelude 6.0.0-alpha",
  "ink_primitives 6.0.0-alpha",
  "ink_storage",
+ "keccak-const",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "polkavm-derive 0.19.0",
@@ -3885,6 +3888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
+
+[[package]]
 name = "keccak-hash"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3893,6 +3902,21 @@ dependencies = [
  "primitive-types 0.13.1",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ proc-macro2 = { version = "1" }
 quickcheck = { version = "1" }
 quickcheck_macros = { version = "1" }
 quote = { version = "1" }
-alloy-sol-types = { version = "0.8.21", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.14.0", default-features = false }
 scale-encode = { version = "0.8.0", default-features = false }
@@ -101,6 +100,11 @@ xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-s
 
 # PolkaVM dependencies
 polkavm-derive = { version = "0.19.0", default-features = false }
+
+# Solidity dependencies
+alloy-sol-types = { version = "0.8.21", default-features = false }
+const_format = { version = "0.2.34", features = ["fmt"] }
+keccak-const = "0.2.0"
 
 # Local dependencies
 ink = { version = "=6.0.0-alpha", path = "crates/ink", default-features = false }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -27,6 +27,8 @@ alloy-sol-types = { workspace = true }
 scale = { workspace = true }
 scale-info = { workspace = true, default-features = false, features = ["derive"], optional = true }
 derive_more = { workspace = true, features = ["from"] }
+const_format = { workspace = true }
+keccak-const = { workspace = true }
 
 # TODO add explainer
 xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", rev = "4a400dc1866f11707331fb6408df1055d0f42a70", default-features = false }

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -155,7 +155,7 @@ impl Dispatch<'_> {
 
                 let mut message_dispatchables = Vec::new();
 
-                if self.contract.config().abi().is_scale() {
+                if self.contract.config().abi().is_ink() {
                     message_dispatchables.push(MessageDispatchable { message, id });
                 }
 
@@ -282,7 +282,7 @@ impl Dispatch<'_> {
 
                 let mut message_infos = Vec::new();
 
-                if encoding.is_scale() {
+                if encoding.is_ink() {
                     message_infos.push(quote_spanned!(message_span=>
                         #( #cfg_attrs )*
                         impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
@@ -438,7 +438,7 @@ impl Dispatch<'_> {
 
                 let mut message_infos = Vec::new();
 
-                if self.contract.config().abi().is_scale() {
+                if self.contract.config().abi().is_ink() {
                    message_infos.push(quote_spanned!(message_span=>
                         #( #cfg_attrs )*
                         impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -1232,9 +1232,9 @@ impl Dispatch<'_> {
 
                         const _: () = {
                             impl #call_type_ident {
-                                pub const SIGNATURE: &str = ::ink::codegen::const_format!(#sig_fmt_lit, #ident_str #(,#sig_param_tys)*);
-                                pub const SELECTOR: [u8; 4] = ::ink::codegen::sol_selector_bytes(Self::SIGNATURE);
-                                pub const SELECTOR_ID: u32 = u32::from_be_bytes(Self::SELECTOR);
+                                pub const SIGNATURE: &'static ::core::primitive::str = ::ink::codegen::const_format!(#sig_fmt_lit, #ident_str #(,#sig_param_tys)*);
+                                pub const SELECTOR: [::core::primitive::u8; 4usize] = ::ink::codegen::sol_selector_bytes(Self::SIGNATURE);
+                                pub const SELECTOR_ID: ::core::primitive::u32 = ::core::primitive::u32::from_be_bytes(Self::SELECTOR);
                             }
                         };
                     )

--- a/crates/ink/codegen/src/generator/env.rs
+++ b/crates/ink/codegen/src/generator/env.rs
@@ -42,6 +42,8 @@ impl GenerateCode for Env<'_> {
             type ChainExtension = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::ChainExtension;
             const MAX_EVENT_TOPICS: usize = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::MAX_EVENT_TOPICS;
             type EventRecord = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::EventRecord;
+
+            type Address = ::ink::primitives::Address;
         }
     }
 }

--- a/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
@@ -335,6 +335,10 @@ impl TraitRegistry<'_> {
         let local_id = message.local_id();
         let selector_bytes = selector.hex_lits();
         let is_payable = message.ink_attrs().is_payable();
+        // TODO: (@davidsemakula) generate Solidity selectors when spec for determining
+        // trait definition ABI is finalized.
+        // NOTE: This doesn't affect call decoding because the selector is computed
+        // directly from the implementation signature.
         quote_spanned!(span=>
             impl<E> ::ink::reflect::TraitMessageInfo<#local_id> for #trait_info_ident<E> {
                 const PAYABLE: ::core::primitive::bool = #is_payable;

--- a/crates/ink/ir/src/ir/config.rs
+++ b/crates/ink/ir/src/ir/config.rs
@@ -68,13 +68,13 @@ impl TryFrom<ast::AttributeArgs> for Config {
                     .zip(arg.value().and_then(ast::MetaValue::as_string));
                 if let Some((name_value, path)) = encoding {
                     let encoding = match path.as_str() {
-                        "scale" => Abi::Scale,
+                        "ink" => Abi::Ink,
                         "solidity" | "sol" => Abi::Solidity,
                         "all" => Abi::All,
                         _ => {
                             return Err(format_err_spanned!(
                                 arg,
-                                "expected one of `scale`, `sol` or `all` for `abi` ink! configuration argument",
+                                "expected one of `ink`, `sol` or `all` for `abi` ink! configuration argument",
                             ));
                         }
                     };
@@ -146,26 +146,25 @@ impl Default for Environment {
     }
 }
 
-/// Which format is used for ABI encoding.
+/// ABI spec for encoding/decoding contract calls.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-
 pub enum Abi {
-    /// SCALE codec, the default.
+    /// ink! ABI spec (the default, uses the SCALE codec for input/output encode/decode).
     #[default]
-    Scale,
-    /// Solidity ABI Encoding.
+    Ink,
+    /// Solidity ABI spec.
     Solidity,
-    /// Support both SCALE and Solidity ABI encoding for each contract entry point.
+    /// Support both ink! and Solidity ABI specs for each contract entry point.
     All,
 }
 
 impl Abi {
-    pub fn is_solidity(&self) -> bool {
-        matches!(self, Self::Solidity | Self::All)
+    pub fn is_ink(&self) -> bool {
+        matches!(self, Self::Ink | Self::All)
     }
 
-    pub fn is_scale(&self) -> bool {
-        matches!(self, Self::Scale | Self::All)
+    pub fn is_solidity(&self) -> bool {
+        matches!(self, Self::Solidity | Self::All)
     }
 
     pub fn is_all(&self) -> bool {

--- a/crates/ink/ir/src/ir/config.rs
+++ b/crates/ink/ir/src/ir/config.rs
@@ -82,7 +82,7 @@ impl TryFrom<ast::AttributeArgs> for Config {
                 } else {
                     return Err(format_err_spanned!(
                         arg,
-                        "expected a string value for `abi` ink! configuration argument",
+                        "expected a string literal value for `abi` ink! configuration argument",
                     ));
                 }
             } else if arg.name().is_ident("keep_attr") {
@@ -275,6 +275,60 @@ mod tests {
         assert_try_from(
             syn::parse_quote! { keep_attr },
             Err("expected a string literal value for `keep_attr` ink! configuration argument"),
+        );
+    }
+
+    #[test]
+    fn abi_works() {
+        assert_try_from(
+            syn::parse_quote! {
+                abi = "ink"
+            },
+            Ok(Config {
+                env: None,
+                abi: Abi::Ink,
+                whitelisted_attributes: Default::default(),
+            }),
+        );
+        assert_try_from(
+            syn::parse_quote! {
+                abi = "sol"
+            },
+            Ok(Config {
+                env: None,
+                abi: Abi::Solidity,
+                whitelisted_attributes: Default::default(),
+            }),
+        );
+        assert_try_from(
+            syn::parse_quote! {
+                abi = "all"
+            },
+            Ok(Config {
+                env: None,
+                abi: Abi::All,
+                whitelisted_attributes: Default::default(),
+            }),
+        );
+    }
+
+    #[test]
+    fn abi_invalid_value_fails() {
+        assert_try_from(
+            syn::parse_quote! { abi = "move" },
+            Err("expected one of `ink`, `sol` or `all` for `abi` ink! configuration argument"),
+        );
+        assert_try_from(
+            syn::parse_quote! { abi = 1u8 },
+            Err("expected a string literal value for `abi` ink! configuration argument"),
+        );
+    }
+
+    #[test]
+    fn abi_missing_value_fails() {
+        assert_try_from(
+            syn::parse_quote! { abi },
+            Err("expected a string literal value for `abi` ink! configuration argument"),
         );
     }
 }

--- a/crates/ink/ir/src/ir/item_impl/callable.rs
+++ b/crates/ink/ir/src/ir/item_impl/callable.rs
@@ -48,8 +48,6 @@ pub struct CallableWithSelector<'a, C> {
     /// The composed selector computed by the associated implementation block
     /// and the given callable.
     composed_selector: ir::Selector,
-    /// The composed selector for the callable with Solidity encoding.
-    composed_solidity_selector: ir::Selector,
     /// The parent implementation block.
     item_impl: &'a ir::ItemImpl,
     /// The actual callable.
@@ -71,7 +69,6 @@ where
     pub(super) fn new(item_impl: &'a ir::ItemImpl, callable: &'a C) -> Self {
         Self {
             composed_selector: compose_selector(item_impl, callable),
-            composed_solidity_selector: compose_selector_solidity(item_impl, callable),
             item_impl,
             callable,
         }
@@ -82,11 +79,6 @@ impl<'a, C> CallableWithSelector<'a, C> {
     /// Returns the composed selector of the ink! callable the `impl` block.
     pub fn composed_selector(&self) -> ir::Selector {
         self.composed_selector
-    }
-
-    /// Returns the composed selector of the ink! callable with Solidity encoding.
-    pub fn composed_solidity_selector(&self) -> ir::Selector {
-        self.composed_solidity_selector
     }
 
     /// Returns a shared reference to the underlying callable.
@@ -334,18 +326,6 @@ where
     }
     let preimage = compose_selector_preimage(item_impl, callable);
     ir::Selector::compute(&preimage)
-}
-
-/// Returns the composed selector of the ink! callable.
-fn compose_selector_solidity<C>(item_impl: &ir::ItemImpl, callable: &C) -> ir::Selector
-where
-    C: Callable,
-{
-    if let Some(selector) = callable.user_provided_selector() {
-        return *selector
-    }
-    let preimage = compose_selector_preimage(item_impl, callable);
-    ir::Selector::compute_keccak(&preimage)
 }
 
 fn compose_selector_preimage<C>(item_impl: &ir::ItemImpl, callable: &C) -> Vec<u8>

--- a/crates/ink/ir/src/ir/item_impl/impl_item.rs
+++ b/crates/ink/ir/src/ir/item_impl/impl_item.rs
@@ -66,7 +66,7 @@ impl TryFrom<syn::ImplItem> for ImplItem {
                     return Ok(Self::Other(fn_item.into()))
                 }
                 let attr = ir::first_ink_attribute(&fn_item.attrs)?
-                    .expect("missing expected ink! attribute for struct");
+                    .expect("missing expected ink! attribute for fn");
                 match attr.first().kind() {
                     ir::AttributeArg::Message => {
                         <Message as TryFrom<_>>::try_from(fn_item)

--- a/crates/ink/ir/src/ir/selector.rs
+++ b/crates/ink/ir/src/ir/selector.rs
@@ -25,7 +25,7 @@ use syn::spanned::Spanned as _;
 ///
 /// # Note
 ///
-/// This is equal to the first four bytes of the SHA-3 hash of a function's name.
+/// This is equal to the first four bytes of the BLAKE-2 256 hash of a function's name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Selector {
     bytes: [u8; 4],

--- a/crates/ink/ir/src/ir/selector.rs
+++ b/crates/ink/ir/src/ir/selector.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{
-    blake2::blake2b_256,
-    sha3::keccak_256,
-};
+use super::blake2::blake2b_256;
 use crate::literal::HexLiteral;
 use proc_macro2::TokenStream as TokenStream2;
 use std::marker::PhantomData;
@@ -71,13 +68,6 @@ impl Selector {
     pub fn compute(input: &[u8]) -> Self {
         let mut output = [0; 32];
         blake2b_256(input, &mut output);
-        Self::from([output[0], output[1], output[2], output[3]])
-    }
-
-    /// Computes the Keccak 256-bit based selector from the given input bytes.
-    pub fn compute_keccak(input: &[u8]) -> Self {
-        let mut output = [0; 32];
-        keccak_256(input, &mut output);
         Self::from([output[0], output[1], output[2], output[3]])
     }
 

--- a/crates/ink/src/codegen/mod.rs
+++ b/crates/ink/src/codegen/mod.rs
@@ -17,6 +17,7 @@
 mod dispatch;
 mod env;
 mod implies_return;
+mod solidity_compat;
 mod trait_def;
 pub mod utils;
 
@@ -32,6 +33,10 @@ pub use self::{
         StaticEnv,
     },
     implies_return::ImpliesReturn,
+    solidity_compat::{
+        const_format,
+        sol_selector_bytes,
+    },
     trait_def::{
         TraitCallBuilder,
         TraitCallForwarder,

--- a/crates/ink/src/codegen/solidity_compat.rs
+++ b/crates/ink/src/codegen/solidity_compat.rs
@@ -1,0 +1,33 @@
+// Copyright (C) ink! contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use keccak_const::Keccak256;
+
+/// Compile-time `format!`-like macro that returns `&'static str`.
+///
+/// The first argument is a format string which can be a `String` (i.e. doesn't have
+/// to be a literal). Like `format!` the format string can contain `{}`s which are
+/// replace by the additional parameters which must all be constant expressions.
+///
+/// See [`const_format::formatc`] for details.
+pub use const_format::formatc as const_format;
+
+/// Compile-time Solidity selector computation.
+///
+/// Takes function signature as a string and returns a 4 byte representation of the
+/// selector.
+pub const fn sol_selector_bytes(sig: &str) -> [u8; 4] {
+    let hash = Keccak256::new().update(sig.as_bytes()).finalize();
+    [hash[0], hash[1], hash[2], hash[3]]
+}

--- a/crates/ink/src/lib.rs
+++ b/crates/ink/src/lib.rs
@@ -95,6 +95,7 @@ pub use ink_macro::{
     EventMetadata,
 };
 pub use ink_primitives::{
+    Address,
     ConstructorResult,
     LangError,
     MessageResult,

--- a/crates/ink/tests/ui/contract/fail/message-selector-overlap-sol.rs
+++ b/crates/ink/tests/ui/contract/fail/message-selector-overlap-sol.rs
@@ -1,0 +1,20 @@
+#![allow(unexpected_cfgs)]
+
+#[ink::contract(abi = "all")]
+pub mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message, selector = 0xe21f37ce)]
+        // Solidity selector is `keccak256("message()")` == `0xe21f37ce` == `3793696718`
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/contract/fail/message-selector-overlap-sol.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-selector-overlap-sol.stderr
@@ -1,0 +1,8 @@
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `Contract`
+  --> tests/ui/contract/fail/message-selector-overlap-sol.rs:16:9
+   |
+16 |         pub fn message(&self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         first implementation here
+   |         conflicting implementation for `Contract`

--- a/crates/ink/tests/ui/contract/fail/trait-message-selector-overlap-sol.rs
+++ b/crates/ink/tests/ui/contract/fail/trait-message-selector-overlap-sol.rs
@@ -1,0 +1,32 @@
+#![allow(unexpected_cfgs)]
+
+#[ink::trait_definition]
+pub trait TraitDefinition {
+    #[ink(message)]
+    fn message(&self);
+}
+
+#[ink::contract(abi = "sol")]
+pub mod contract {
+    use super::TraitDefinition;
+
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+
+    impl TraitDefinition for Contract {
+        #[ink(message)]
+        fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/contract/fail/trait-message-selector-overlap-sol.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait-message-selector-overlap-sol.stderr
@@ -1,0 +1,8 @@
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `Contract`
+  --> tests/ui/contract/fail/trait-message-selector-overlap-sol.rs:28:9
+   |
+23 |         pub fn message(&self) {}
+   |         ------------------------ first implementation here
+...
+28 |         fn message(&self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`

--- a/crates/ink/tests/ui/contract/pass/01-message-encoding-inputs-sol.rs
+++ b/crates/ink/tests/ui/contract/pass/01-message-encoding-inputs-sol.rs
@@ -42,7 +42,7 @@ mod contract {
             &mut self,
             _input_0: AccountId,
             _input_1: Hash,
-            _input_2: ink::H160,
+            _input_2: Address,
         ) {
         }
     }

--- a/crates/ink/tests/ui/contract/pass/message-selector-encoding-all.rs
+++ b/crates/ink/tests/ui/contract/pass/message-selector-encoding-all.rs
@@ -7,8 +7,19 @@ mod contract {
 
     #[ink::trait_definition]
     pub trait Messages {
+        #[ink(message)]
+        fn message_0(&self);
+
         #[ink(message, selector = 1)]
         fn message_1(&self);
+    }
+
+    impl Messages for Contract {
+        #[ink(message)]
+        fn message_0(&self) {}
+
+        #[ink(message, selector = 1)]
+        fn message_1(&self) {}
     }
 
     impl Contract {
@@ -24,11 +35,6 @@ mod contract {
         pub fn message_3(&self) {}
     }
 
-    impl Messages for Contract {
-        #[ink(message, selector = 1)]
-        fn message_1(&self) {}
-    }
-
     #[ink::trait_definition]
     pub trait Messages2 {
         #[ink(message, selector = 0x12345678)]
@@ -42,24 +48,60 @@ mod contract {
 }
 
 fn main() {
+    // ink! `message_0` trait definition
+    const TRAIT_ID: u32 = ::ink::selector_id!("Messages::message_0");
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<TRAIT_ID>>::SELECTOR,
+        [0xFB, 0xAB, 0x03, 0xCE],
+    );
+    // Solidity `keccak256("message_0()")` == `0xdf4bc0a6`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xdf4bc0a6_u32>>::SELECTOR,
+        [0xdf, 0x4b, 0xc0, 0xa6],
+    );
+
+    // ink! `message_1` user-provided
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<1_u32>>::SELECTOR,
         1_u32.to_be_bytes(),
     );
+    // Solidity `keccak256("message_1()")` == `0x20896153`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x20896153_u32>>::SELECTOR,
+        [0x20, 0x89, 0x61, 0x53],
+    );
+
+    // ink! `message_2` user-provided
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0xC0DE_CAFE_u32>>::SELECTOR,
         0xC0DE_CAFE_u32.to_be_bytes(),
     );
-
-    // manually calculated "message_3"
-    const INHERENT_ID_RLP: u32 = 0x0cd0f0f1;
+    // Solidity `keccak256("message_2()")` == `0x551578a6`
     assert_eq!(
-        <Contract as ::ink::reflect::DispatchableMessageInfo<INHERENT_ID_RLP>>::SELECTOR,
-        [0x0C, 0xD0, 0xF0, 0xF1],
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x551578a6_u32>>::SELECTOR,
+        [0x55, 0x15, 0x78, 0xa6],
     );
 
+    // ink! `message_3` inherent
+    const INHERENT_ID: u32 = ::ink::selector_id!("message_3");
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<INHERENT_ID>>::SELECTOR,
+        [0xB6, 0xC3, 0x27, 0x49],
+    );
+    // Solidity `keccak256("message_3()")` == `0xb2f14ed9`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xb2f14ed9_u32>>::SELECTOR,
+        [0xb2, 0xf1, 0x4e, 0xd9],
+    );
+
+    // ink! `message_4` user-provided
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x12345678_u32>>::SELECTOR,
         0x12345678_u32.to_be_bytes(),
+    );
+    // Solidity `keccak256("message_4()")` == `0xdc48aa5a`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xdc48aa5a_u32>>::SELECTOR,
+        [0xdc, 0x48, 0xaa, 0x5a],
     );
 }

--- a/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
+++ b/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
@@ -27,12 +27,20 @@ mod contract {
     #[ink::trait_definition]
     pub trait Messages {
         #[ink(message, selector = 0x12345678)]
-        fn message_4(&self, _input: Vec<u8>);
+        fn message_4(&self, _input_1: Vec<u8>);
     }
 
     impl Messages for Contract {
         #[ink(message, selector = 0x12345678)]
-        fn message_4(&self, _input: Vec<u8>) {}
+        fn message_4(&self, _input_1: Vec<u8>) {}
+    }
+
+    impl Contract {
+        #[ink(message)]
+        pub fn message_5(&self, _input_1: String) {}
+
+        #[ink(message)]
+        pub fn message_6(&self, _input_1: bool, _input_2: String, _input_3: [u8; 32], _input_4: Vec<u8>, _input_5: [u16; 4], _input_6: Vec<u16>) {}
     }
 }
 
@@ -65,5 +73,17 @@ fn main() {
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x0e59eb1b_u32>>::SELECTOR,
         [0x0e, 0x59, 0xeb, 0x1b],
+    );
+
+    // `keccak256("message_5(string)")` == `0x596379bc`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x596379bc_u32>>::SELECTOR,
+        [0x59, 0x63, 0x79, 0xbc],
+    );
+
+    // `keccak256("message_6(bool,string,bytes32,bytes,uint16[4],uint16[])")` == `0x270af153`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x270af153_u32>>::SELECTOR,
+        [0x27, 0x0a, 0xf1, 0x53],
     );
 }

--- a/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
+++ b/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
@@ -1,0 +1,69 @@
+use contract::Contract;
+
+#[ink::contract(abi = "sol")]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message_0(&self, _input_1: bool) {}
+
+        #[ink(message, selector = 1)]
+        pub fn message_1(&self, _input_1: i8) {}
+
+        #[ink(message, selector = 0xC0DE_CAFE)]
+        pub fn message_2(&self, _input_1: [u8; 32]) {}
+
+        #[ink(message)]
+        pub fn message_3(&self, _input_1: bool, _input_2: i8) {}
+    }
+
+    #[ink::trait_definition]
+    pub trait Messages {
+        #[ink(message, selector = 0x12345678)]
+        fn message_4(&self, _input: Vec<u8>);
+    }
+
+    impl Messages for Contract {
+        #[ink(message, selector = 0x12345678)]
+        fn message_4(&self, _input: Vec<u8>) {}
+    }
+}
+
+fn main() {
+    // `keccak256("message_0(bool)")` == `0xc58b7175`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xc58b7175_u32>>::SELECTOR,
+        [0xc5, 0x8b, 0x71, 0x75],
+    );
+
+    // `keccak256("message_1(int8)")` == `0xb316130f`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xb316130f_u32>>::SELECTOR,
+        [0xb3, 0x16, 0x13, 0x0f],
+    );
+
+    // `keccak256("message_2(bytes32)")` == `0x468f916c`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x468f916c_u32>>::SELECTOR,
+        [0x46, 0x8f, 0x91, 0x6c],
+    );
+
+    // `keccak256("message_3(bool,int8)")` == `0xf4bf21e5`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xf4bf21e5_u32>>::SELECTOR,
+        [0xf4, 0xbf, 0x21, 0xe5],
+    );
+
+    // `keccak256("message_4(bytes)")` == `0x0e59eb1b`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x0e59eb1b_u32>>::SELECTOR,
+        [0x0e, 0x59, 0xeb, 0x1b],
+    );
+}

--- a/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
+++ b/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol-args.rs
@@ -40,7 +40,19 @@ mod contract {
         pub fn message_5(&self, _input_1: String) {}
 
         #[ink(message)]
-        pub fn message_6(&self, _input_1: bool, _input_2: String, _input_3: [u8; 32], _input_4: Vec<u8>, _input_5: [u16; 4], _input_6: Vec<u16>) {}
+        pub fn message_6(
+            &self,
+            _input_1: bool,
+            _input_2: String,
+            _input_3: [u8; 32],
+            _input_4: Vec<u8>,
+            _input_5: [u16; 4],
+            _input_6: Vec<u16>,
+        ) {
+        }
+
+        #[ink(message)]
+        pub fn message_7(&self, _input_1: AccountId, _input_2: Hash, _input_3: Address) {}
     }
 }
 
@@ -81,9 +93,16 @@ fn main() {
         [0x59, 0x63, 0x79, 0xbc],
     );
 
-    // `keccak256("message_6(bool,string,bytes32,bytes,uint16[4],uint16[])")` == `0x270af153`
+    // `keccak256("message_6(bool,string,bytes32,bytes,uint16[4],uint16[])")` ==
+    // `0x270af153`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x270af153_u32>>::SELECTOR,
         [0x27, 0x0a, 0xf1, 0x53],
+    );
+
+    // `keccak256("message_7(bytes32,bytes32,address)")` == `0xee34840f`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xee34840f_u32>>::SELECTOR,
+        [0xee, 0x34, 0x84, 0x0f],
     );
 }

--- a/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol.rs
+++ b/crates/ink/tests/ui/contract/pass/message-selector-encoding-sol.rs
@@ -7,8 +7,19 @@ mod contract {
 
     #[ink::trait_definition]
     pub trait Messages {
+        #[ink(message)]
+        fn message_0(&self);
+
         #[ink(message, selector = 1)]
         fn message_1(&self);
+    }
+
+    impl Messages for Contract {
+        #[ink(message)]
+        fn message_0(&self) {}
+
+        #[ink(message, selector = 1)]
+        fn message_1(&self) {}
     }
 
     impl Contract {
@@ -24,11 +35,6 @@ mod contract {
         pub fn message_3(&self) {}
     }
 
-    impl Messages for Contract {
-        #[ink(message, selector = 1)]
-        fn message_1(&self) {}
-    }
-
     #[ink::trait_definition]
     pub trait Messages2 {
         #[ink(message, selector = 0x12345678)]
@@ -42,24 +48,33 @@ mod contract {
 }
 
 fn main() {
+    // `keccak256("message_0()")` == `0xdf4bc0a6`
     assert_eq!(
-        <Contract as ::ink::reflect::DispatchableMessageInfo<1_u32>>::SELECTOR,
-        1_u32.to_be_bytes(),
-    );
-    assert_eq!(
-        <Contract as ::ink::reflect::DispatchableMessageInfo<0xC0DE_CAFE_u32>>::SELECTOR,
-        0xC0DE_CAFE_u32.to_be_bytes(),
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xdf4bc0a6_u32>>::SELECTOR,
+        [0xdf, 0x4b, 0xc0, 0xa6],
     );
 
-    // manually calculated "message_3"
-    const INHERENT_ID_RLP: u32 = 0x0cd0f0f1;
+    // `keccak256("message_1()")` == `0x20896153`
     assert_eq!(
-        <Contract as ::ink::reflect::DispatchableMessageInfo<INHERENT_ID_RLP>>::SELECTOR,
-        [0x0C, 0xD0, 0xF0, 0xF1],
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x20896153_u32>>::SELECTOR,
+        [0x20, 0x89, 0x61, 0x53],
     );
 
+    // `keccak256("message_2()")` == `0x551578a6`
     assert_eq!(
-        <Contract as ::ink::reflect::DispatchableMessageInfo<0x12345678_u32>>::SELECTOR,
-        0x12345678_u32.to_be_bytes(),
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x551578a6_u32>>::SELECTOR,
+        [0x55, 0x15, 0x78, 0xa6],
+    );
+
+    // `keccak256("message_3()")` == `0xb2f14ed9`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xb2f14ed9_u32>>::SELECTOR,
+        [0xb2, 0xf1, 0x4e, 0xd9],
+    );
+
+    // `keccak256("message_4()")` == `0xdc48aa5a`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xdc48aa5a_u32>>::SELECTOR,
+        [0xdc, 0x48, 0xaa, 0x5a],
     );
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -44,6 +44,7 @@ pub use self::{
     },
     types::{
         AccountId,
+        Address,
         Clear,
         DepositLimit,
         Hash,

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -14,7 +14,10 @@
 
 use crate::arithmetic::AtLeast32BitUnsigned;
 use alloy_sol_types::{
-    private::primitives::FixedBytes,
+    private::{
+        Address as SolAddress,
+        FixedBytes,
+    },
     sol_data,
     SolValue,
 };
@@ -489,4 +492,76 @@ pub enum Phase {
 pub enum Origin<E: Environment> {
     Root,
     Signed(E::AccountId),
+}
+
+/// A Solidity compatible `address` type.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Decode,
+    Encode,
+    MaxEncodedLen,
+    From,
+)]
+#[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
+pub struct Address(pub [u8; 20]);
+
+impl AsRef<[u8; 20]> for Address {
+    fn as_ref(&self) -> &[u8; 20] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8; 20]> for Address {
+    fn as_mut(&mut self) -> &mut [u8; 20] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Address {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl AsMut<[u8]> for Address {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Address {
+    type Error = TryFromSliceError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, TryFromSliceError> {
+        let address = <[u8; 20]>::try_from(bytes)?;
+        Ok(Self(address))
+    }
+}
+
+impl Borrow<[u8; 20]> for Address {
+    fn borrow(&self) -> &[u8; 20] {
+        &self.0
+    }
+}
+
+impl SolValue for Address {
+    type SolType = sol_data::Address;
+
+    #[inline]
+    fn abi_encode(&self) -> ink_prelude::vec::Vec<u8> {
+        self.0.as_slice().abi_encode()
+    }
+}
+
+impl From<SolAddress> for Address {
+    fn from(value: SolAddress) -> Self {
+        Address(value.into_array())
+    }
 }

--- a/crates/storage/traits/src/layout/impls.rs
+++ b/crates/storage/traits/src/layout/impls.rs
@@ -38,6 +38,7 @@ use ink_prelude::{
 };
 use ink_primitives::{
     AccountId,
+    Address,
     Hash,
     Key,
     H160,
@@ -59,7 +60,7 @@ macro_rules! impl_storage_layout_for_primitives {
 }
 #[rustfmt::skip]
 impl_storage_layout_for_primitives!(
-    AccountId, Hash, String,
+    AccountId, Address, Hash, String,
     H160, H256, U256,
     bool, char, (),
     u8, u16, u32, u64, u128,


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->
Allows Solidity contracts and tools to transparently call ink! contracts

## Description
<!--- Describe your changes in detail -->
- Update Solidity selectors to be Solidity ABI compatible
- More robust Solidity call input decoding

NOTE: Also renames native ABI (including the `ink::contract` config attribute arg) from SCALE to ink

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
