### PR TITLE
Documentation for contract abi arg and provided Rust/ink! to Solidity type mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 - Improve support for Solidity ABI calling conventions - [#2411](https://github.com/use-ink/ink/pull/2411)
 - Implement contract invocation in off-chain environment engine - [#1957](https://github.com/paritytech/ink/pull/1988)
 - Abstractions for mapping arbitrary Rust types to Solidity ABI compatible types - [#2441](https://github.com/use-ink/ink/pull/2441)
+- Documentation for contract abi arg and provided Rust/ink! to Solidity type mappings - [2463](https://github.com/use-ink/ink/pull/2463)
 
 ## Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,19 +66,22 @@ For the type of a contract's balance, `pallet-revive` uses depending on the cont
   In an upcoming beta release this could be simplified to reduce UX friction by just
   using one type everywhere and converting to the `pallet-revive` one.
 
-#### Contract Address: `H160`
+#### Contract Address: `Address` / `H160`
 For a contract's account, `pallet-revive` is using either the configured `AccountId` type
 of the `polkadot-sdk` runtime, or `H160`.
 
-Finding the `H160` for an `AccountId` is done via an address derivation scheme derived in
-[#7662](https://github.com/paritytech/polkadot-sdk/pull/7662).
+`Address` is a more semantically named type alias for `H160` defined in `ink_primitives`,
+and re-exported in the `ink` crate.
+
+Finding the `Address`/`H160` for an `AccountId` is done via an address derivation scheme
+derived in [#7662](https://github.com/paritytech/polkadot-sdk/pull/7662).
 After instantiating a contract, the address is no longer returned by `pallet-revive`.
 Instead one has to derive it from given parameters (see the linked PR). `cargo-contract`
 does that automatically.
 
 For contract instantiations and contract calls the pallet requires that a 1-to-1 mapping
-of an `AccountId` to a `H160` has been created. This can be done via the `map_account`/
-`unmap_account` API.
+of an `AccountId` to an `Address`/`H160` has been created. This can be done via the
+`map_account`/`unmap_account` API.
 The PR [#6096](https://github.com/paritytech/polkadot-sdk/pull/6096) contains more
 information.
 
@@ -89,7 +92,7 @@ Substrate `AccountId` which it is mapped to.
 #### Contract Hash: `H256`
 For a contract's hash value, `pallet-revive` uses a fixed `H256`, Previously,
 the `ink::Environment::Hash` type referenced the hash type being used for the
-contract's hash. Now it's just a fixed `H160`.
+contract's hash. Now it's just a fixed `H256`.
 
 ### Contract delegates can no longer be done by code
 In `pallet-contracts` (and hence up until ink! v5), a pattern for upgradeable

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -240,7 +240,7 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 /// - `keep_attr: String`
 ///
 ///   Tells the ink! code generator which attributes should be passed to call builders.
-///   Call builders are used to doing cross-contract calls and are automatically
+///   Call builders are used for making cross-contract calls and are automatically
 ///   generated for contracts.
 ///
 ///   **Usage Example:**
@@ -746,7 +746,7 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// - `keep_attr: String`
 ///
 ///   Tells the ink! code generator which attributes should be passed to call builders.
-///   Call builders are used to doing cross-contract calls and are automatically
+///   Call builders are used for making cross-contract calls and are automatically
 ///   generated for contracts.
 ///
 ///   **Usage Example:**

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -201,14 +201,14 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///   | `bool` | `bool` ||
 ///   | `iN` for `N ∈ {8,16,32,64,128}` | `intN` | e.g `i8` <=> `int8` |
 ///   | `uN` for `N ∈ {8,16,32,64,128}` | `uintN` | e.g `u8` <=> `uint8` |
-///   | `U256` | `uint256` ||
+///   | [`ink::U256`][ink-u256] | `uint256` ||
 ///   | `String` | `string` ||
-///   | `Address` / `H160` | `address` | `Address` is a type alias for the `H160` type used for addresses in `pallet-revive` |
+///   | [`ink::Address`][ink-address] / [`H160`][ink-h160] | `address` | `ink::Address` is a type alias for the `ink::H160` type used for addresses in `pallet-revive` |
 ///   | `[T; N]` for `const N: usize` | `T[N]` | e.g. `[i8; 64]` <=> `int8[64]` |
 ///   | `Vec<T>` | `T[]` | e.g. `Vec<i8>` <=> `int8[]` |
-///   | `SolBytes<u8>` |  `bytes1` ||
-///   | `SolBytes<[u8; N]>` for `1 <= N <= 32` |  `bytesN` | e.g. `SolBytes<[u8; 1]>` <=> `bytes1` |
-///   | `SolBytes<Vec<u8>>` |  `bytes` ||
+///   | [`ink::SolBytes<u8>`][ink-sol-bytes] |  `bytes1` ||
+///   | [`ink::SolBytes<[u8; N]>`][ink-sol-bytes] for `1 <= N <= 32` |  `bytesN` | e.g. `ink::SolBytes<[u8; 1]>` <=> `bytes1` |
+///   | [`ink::SolBytes<Vec<u8>>`][ink-sol-bytes] |  `bytes` ||
 ///   | `(T1, T2, T3, ... T12)` | `(U1, U2, U3, ... U12)` | where `T1` <=> `U1`, ... `T12` <=> `U12` e.g. `(bool, u8, Address)` <=> `(bool, uint8, address)` |
 ///
 ///   [`SolEncode`][sol-trait-encode] is additionally implemented for reference and smart
@@ -233,6 +233,10 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 /// [sol-abi]: https://docs.soliditylang.org/en/latest/abi-spec.html
 /// [sol-abi-selector]: https://docs.soliditylang.org/en/latest/abi-spec.html#function-selector
 /// [sol-abi-codec]: https://docs.soliditylang.org/en/latest/abi-spec.html#formal-specification-of-the-encoding
+/// [ink-u256]: https://docs.rs/ink/latest/ink/struct.U256.html
+/// [ink-address]: https://docs.rs/ink/latest/ink/type.Address.html
+/// [ink-h160]: https://docs.rs/ink/latest/ink/struct.H160.html
+/// [ink-sol-bytes]: https://docs.rs/ink/latest/ink/struct.SolBytes.html
 /// [sol-trait-encode]: https://docs.rs/ink/latest/ink/trait.SolEncode.html
 /// [sol-trait-decode]: https://docs.rs/ink/latest/ink/trait.SolEncode.html
 /// [rust-coherence]: https://doc.rust-lang.org/reference/items/implementations.html#trait-implementation-coherence

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -117,6 +117,125 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///
 /// The `#[ink::contract]` macro can be provided with some additional comma-separated
 /// header arguments:
+/// - `abi: String`
+///
+///   Tells the ink! code generator which ABI (Application Binary Interface)
+///   specification(s) to support for contract interactions
+///   (i.e. which calling conventions to use for message calls).
+///
+///   **Default value:** `"ink"`
+///
+///   **Allowed values:** `"ink"`, `"sol"`, `"all"`
+///
+///   **Usage Example:**
+///   ```
+///   #[ink::contract(abi = "sol")]
+///   mod my_contract {
+///       # #[ink(storage)]
+///       # pub struct MyStorage;
+///       # impl MyStorage {
+///       #     #[ink(constructor)]
+///       //    #[bar]
+///       #     pub fn construct() -> Self { MyStorage {} }
+///       #     #[ink(message)]
+///       //    #[foo]
+///       #     pub fn message(&self) {}
+///       # }
+///       // ...
+///   }
+///   ```
+///
+///   - `abi = "ink"`
+///
+///      The code generator follows the ink! ABI specification. This means:
+///      - By default, message selectors are generated according to the [ink! ABI
+///        specification for selectors][ink-spec-selector].
+///      - Message selectors can be manually overridden using the `selector` attribute.
+///      - Parity's [SCALE Codec][scale-codec] is used for input/output encoding/decoding.
+///      - Call builders (used for making cross-contract calls) are generated for ink! ABI
+///        calling conventions.
+///
+///   - `abi = "sol"`
+///
+///      The code generator follows the [Solidity ABI specification][sol-abi]. This means:
+///      - Message selectors are **always** generated according to the [Solidity ABI
+///        specification for function selectors][sol-abi-selector].
+///      - Message selector manual overrides using the `selector` attribute are ignored.
+///      - [Solidity ABI encoding][sol-abi-codec] is used for input/output
+///        encoding/decoding.
+///      - Call builders are generated for Solidity ABI calling conventions.
+///
+///   - `abi = "all"`
+///
+///     The code generator follows both the ink! and Solidity ABI specifications, and
+///     generates entry points for both calling conventions. This means:
+///     - For each message, two selectors are generated, one for ink! and another for
+///       Solidity ABI.
+///     - Each selector is ABI specific and its entry point uses the corresponding
+///       input/output encoding/decoding scheme (i.e. entry points for ink! selectors use
+///       Parity's [SCALE Codec][scale-codec], while entry points for Solidity selectors
+///       use Solidity ABI encoding/decoding for input/output encoding/decoding).
+///     - Message selector manual overrides (using the `selector` attribute) are respected
+///       for ink! ABI entry points but ignored for Solidity ABI entry points (i.e.
+///       Solidity selectors are **always** generated according to the [Solidity ABI
+///       specification for function selectors][sol-abi-selector]).
+///     - Call builders are generated for both ink! and Solidity ABI calling conventions,
+///       and a `_sol` suffix is used to disambiguate Solidity calls.
+///
+///     Please note that your contract sizes will get larger if you support both the ink!
+///     and Solidity ABI.
+///
+///   For contracts that support Solidity ABI encoding
+///   (i.e. `abi = "sol"` or `abi = "all"`), all types used as constructor/message
+///   arguments and return types must define a mapping to an equivalent Solidity type.
+///   This mapping is defined using the [`SolEncode`][sol-trait-encode] and
+///   [`SolDecode`][sol-trait-decode] traits that are analogs to `scale::Encode` and
+///   `scale::Decode` (but for Solidity ABI encoding/decoding).
+///
+///   [`SolEncode`][sol-trait-encode] and [`SolDecode`][sol-trait-decode] are implemented
+///   for the following Rust/ink! primitive types creating a mapping
+///   to the corresponding Solidity ABI types as shown in the table below:
+///
+///   | Rust/ink! type | Solidity ABI type | Notes |
+///   | -------------- | ----------------- | ----- |
+///   | `bool` | `bool` ||
+///   | `iN` for `N ∈ {8,16,32,64,128}` | `intN` | e.g `i8` <=> `int8` |
+///   | `uN` for `N ∈ {8,16,32,64,128}` | `uintN` | e.g `u8` <=> `uint8` |
+///   | `U256` | `uint256` ||
+///   | `String` | `string` ||
+///   | `Address` / `H160` | `address` | `Address` is a type alias for the `H160` type used for addresses in `pallet-revive` |
+///   | `[T; N]` for `const N: usize` | `T[N]` | e.g. `[i8; 64]` <=> `int8[64]` |
+///   | `Vec<T>` | `T[]` | e.g. `Vec<i8>` <=> `int8[]` |
+///   | `SolBytes<u8>` |  `bytes1` ||
+///   | `SolBytes<[u8; N]>` for `1 <= N <= 32` |  `bytesN` | e.g. `SolBytes<[u8; 1]>` <=> `bytes1` |
+///   | `SolBytes<Vec<u8>>` |  `bytes` ||
+///   | `(T1, T2, T3, ... T12)` | `(U1, U2, U3, ... U12)` | where `T1` <=> `U1`, ... `T12` <=> `U12` e.g. `(bool, u8, Address)` <=> `(bool, uint8, address)` |
+///
+///   [`SolEncode`][sol-trait-encode] is additionally implemented for reference and smart
+///   pointer types below:
+///
+///   | Rust/ink! type | Solidity ABI type | Notes |
+///   | -------------- | ----------------- | ----- |
+///   | `&str`, `&mut str`, `Box<str>` | string ||
+///   | `&T`, `&mut T`, `Box<T>` | T | e.g. `&i8 <=> int8` |
+///   | `&[T]`, `&mut [T]`, `Box<[T]>` | T[] | e.g. `&[i8]` <=> `int8[]` |
+///
+///   See the rustdoc for [`SolEncode`][sol-trait-encode] and
+///   [`SolDecode`][sol-trait-decode] for instructions for implementing the traits for
+///   custom arbitrary types.
+///
+///   Please note that Rust's [coherence/orphan rules][rust-coherence] mean that you can
+///   only implement the [`SolEncode`][sol-trait-encode] and
+///   [`SolDecode`][sol-trait-decode]   traits for local types.
+///
+/// [ink-spec-selector]: https://use.ink/basics/selectors/
+/// [scale-codec]: https://docs.rs/parity-scale-codec/latest/parity_scale_codec
+/// [sol-abi]: https://docs.soliditylang.org/en/latest/abi-spec.html
+/// [sol-abi-selector]: https://docs.soliditylang.org/en/latest/abi-spec.html#function-selector
+/// [sol-abi-codec]: https://docs.soliditylang.org/en/latest/abi-spec.html#formal-specification-of-the-encoding
+/// [sol-trait-encode]: https://docs.rs/ink/latest/ink/trait.SolEncode.html
+/// [sol-trait-decode]: https://docs.rs/ink/latest/ink/trait.SolEncode.html
+/// [rust-coherence]: https://doc.rust-lang.org/reference/items/implementations.html#trait-implementation-coherence
 ///
 /// - `keep_attr: String`
 ///

--- a/crates/ink/src/lib.rs
+++ b/crates/ink/src/lib.rs
@@ -101,6 +101,7 @@ pub use ink_primitives::{
     SolBytes,
     SolDecode,
     SolEncode,
+    H160,
     H256,
     U256,
 };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -60,6 +60,7 @@ pub use self::{
 };
 
 pub use primitive_types::{
+    H160,
     H256,
     U256,
 };

--- a/integration-tests/internal/sr25519-verification/Cargo.toml
+++ b/integration-tests/internal/sr25519-verification/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

Adds docs for contract abi arg and provided Rust/ink! to Solidity type mappings to the the contract macro rustdoc

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
