### PR TITLE
chore: Remove `alloy-sol-types` dependency from `ink_env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,6 @@ dependencies = [
 name = "ink_env"
 version = "6.0.0-alpha"
 dependencies = [
- "alloy-sol-types",
  "blake2",
  "cfg-if",
  "const_env",

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -23,7 +23,6 @@ ink_primitives = { workspace = true }
 ink_macro = { workspace = true }
 pallet-revive-uapi = { workspace = true }
 
-alloy-sol-types = { workspace = true }
 scale = { workspace = true, features = ["max-encoded-len"] }
 derive_more = { workspace = true, features = ["from", "display"] }
 num-traits = { workspace = true, features = ["i128"] }
@@ -68,7 +67,6 @@ ink = { path = "../ink" }
 [features]
 default = ["std"]
 std = [
-    "alloy-sol-types/std",
     "blake2",
     "ink/std",
     "ink_allocator/std",

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     /// Error upon decoding an encoded value.
     Decode(scale::Error),
     /// Error upon decoding with the Solidity ABI encoding.
-    DecodeSol(alloy_sol_types::Error),
+    DecodeSol(ink_primitives::sol::Error),
     /// The static buffer used during ABI encoding or ABI decoding is too small.
     BufferTooSmall,
     /// An error that can only occur in the off-chain environment.

--- a/crates/primitives/src/reflect/dispatch.rs
+++ b/crates/primitives/src/reflect/dispatch.rs
@@ -16,6 +16,7 @@ use ink_prelude::vec::Vec;
 use pallet_revive_uapi::ReturnFlags;
 
 use crate::sol::{
+    self,
     SolDecode,
     SolEncode,
 };
@@ -317,7 +318,7 @@ where
 }
 
 impl<T: SolDecode> AbiDecodeWith<SolEncoding> for T {
-    type Error = alloy_sol_types::Error;
+    type Error = sol::Error;
     fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error> {
         T::decode(buffer)
     }

--- a/crates/primitives/src/sol.rs
+++ b/crates/primitives/src/sol.rs
@@ -20,11 +20,12 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+use core::ops::Deref;
+
 use alloy_sol_types::{
     sol_data,
     SolType as AlloySolType,
 };
-use core::ops::Deref;
 use impl_trait_for_tuples::impl_for_tuples;
 use ink_prelude::{
     borrow::Cow,
@@ -32,16 +33,19 @@ use ink_prelude::{
     string::String,
     vec::Vec,
 };
-
-pub use bytes::SolBytes;
 use primitive_types::{
     H256,
     U256,
 };
-pub use types::{
-    SolTypeDecode,
-    SolTypeEncode,
+
+pub use self::{
+    bytes::SolBytes,
+    types::{
+        SolTypeDecode,
+        SolTypeEncode,
+    },
 };
+pub use alloy_sol_types::Error;
 
 use crate::types::{
     AccountId,


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
