### PR TITLE
Fix broken link

### DIFF
--- a/integration-tests/public/contract-invocation/README.md
+++ b/integration-tests/public/contract-invocation/README.md
@@ -18,7 +18,7 @@ where
 
 ## Related ink! functions
 
-- [instantiate_contract](https://paritytech.github.io/ink/ink_env/fn.instantiate_contract.html)
+- [instantiate_contract](https://docs.rs/ink_env/latest/ink_env/fn.instantiate_contract.html)
 
 ## Test case (original status)
 


### PR DESCRIPTION
Old link: https://paritytech.github.io/ink/ink_env/fn.instantiate_contract.html
New link: https://docs.rs/ink_env/latest/ink_env/fn.instantiate_contract.html
Reason for Changes
The old link was broken or outdated.
The new link points to the latest version on docs.rs, ensuring users get accurate information.
If you have a better link suggestion, feel free to propose it, and I will update it! 🚀
