### PR TITLE
fix: Always use ink! ABI/ SCALE codec for constructor and instantiation related builders and utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 
 ## Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)
+- Always use ink! ABI/ SCALE codec for constructor and instantiation related builders and utilities - [#2474](https://github.com/use-ink/ink/pull/2474)
 
 ## Version 5.1.0
 

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -38,6 +38,7 @@ use ink_primitives::{
     reflect::{
         AbiDecodeWith,
         AbiEncodeWith,
+        ScaleEncoding,
     },
     DepositLimit,
 };
@@ -133,15 +134,14 @@ pub trait ContractsBackend<E: Environment> {
     fn instantiate<
         'a,
         Contract: Clone,
-        Args: Send + Clone + AbiEncodeWith<Abi> + Sync,
+        Args: Send + Clone + AbiEncodeWith<ScaleEncoding> + Sync,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &'a mut self,
         contract_name: &'a str,
         caller: &'a Keypair,
-        constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
-    ) -> InstantiateBuilder<'a, E, Contract, Args, R, Self, Abi>
+        constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R>,
+    ) -> InstantiateBuilder<'a, E, Contract, Args, R, Self>
     where
         Self: Sized + BuilderClient<E>,
     {
@@ -311,14 +311,13 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
     /// instance is reused!
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
@@ -327,14 +326,13 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
     /// Dry run contract instantiation.
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
     ) -> Result<InstantiateDryRunResult<E>, Self::Error>;

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -33,6 +33,7 @@ use ink_primitives::{
     reflect::{
         AbiDecodeWith,
         AbiEncodeWith,
+        ScaleEncoding,
     },
     DepositLimit,
 };
@@ -199,10 +200,10 @@ where
 }
 
 /// Allows to build an end-to-end instantiation call using a builder pattern.
-pub struct InstantiateBuilder<'a, E, Contract, Args, R, B, Abi>
+pub struct InstantiateBuilder<'a, E, Contract, Args, R, B>
 where
     E: Environment,
-    Args: AbiEncodeWith<Abi> + Clone,
+    Args: AbiEncodeWith<ScaleEncoding> + Clone,
     Contract: Clone,
 
     B: ContractsBackend<E>,
@@ -210,29 +211,27 @@ where
     client: &'a mut B,
     caller: &'a Keypair,
     contract_name: &'a str,
-    constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+    constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R>,
     value: E::Balance,
     extra_gas_portion: Option<u64>,
     gas_limit: Option<Weight>,
     storage_deposit_limit: DepositLimit<E::Balance>,
 }
 
-impl<'a, E, Contract, Args, R, B, Abi>
-    InstantiateBuilder<'a, E, Contract, Args, R, B, Abi>
+impl<'a, E, Contract, Args, R, B> InstantiateBuilder<'a, E, Contract, Args, R, B>
 where
     E: Environment,
-    Args: AbiEncodeWith<Abi> + Clone + Send + Sync,
+    Args: AbiEncodeWith<ScaleEncoding> + Clone + Send + Sync,
     Contract: Clone,
     B: BuilderClient<E>,
-    Abi: Send + Sync + Clone,
 {
     /// Initialize a call builder with essential values.
     pub fn new(
         client: &'a mut B,
         caller: &'a Keypair,
         contract_name: &'a str,
-        constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
-    ) -> InstantiateBuilder<'a, E, Contract, Args, R, B, Abi>
+        constructor: &'a mut CreateBuilderPartial<E, Contract, Args, R>,
+    ) -> InstantiateBuilder<'a, E, Contract, Args, R, B>
     where
         E::Balance: From<u32>,
     {

--- a/crates/e2e/src/builders.rs
+++ b/crates/e2e/src/builders.rs
@@ -25,21 +25,24 @@ use ink_env::{
     },
     Environment,
 };
-use ink_primitives::reflect::AbiEncodeWith;
+use ink_primitives::reflect::{
+    AbiEncodeWith,
+    ScaleEncoding,
+};
 
 /// The type returned from `ContractRef` constructors, partially initialized with the
 /// execution input arguments.
-pub type CreateBuilderPartial<E, ContractRef, Args, R, Abi> = CreateBuilder<
+pub type CreateBuilderPartial<E, ContractRef, Args, R> = CreateBuilder<
     E,
     ContractRef,
     Set<LimitParamsV2>,
