### PR TITLE
chore: optimize `cargo metadata` command execution

### DIFF
--- a/scripts/is_contract.sh
+++ b/scripts/is_contract.sh
@@ -30,9 +30,10 @@ fi
 
 ROOT_PACKAGE=$(cargo metadata --format-version=1 --manifest-path "$MANIFEST_PATH" |
   jq -r '.resolve.root')
-SOURCE_PATH=$(cargo metadata --format-version=1 --manifest-path "$MANIFEST_PATH" |
-  jq -r --arg ROOT_PACKAGE "$ROOT_PACKAGE" '
-    .packages[]
+  
+METADATA=$(cargo metadata --format-version=1 --manifest-path "$MANIFEST_PATH")
+ROOT_PACKAGE=$(echo "$METADATA" | jq -r '.resolve.root')
+SOURCE_PATH=$(echo "$METADATA" | jq -r --arg ROOT_PACKAGE "$ROOT_PACKAGE" '
     | select(.id == $ROOT_PACKAGE).targets[]
     | select(.kind[] | contains("lib")).src_path')
 


### PR DESCRIPTION
## Description
`cargo metadata` command was being executed twice with the same parameters, which resulted in redundant operations and unnecessary load, to address this, I've modified the script to run the `cargo metadata` command just once, saving the result into a variable and reusing it for further processing.

this should improve the script's efficiency and reduce unnecessary computations.

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
