### PR TITLE
fix(codegen): call-builder postfixes "_sol" when abi is all

### DIFF
--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -23,6 +23,7 @@ use ir::{
 };
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{
+    format_ident,
     quote,
     quote_spanned,
 };
@@ -496,6 +497,13 @@ impl ContractRef<'_> {
         }
 
         if abi.is_solidity() {
+            // If ABI is all, we generate a second constructor with a "_sol" postfix.
+            // Otherwise, we use the same name.
+            let sol_constructor_ident = if abi.is_all() {
+                format_ident!("{}_sol", constructor_ident)
+            } else {
+                constructor_ident.clone()
+            };
             let arg_list = generator::generate_argument_list(
                 input_types.iter().cloned(),
                 quote!(::ink::reflect::SolEncoding),
@@ -505,7 +513,7 @@ impl ContractRef<'_> {
                 #( #attrs )*
                 #[inline]
                 #[allow(clippy::type_complexity)]
-                pub fn #constructor_ident(
+                pub fn #sol_constructor_ident(
                     #( #input_bindings : #input_types ),*
                 ) -> ::ink::env::call::CreateBuilder<
                     Environment,

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -44,7 +44,6 @@ use quote::{
 use syn::{
     spanned::Spanned as _,
     LitInt,
-    Type,
 };
 
 /// A message to be dispatched.

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -16,6 +16,12 @@ use core::iter;
 
 use crate::{
     generator,
+    generator::solidity::{
+        sol_type,
+        solidity_call_type_ident,
+        solidity_selector,
+        solidity_selector_id,
+    },
     GenerateCode,
 };
 use derive_more::From;
@@ -1272,62 +1278,6 @@ impl Dispatch<'_> {
             )
         } else {
             quote!()
-        }
-    }
-}
-
-/// Returns Solidity ABI compatible selector of an ink! message.
-fn solidity_selector(message: &CallableWithSelector<Message>) -> TokenStream2 {
-    let call_type_ident = solidity_call_type_ident(message);
-    quote!(
-        {
-            <__ink_sol_interop__::#call_type_ident>::SELECTOR
-        }
-    )
-}
-
-/// Returns a `u32` representation of the Solidity ABI compatible selector of an ink!
-/// message.
-fn solidity_selector_id(message: &CallableWithSelector<Message>) -> TokenStream2 {
-    let call_type_ident = solidity_call_type_ident(message);
-    quote!(
-        {
-            <__ink_sol_interop__::#call_type_ident>::SELECTOR_ID
-        }
-    )
-}
-
-/// Returns the Solidity call info type identifier for an ink! message.
-///
-/// See [`ink::alloy_sol_types::sol`]
-fn solidity_call_type_ident(message: &CallableWithSelector<Message>) -> Ident {
-    let ident = message.ident();
-    let id = message.composed_selector().into_be_u32();
-    format_ident!("{ident}{id}Call")
-}
-
-/// Returns [`ink::alloy_sol_types::SolType`] representation for the given type.
-fn sol_type(ty: &Type) -> TokenStream2 {
-    match ty {
-        // TODO: (@davidsemakula) replace with more robust solution before release v6
-        // release. Necessary because `alloy_sol_types::SolValue` is not
-        // implemented for u8.
-        Type::Path(ty) if ty.path.is_ident("u8") => {
-            quote! {
-                ::ink::alloy_sol_types::sol_data::Uint<8>
-            }
-        }
-        Type::Reference(ty) => sol_type(&ty.elem),
-        Type::Tuple(tys) => {
-            let tuple_tys = tys.elems.iter().map(sol_type);
-            quote! {
-                (#(#tuple_tys,)*)
-            }
-        }
-        _ => {
-            quote! {
-                <#ty as ::ink::alloy_sol_types::SolValue>::SolType
-            }
         }
     }
 }

--- a/crates/ink/codegen/src/generator/mod.rs
+++ b/crates/ink/codegen/src/generator/mod.rs
@@ -38,6 +38,7 @@ mod ink_test;
 mod item_impls;
 mod metadata;
 mod selector;
+mod solidity;
 mod storage;
 mod storage_item;
 mod trait_def;

--- a/crates/ink/codegen/src/generator/solidity.rs
+++ b/crates/ink/codegen/src/generator/solidity.rs
@@ -1,0 +1,72 @@
+use ir::{
+    Callable,
+    CallableWithSelector,
+    Message,
+};
+use proc_macro2::{
+    Ident,
+    TokenStream as TokenStream2,
+};
+use quote::{
+    format_ident,
+    quote,
+};
+use syn::Type;
+
+/// Returns Solidity ABI compatible selector of an ink! message.
+pub(crate) fn solidity_selector(message: &CallableWithSelector<Message>) -> TokenStream2 {
+    let call_type_ident = solidity_call_type_ident(message);
+    quote!(
+        {
+            <__ink_sol_interop__::#call_type_ident>::SELECTOR
+        }
+    )
+}
+
+/// Returns a `u32` representation of the Solidity ABI compatible selector of an ink!
+/// message.
+pub(crate) fn solidity_selector_id(
+    message: &CallableWithSelector<Message>,
+) -> TokenStream2 {
+    let call_type_ident = solidity_call_type_ident(message);
+    quote!(
+        {
+            <__ink_sol_interop__::#call_type_ident>::SELECTOR_ID
+        }
+    )
+}
+
+/// Returns the Solidity call info type identifier for an ink! message.
+///
+/// See [`ink::alloy_sol_types::sol`]
+pub(crate) fn solidity_call_type_ident(message: &CallableWithSelector<Message>) -> Ident {
+    let ident = message.ident();
+    let id = message.composed_selector().into_be_u32();
+    format_ident!("{ident}{id}Call")
+}
+
+/// Returns [`ink::alloy_sol_types::SolType`] representation for the given type.
+pub(crate) fn sol_type(ty: &Type) -> TokenStream2 {
+    match ty {
+        // TODO: (@davidsemakula) replace with more robust solution before release v6
+        // release. Necessary because `alloy_sol_types::SolValue` is not
+        // implemented for u8.
+        Type::Path(ty) if ty.path.is_ident("u8") => {
+            quote! {
+                ::ink::alloy_sol_types::sol_data::Uint<8>
+            }
+        }
+        Type::Reference(ty) => sol_type(&ty.elem),
+        Type::Tuple(tys) => {
+            let tuple_tys = tys.elems.iter().map(sol_type);
+            quote! {
+                (#(#tuple_tys,)*)
+            }
+        }
+        _ => {
+            quote! {
+                <#ty as ::ink::alloy_sol_types::SolValue>::SolType
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Because a contract now supports separate ABIs, the call-builder generated had to use different codec types. This resulted in duplicate function signatures being created for the call-builder impl.

To solve this, this PR will check if the abi is all, and if so will postfix "_sol" to the constructor or message name.

Note: there is also a new file created under `generator/solidity.rs`. This now holds the solidity helper functions for codegen.

``` rust
#[ink::contract(abi = "all")]
mod contract {
        #[ink(constructor)]
        pub fn constructor() -> Self {
            Self {}
        }
}

// results in ...
impl ContractRef {
    pub fn constructor() -> ::ink::env::call::CreateBuilder<...> ...
    // and 
    pub fn constructor_sol() -> ::ink::env::call::CreateBuilder<...>...
}

// just ink! or sol
#[ink::contract(abi = "sol")]
mod contract {
        #[ink(constructor)]
        pub fn constructor() -> Self {
            Self {}
        }
}

// results in only ...
impl ContractRef {
    pub fn constructor() -> ::ink::env::call::CreateBuilder<...> ...
}

// similarly, messages have the same format. 
impl CallBuilder {
    pub fn message_2(...) -> ::ink::env::call::CallBuilder<...>...
    // and
    pub fn message_2_sol(...) -> ::ink::env::call::CallBuilder<...>...
}
```

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