-    Set<ExecutionInput<Args, Abi>>,
+    Set<ExecutionInput<Args, ScaleEncoding>>,
     Set<ReturnType<R>>,
 >;
 
 /// Get the encoded constructor arguments from the partially initialized `CreateBuilder`
-pub fn constructor_exec_input<E, ContractRef, Args: AbiEncodeWith<Abi>, R, Abi>(
-    builder: CreateBuilderPartial<E, ContractRef, Args, R, Abi>,
+pub fn constructor_exec_input<E, ContractRef, Args: AbiEncodeWith<ScaleEncoding>, R>(
+    builder: CreateBuilderPartial<E, ContractRef, Args, R>,
 ) -> Vec<u8>
 where
     E: Environment,

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -51,6 +51,7 @@ use ink_primitives::{
     reflect::{
         AbiDecodeWith,
         AbiEncodeWith,
+        ScaleEncoding,
     },
     DepositLimit,
 };
@@ -246,14 +247,13 @@ where
 {
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
@@ -306,14 +306,13 @@ where
 
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
     ) -> Result<InstantiateDryRunResult<E>, Self::Error> {

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -66,6 +66,7 @@ use ink_primitives::{
     reflect::{
         AbiDecodeWith,
         AbiEncodeWith,
+        ScaleEncoding,
     },
     types::AccountIdMapper,
     DepositLimit,
@@ -489,14 +490,13 @@ where
 {
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
@@ -513,14 +513,13 @@ where
 
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
+        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
         R,
-        Abi: Send + Sync + Clone,
     >(
         &mut self,
         contract_name: &str,
         caller: &Keypair,
-        constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
+        constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
     ) -> Result<InstantiateDryRunResult<E>, Self::Error> {

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -49,6 +49,8 @@ use crate::{
     DispatchError,
     Result,
 };
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::reflect::ScaleEncoding;
 use ink_primitives::{
     reflect::{
         AbiDecodeWith,
@@ -347,8 +349,8 @@ where
 /// - If given insufficient endowment.
 /// - If the returned account ID failed to decode properly.
 #[cfg(feature = "unstable-hostfn")]
-pub fn instantiate_contract<E, ContractRef, Args, R, Abi>(
-    params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
+pub fn instantiate_contract<E, ContractRef, Args, R>(
+    params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R>,
 ) -> Result<
     ink_primitives::ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>,
 >
@@ -358,13 +360,11 @@ where
     <ContractRef as crate::ContractReverseReference>::Type:
         crate::reflect::ContractConstructorDecoder,
 
-    Args: AbiEncodeWith<Abi>,
+    Args: AbiEncodeWith<ScaleEncoding>,
     R: ConstructorReturnType<ContractRef>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::instantiate_contract::<E, ContractRef, Args, R, Abi>(
-            instance, params,
-        )
+        TypedEnvBackend::instantiate_contract::<E, ContractRef, Args, R>(instance, params)
     })
 }
 

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -35,6 +35,8 @@ use crate::{
     DispatchError,
     Result,
 };
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::reflect::ScaleEncoding;
 use ink_primitives::{
     reflect::{
         AbiDecodeWith,
@@ -365,9 +367,9 @@ pub trait TypedEnvBackend: EnvBackend {
     ///
     /// For more details visit: [`instantiate_contract`][`crate::instantiate_contract`]
     #[cfg(feature = "unstable-hostfn")]
-    fn instantiate_contract<E, ContractRef, Args, R, Abi>(
+    fn instantiate_contract<E, ContractRef, Args, R>(
         &mut self,
-        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,
@@ -378,7 +380,7 @@ pub trait TypedEnvBackend: EnvBackend {
         ContractRef: FromAddr + crate::ContractReverseReference,
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
-        Args: AbiEncodeWith<Abi>,
+        Args: AbiEncodeWith<ScaleEncoding>,
         R: ConstructorReturnType<ContractRef>;
 
     /// Terminates a smart contract.

--- a/crates/env/src/call/mod.rs
+++ b/crates/env/src/call/mod.rs
@@ -51,7 +51,6 @@ pub use self::{
     },
     create_builder::{
         build_create,
-        build_create_solidity,
         state,
         ConstructorReturnType,
         CreateBuilder,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -53,7 +53,10 @@ use crate::{
 };
 use ink_engine::ext::Engine;
 #[cfg(feature = "unstable-hostfn")]
-use ink_primitives::types::AccountIdMapper;
+use ink_primitives::{
+    reflect::ScaleEncoding,
+    types::AccountIdMapper,
+};
 use ink_primitives::{
     reflect::{
         AbiDecodeWith,
@@ -640,9 +643,9 @@ impl TypedEnvBackend for EnvInstance {
     }
 
     #[cfg(feature = "unstable-hostfn")]
-    fn instantiate_contract<E, ContractRef, Args, R, Abi>(
+    fn instantiate_contract<E, ContractRef, Args, R>(
         &mut self,
-        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,
@@ -653,7 +656,7 @@ impl TypedEnvBackend for EnvInstance {
         ContractRef: FromAddr + crate::ContractReverseReference,
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
-        Args: AbiEncodeWith<Abi>,
+        Args: AbiEncodeWith<ScaleEncoding>,
         R: ConstructorReturnType<ContractRef>,
     {
         let endowment = params.endowment();

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -56,6 +56,8 @@ use crate::{
     },
     Clear,
 };
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::reflect::ScaleEncoding;
 use ink_primitives::{
     reflect::{
         AbiDecodeWith,
@@ -598,9 +600,9 @@ impl TypedEnvBackend for EnvInstance {
     }
 
     #[cfg(feature = "unstable-hostfn")]
-    fn instantiate_contract<E, ContractRef, Args, RetType, Abi>(
+    fn instantiate_contract<E, ContractRef, Args, RetType>(
         &mut self,
-        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, RetType, Abi>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, RetType>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <RetType as ConstructorReturnType<ContractRef>>::Output,
@@ -609,8 +611,7 @@ impl TypedEnvBackend for EnvInstance {
     where
         E: Environment,
         ContractRef: FromAddr,
-
-        Args: AbiEncodeWith<Abi>,
+        Args: AbiEncodeWith<ScaleEncoding>,
         RetType: ConstructorReturnType<ContractRef>,
     {
         let mut scoped = self.scoped_buffer();

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -35,6 +35,8 @@ use ink_env::{
     Environment,
     Result,
 };
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::reflect::ScaleEncoding;
 use ink_primitives::{
     reflect::{
         AbiDecodeWith,
@@ -486,9 +488,9 @@ where
     ///
     /// For more details visit: [`ink_env::instantiate_contract`]
     #[cfg(feature = "unstable-hostfn")]
-    pub fn instantiate_contract<ContractRef, Args, R, Abi>(
+    pub fn instantiate_contract<ContractRef, Args, R>(
         self,
-        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,
@@ -499,10 +501,10 @@ where
         <ContractRef as ink_env::ContractReverseReference>::Type:
             ink_env::reflect::ContractConstructorDecoder,
 
-        Args: AbiEncodeWith<Abi>,
+        Args: AbiEncodeWith<ScaleEncoding>,
         R: ConstructorReturnType<ContractRef>,
     {
-        ink_env::instantiate_contract::<E, ContractRef, Args, R, Abi>(params)
+        ink_env::instantiate_contract::<E, ContractRef, Args, R>(params)
     }
 
     /// Invokes a contract message and returns its result.

--- a/crates/primitives/src/reflect/dispatch.rs
+++ b/crates/primitives/src/reflect/dispatch.rs
@@ -245,11 +245,12 @@ pub enum Encoding {
 
 /// Marker type for SCALE encoding. Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and
 /// `DecodeMessageResult`.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ScaleEncoding;
+
 /// Marker type for Solidity ABI encoding. Used with [`AbiEncodeWith`],
 /// [`AbiDecodeWith`] and `DecodeMessageResult`.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct SolEncoding;
 
 /// Trait for ABI-specific encoding with support for both slice and vector buffers.


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
- Removes `_sol` suffixed constructor variants from contract references
- Removes `build_create_solidity` utility
- Removes `Abi` type params from constructor and instantiation related builders and utilities and always use `ink_primitives::reflect::ScaleEncoding` where necessary

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
