### PR TITLE
fix: incorrect getopt parsing for `--quiet` flag

### DIFF
--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -48,7 +48,7 @@ shopt -s globstar
 
 command=( "${@:2}" )
 
-options=$(getopt -o p:i:q: --long path:,ignore:,quiet:,partition: -- "$@")
+options=$(getopt -o p:i:q --long path:,ignore:,quiet,partition: -- "$@")
 [ $? -eq 0 ] || {
     >&2 echo "Incorrect option provided"
     usage


### PR DESCRIPTION
## **Description**  

Fixed incorrect `getopt` parsing for the `--quiet` flag. Previously, it was defined as requiring an argument (`quiet:`), but `--quiet` is a standalone flag and shouldn't expect a value. This has been corrected to ensure proper flag handling.  

## **Checklist before requesting a review**  
- [ ] I have added an entry to `CHANGELOG.md`  
- [ ] I have commented on my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] Any dependent changes have been merged and published in downstream modules  