### PR TITLE
ci: remove toolchain adjustments

### DIFF
--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -1,24 +1,21 @@
-name: init
+name: Initialize Runner
 description: |
-  This action initializes a worker for use in other actions by maximizing build space and initializing caching for 
-  Rust/Cargo projects.
+  This action initializes a runner/worker for use in other actions by maximizing build space and initializing caching 
+  for Rust/Cargo projects.
 
 inputs:
   maximize-space:
-    description: Whether to maximise build space
+    description: Whether to maximise build space by removing unnecessary software by default. Defaults to true.
     default: 'true'
   cache:
-    description: Whether to cache Rust/cargo projects
-    required: false
+    description: Whether to cache Rust/cargo projects.
   cache-all-crates:
-    description: Whether all crates should be cached, or only dependent crates.
+    description: Whether all crates should be cached, or only dependent crates. Defaults to true.
     default: 'true'
   cache-directories:
-    description: Additional non workspace directories to be cached, separated by newlines.
-    required: false
+    description: Additional non-workspace directories to be cached, separated by newlines.
   cache-on-failure:
     description: Cache even if the build fails. Defaults to false.
-    required: false
     default: 'false'
   cache-key:
     description: An additional optional key to be added. Useful for jobs utilizing a matrix.
@@ -33,10 +30,11 @@ runs:
       with:
         remove-android: 'true'
         remove-codeql: 'true'
+        remove-docker-images: 'true'
         remove-dotnet: 'true'
         remove-haskell: 'true'
 
-    - name: Rust Cache
+    - name: Cache Rust/Cargo projects and dependencies
       uses: Swatinem/rust-cache@v2
       if: ${{ inputs.cache == 'true' }}
       with:

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -23,7 +23,6 @@ runs:
       with:
         remove-android: 'true'
         remove-codeql: 'true'
-        remove-docker-images: 'true'
         remove-dotnet: 'true'
         remove-haskell: 'true'
 

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -1,12 +1,8 @@
 name: init
 description: |
-  This action sets up a worker for use in other actions by checking out the repository, maximizing build space and
-  initializing caching.
+  This action sets up a worker for use in other actions by maximizing build space and optionally initializing caching.
 
 inputs:
-  checkout:
-    description: Checkout the repository
-    default: 'true'
   maximize-space:
     description: Maximises build space
     default: 'true'
@@ -25,12 +21,6 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
-      with:
-        fetch-depth: 1
-
     - name: Maximize build space
       uses: AdityaGarg8/remove-unwanted-software@v5
       if: ${{ inputs.maximize-space == 'true' }}

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -1,8 +1,15 @@
 name: init
 description: |
-  This action sets up a worker for use in other actions.
+  This action sets up a worker for use in other actions by checking out the repository, maximizing build space and
+  initializing caching.
 
 inputs:
+  checkout:
+    description: Checkout the repository
+    default: 'true'
+  maximize-space:
+    description: Maximises build space
+    default: 'true'
   cache:
     description: Whether to cache Rust/cargo projects
     required: false
@@ -18,8 +25,15 @@ runs:
   using: composite
 
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      if: ${{ inputs.checkout == 'true' }}
+      with:
+        fetch-depth: 1
+
     - name: Maximize build space
       uses: AdityaGarg8/remove-unwanted-software@v5
+      if: ${{ inputs.maximize-space == 'true' }}
       with:
         remove-android: 'true'
         remove-codeql: 'true'

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -20,6 +20,8 @@ inputs:
     description: Cache even if the build fails. Defaults to false.
     required: false
     default: 'false'
+  cache-key:
+    description: An additional optional key to be added. Useful for jobs utilizing a matrix.
 
 runs:
   using: composite
@@ -41,3 +43,4 @@ runs:
         cache-all-crates: ${{ inputs.cache-all-crates }}
         cache-directories: ${{ inputs.cache-directories }}
         cache-on-failure: ${{ inputs.cache-on-failure }}
+        key: ${{ inputs.cache-key }}

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -1,14 +1,18 @@
 name: init
 description: |
-  This action sets up a worker for use in other actions by maximizing build space and optionally initializing caching.
+  This action initializes a worker for use in other actions by maximizing build space and initializing caching for 
+  Rust/Cargo projects.
 
 inputs:
   maximize-space:
-    description: Maximises build space
+    description: Whether to maximise build space
     default: 'true'
   cache:
     description: Whether to cache Rust/cargo projects
     required: false
+  cache-all-crates:
+    description: Whether all crates should be cached, or only dependent crates.
+    default: 'true'
   cache-directories:
     description: Additional non workspace directories to be cached, separated by newlines.
     required: false
@@ -30,13 +34,10 @@ runs:
         remove-dotnet: 'true'
         remove-haskell: 'true'
 
-#    - name: Rust Info
-#      uses: ./.github/rust-info
-
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
       if: ${{ inputs.cache == 'true' }}
       with:
+        cache-all-crates: ${{ inputs.cache-all-crates }}
         cache-directories: ${{ inputs.cache-directories }}
-        cache-all-crates: true
         cache-on-failure: ${{ inputs.cache-on-failure }}

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -27,8 +27,8 @@ runs:
         remove-dotnet: 'true'
         remove-haskell: 'true'
 
-    - name: Rust Info
-      uses: ./.github/rust-info
+#    - name: Rust Info
+#      uses: ./.github/rust-info
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/init/action.yaml
+++ b/.github/init/action.yaml
@@ -1,0 +1,39 @@
+name: init
+description: |
+  This action sets up a worker for use in other actions.
+
+inputs:
+  cache:
+    description: Whether to cache Rust/cargo projects
+    required: false
+  cache-directories:
+    description: Additional non workspace directories to be cached, separated by newlines.
+    required: false
+  cache-on-failure:
+    description: Cache even if the build fails. Defaults to false.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+
+  steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v5
+      with:
+        remove-android: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
+
+    - name: Rust Info
+      uses: ./.github/rust-info
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+      if: ${{ inputs.cache == 'true' }}
+      with:
+        cache-directories: ${{ inputs.cache-directories }}
+        cache-all-crates: true
+        cache-on-failure: ${{ inputs.cache-on-failure }}

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -3,10 +3,6 @@ description: |
   This action runs a specified command within a container using an optionally specified image.
 
 inputs:
-  image:
-    description: The Docker image to use.
-    # Image can be edited at https://github.com/use-ink/docker-images
-    default: evilrobot/useink:pr-4
   command:
     description: The command to run
     required: true
@@ -17,31 +13,22 @@ inputs:
 runs:
   using: composite
 
+  # NOTE: due to a limitation in reading an environment variable/input dynamically to set the image tag, be sure to
+  # update BOTH instances below if ever making any changes. See https://github.com/actions/runner/issues/1035 for more details.
   steps:
-    - name: Set Image
-      id: set_image
-      outputs:
-        IMAGE: ${{ inputs.image }}
-
     - name: Rust Info
-      uses: "docker://${{ steps.set_image.outputs.IMAGE }}"
+      # Image can be edited at https://github.com/use-ink/docker-images
+      uses: docker://evilrobot/useink:pr-4
       if: ${{ inputs.output-info == 'true' }}
       with:
         entrypoint: /bin/bash
-        args: > 
-          -c 
-          "rustup show
-          cargo --version
-          rustup +nightly show
-          cargo +nightly --version
-          bash --version
-          ink-node --version
-          cargo contract --version
-          git --version
-          echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
+        args: -c "rustup show; cargo --version; rustup +nightly show; cargo +nightly --version; bash --version; " \
+          ink-node --version; cargo contract --version; git --version; " \
+          "echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
 
     - name: Run command in container
-      uses: "docker://${{ steps.set_image.outputs.IMAGE }}"
+      # Image can be edited at https://github.com/use-ink/docker-images
+      uses: docker://evilrobot/useink:pr-4
       with:
         entrypoint: /bin/bash
         args: -c "${{ inputs.command }}"

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Run command in container
       # Image can be edited at https://github.com/use-ink/docker-images
-      uses: docker://evilrobot/useink:pr-4-stable
+      uses: docker://useink/ci
       env:
         # Update the target directory used within the container to one which is within the path mounted to the host
         # runner workspace path. Required for effective caching.

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -18,8 +18,13 @@ runs:
   using: composite
 
   steps:
+    - name: Set Image
+      id: set_image
+      outputs:
+        IMAGE: ${{ inputs.image }}
+
     - name: Rust Info
-      uses: "docker://${{ inputs.image }}"
+      uses: "docker://${{ steps.set_image.outputs.IMAGE }}"
       if: ${{ inputs.output-info == 'true' }}
       with:
         entrypoint: /bin/bash
@@ -36,7 +41,7 @@ runs:
           echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
 
     - name: Run command in container
-      uses: "docker://${{ inputs.image }}"
+      uses: "docker://${{ steps.set_image.outputs.IMAGE }}"
       with:
         entrypoint: /bin/bash
         args: -c "${{ inputs.command }}"

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -15,6 +15,7 @@ runs:
 
   steps:
     - name: Run command in container
+      # Image can be edited at https://github.com/use-ink/docker-images
       uses: docker://evilrobot/useink:pr-4
 #      uses: docker://${{ inputs.image }} todo
       with:

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -17,6 +17,8 @@ runs:
     - name: Run command in container
       # Image can be edited at https://github.com/use-ink/docker-images
       uses: docker://evilrobot/useink:pr-4
+      env:
+        CARGO_TARGET_DIR: "/github/workspace/${{ env.CARGO_TARGET_DIR }}"
       with:
         entrypoint: /bin/bash
         args: -c "${{ inputs.command }}"

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -5,19 +5,38 @@ description: |
 inputs:
   image:
     description: The Docker image to use.
+    # Image can be edited at https://github.com/use-ink/docker-images
     default: evilrobot/useink:pr-4
   command:
     description: The command to run
     required: true
+  output-info:
+    description: Whether to output environment information
+    default: 'true'
 
 runs:
   using: composite
 
   steps:
+    - name: Rust Info
+      uses: "docker://${{ inputs.image }}"
+      if: ${{ inputs.output-info == 'true' }}
+      with:
+        entrypoint: /bin/bash
+        args: > 
+          -c 
+          "rustup show
+          cargo --version
+          rustup +nightly show
+          cargo +nightly --version
+          bash --version
+          ink-node --version
+          cargo contract --version
+          git --version
+          echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
+
     - name: Run command in container
-      # Image can be edited at https://github.com/use-ink/docker-images
-      uses: docker://evilrobot/useink:pr-4
-#      uses: docker://${{ inputs.image }} todo
+      uses: "docker://${{ inputs.image }}"
       with:
         entrypoint: /bin/bash
         args: -c "${{ inputs.command }}"

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -1,14 +1,11 @@
-name: run container command
+name: Run Container Command
 description: |
-  This action runs a specified command within a container using an optionally specified image.
+  This action runs a specified command within a container using the `useink/ci` image.
 
 inputs:
   command:
-    description: The command to run
+    description: The command to be run within a container.
     required: true
-  output-info:
-    description: Whether to output environment information
-    default: 'true'
 
 runs:
   using: composite
@@ -18,6 +15,8 @@ runs:
       # Image can be edited at https://github.com/use-ink/docker-images
       uses: docker://evilrobot/useink:pr-4-stable
       env:
+        # Update the target directory used within the container to one which is within the path mounted to the host
+        # runner workspace path. Required for effective caching.
         CARGO_TARGET_DIR: "/github/workspace/${{ env.CARGO_TARGET_DIR }}"
       with:
         entrypoint: /bin/bash

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Run command in container
       # Image can be edited at https://github.com/use-ink/docker-images
-      uses: docker://evilrobot/useink:pr-4
+      uses: docker://evilrobot/useink:pr-4-stable
       env:
         CARGO_TARGET_DIR: "/github/workspace/${{ env.CARGO_TARGET_DIR }}"
       with:

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -13,19 +13,7 @@ inputs:
 runs:
   using: composite
 
-  # NOTE: due to a limitation in reading an environment variable/input dynamically to set the image tag, be sure to
-  # update BOTH instances below if ever making any changes. See https://github.com/actions/runner/issues/1035 for more details.
   steps:
-    - name: Rust Info
-      # Image can be edited at https://github.com/use-ink/docker-images
-      uses: docker://evilrobot/useink:pr-4
-      if: ${{ inputs.output-info == 'true' }}
-      with:
-        entrypoint: /bin/bash
-        args: -c "rustup show; cargo --version; rustup +nightly show; cargo +nightly --version; bash --version; " \
-          ink-node --version; cargo contract --version; git --version; " \
-          "echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
-
     - name: Run command in container
       # Image can be edited at https://github.com/use-ink/docker-images
       uses: docker://evilrobot/useink:pr-4

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -1,0 +1,21 @@
+name: run container command
+description: |
+  This action runs a specified command within a container using an optionally specified image.
+
+inputs:
+  image:
+    description: The Docker image to use.
+    default: evilrobot/useink:pr-4
+  command:
+    description: The command to run
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Run command in container
+      uses: docker://${{ inputs.image }}
+      with:
+        entrypoint: /bin/bash
+        args: -c "${{ inputs.command }}"

--- a/.github/run-container-command/action.yaml
+++ b/.github/run-container-command/action.yaml
@@ -15,7 +15,8 @@ runs:
 
   steps:
     - name: Run command in container
-      uses: docker://${{ inputs.image }}
+      uses: docker://evilrobot/useink:pr-4
+#      uses: docker://${{ inputs.image }} todo
       with:
         entrypoint: /bin/bash
         args: -c "${{ inputs.command }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,11 @@ jobs:
         uses: ./.github/run-container-command
         with:
           command: |
-            ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
+            ALL_CRATES="${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
              for crate in ${ALL_CRATES}; do
                echo $crate;
                cargo +nightly clippy --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml \
-                 -- -D warnings -A ${CLIPPY_ALLOWED};
+                 -- -D warnings -A ${{ env.CLIPPY_ALLOWED }};
              done
 
   clippy-riscv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,11 +648,12 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
           MANIFEST_PATH: ""
-          CONTRACT_SIZE_FILE: "measurements-${{ steps.extract_branch.outputs.branch }}/contract_size_"
+          # `github.run_id` used as the branch name may contain '/'
+          CONTRACT_SIZE_FILE: "measurements-${{ github.run_id }}/contract_size_"
           CARGO_INCREMENTAL: 0
         with:
           command: |
-            mkdir -p measurements-${{ steps.extract_branch.outputs.branch }}/
+            mkdir -p measurements-${{ github.run_id }}/
             scripts/for_all_contracts_exec2.sh --path integration-tests -- \
               scripts/build_and_determine_contract_size.sh {}
   
@@ -661,7 +662,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-            path: ./measurements-${{ steps.extract_branch.outputs.branch }}/*
+            path: ./measurements-${{ github.run_id }}/*
             name: ${{ github.run_id }}_artifact
             retention-days: 1
 
@@ -683,13 +684,13 @@ jobs:
         run: |
             cat downloaded_artifacts/${{github.run_id}}_artifact/* | \
             sed -e 's/^integration-tests\/\(public\/\|internal\/\)\?//' | \
-            sort | uniq > measurements-${{ steps.extract_branch.outputs.branch }}
-            cat measurements-${{ steps.extract_branch.outputs.branch }}
+            sort | uniq > measurements-${{ github.run_id }}
+            cat measurements-${{ github.run_id }}
 
       - uses: actions/upload-artifact@v4
         with:
-            name: measurements-${{ steps.extract_branch.outputs.branch }}
-            path: ./measurements-${{ steps.extract_branch.outputs.branch }}
+            name: measurements-${{ github.run_id }}
+            path: ./measurements-${{ github.run_id }}
             retention-days: 31
 
   examples-docs:
@@ -845,7 +846,7 @@ jobs:
         - name: Download artifact from this branch
           uses: dawidd6/action-download-artifact@v9
           with:
-              name: measurements-${{ steps.extract_branch.outputs.branch }}
+              name: measurements-${{ github.run_id }}
               run_id: ${{ github.run_id }}
 
         - name: Download master artifact
@@ -861,9 +862,9 @@ jobs:
               echo "master:"
               cat measurements-master
               echo "branch:"
-              cat measurements-${{ steps.extract_branch.outputs.branch }}
+              cat measurements-${{ github.run_id }}
               echo "---"
-              ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ steps.extract_branch.outputs.branch }} > contract_sizes_diff.md
+              ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ github.run_id }} > contract_sizes_diff.md
               cat contract_sizes_diff.md
 
         - name: Submit Comment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Initialize
         uses: ./.github/init
+        with:
+          maximize-space: 'false'
 
       - name: Rust Info
         uses: ./.github/run-container-command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,18 +111,22 @@ jobs:
         uses: ./.github/init
 
       - name: Check Formatting
-        run: |
-          zepter run check
-          cargo +nightly fmt --all -- --check
-          # For the UI tests we need to disable the license check
-          cargo +nightly fmt --all -- --check ./crates/ink/tests/ui/contract/{pass,fail}/*.rs
-          cargo +nightly fmt --all -- --check ./crates/ink/tests/ui/trait_def/{pass,fail}/*.rs
+        uses: ./.github/run-container-command
+        with:
+          command: |
+            zepter run check
+            cargo +nightly fmt --all -- --check
+            # For the UI tests we need to disable the license check
+            cargo +nightly fmt --all -- --check ./crates/ink/tests/ui/contract/{pass,fail}/*.rs
+            cargo +nightly fmt --all -- --check ./crates/ink/tests/ui/trait_def/{pass,fail}/*.rs
 
       - name: Check Examples Formatting
-        run: |
-          scripts/for_all_contracts_exec.sh --path integration-tests -- cargo +nightly fmt --manifest-path {} -- --check
-          # This file is not a part of the cargo project, so it wouldn't be formatted the usual way
-          rustfmt +nightly --check ./integration-tests/public/psp22-extension/runtime/psp22-extension-example.rs
+        uses: ./.github/run-container-command
+        with:
+          command: |
+            scripts/for_all_contracts_exec.sh --path integration-tests -- cargo +nightly fmt --manifest-path {} -- --check
+            # This file is not a part of the cargo project, so it wouldn't be formatted the usual way
+            rustfmt +nightly --check ./integration-tests/public/psp22-extension/runtime/psp22-extension-example.rs
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,17 +653,7 @@ jobs:
 
   examples-contract-build-riscv:
     runs-on: ubuntu-latest
-    needs: [set-image]
-    # needs: [set-image, build-std, build-riscv]
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    needs: [set-image, build]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -683,18 +673,20 @@ jobs:
         id: extract_branch
 
       - name: Build Contract Examples for RISC-V
+        uses: ./.github/run-container-command
         env:
           RUSTC_BOOTSTRAP: 1
           MANIFEST_PATH: ""
           CONTRACT_SIZE_FILE: "measurements-${{ steps.extract_branch.outputs.branch }}/contract_size_"
           CARGO_INCREMENTAL: 0
-        run: |
-          mkdir -p measurements-${{ steps.extract_branch.outputs.branch }}/
-          scripts/for_all_contracts_exec2.sh --path integration-tests --partition ${{ matrix.partition }}/30 -- \
-            scripts/build_and_determine_contract_size.sh {}
-
-            #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
-            #sed -ie 's/^integration-tests\/\(public\/\|internal\/\)\?//' ${CONTRACT_SIZE_FILE}"
+        with:
+          command: |
+            mkdir -p measurements-${{ steps.extract_branch.outputs.branch }}/
+            scripts/for_all_contracts_exec2.sh --path integration-tests --partition ${{ matrix.partition }}/30 -- \
+              scripts/build_and_determine_contract_size.sh {}
+  
+              #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
+              #sed -ie 's/^integration-tests\/\(public\/\|internal\/\)\?//' ${CONTRACT_SIZE_FILE}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,12 +253,7 @@ jobs:
 
   dylint-checks:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,26 +267,23 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Dylint
+        uses: ./.github/run-container-command
         env:
           # Setting incremental = 0 to reduce compilation artifact size.
           # The CI otherwise fails with "no disk space"
           CARGO_INCREMENTAL: 0
-        run: |
-          cd linting/
-          # we are using a toolchain file in this directory
-          # add required components for CI
-          cargo check --verbose
-          cargo +nightly fmt --all -- --check
-          cargo clippy -- -D warnings;
+        with:
+          command: |
+            cd linting/
+            # we are using a toolchain file in this directory
+            # add required components for CI
+            cargo check --verbose
+            cargo +nightly fmt --all -- --check
+            cargo clippy -- -D warnings;
 
   dylint-testing:
       runs-on: ubuntu-latest
-      defaults:
-          run:
-              shell: bash
       needs: [set-image]
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
       steps:
           - name: Checkout
             uses: actions/checkout@v4
@@ -305,14 +297,16 @@ jobs:
               cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Dylint
+            uses: ./.github/run-container-command
             env:
                 # Setting incremental = 0 to reduce compilation artifact size.
                 # The CI otherwise fails with "no disk space"
                 # todo Remove again at one point. This is a speed trade-off.
                 CARGO_INCREMENTAL: 0
-            run: |
-                cd linting/
-                cargo test --all-features
+            with:
+              command: |
+                  cd linting/
+                  cargo test --all-features
 
 ### workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/init
 
       - name: Rust Info
-        uses: docker://${{ env.IMAGE }}
+        uses: docker://evilrobot/useink:pr-4
         with:
           entrypoint: bash
           args:
@@ -91,7 +91,7 @@ jobs:
              echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
 
       - name: Check Spelling
-        uses: docker://${{ env.IMAGE }}
+        uses: docker://evilrobot/useink:pr-4
         with:
           entrypoint: bash
           args:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,6 @@ jobs:
 
   spellcheck:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,9 +75,14 @@ jobs:
         uses: ./.github/init
 
       - name: Check Spelling
-        run: |
-          cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
-          cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*
+        uses: docker://${{ env.IMAGE }}
+        with:
+          entrypoint: "bash"
+          args:
+            "pwd
+            ls *
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*"
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
       - 'FILE_HEADER'
 
 env:
-  CARGO_TARGET_DIR:                /ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
+  CARGO_TARGET_DIR:                ./ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
   PURELY_STD_CRATES:               ink/codegen metadata engine e2e e2e/macro ink/ir
   ALSO_RISCV_CRATES:               env storage storage/traits allocator prelude primitives ink ink/macro
   # TODO `cargo clippy --all-targets --all-features` for this crate
@@ -80,11 +80,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize runner
-        uses: ./.github/init
-        with:
-          maximize-space: 'false'
-
       - name: Check Spelling
         uses: ./.github/run-container-command
         with:
@@ -100,9 +95,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Initialize runner
-        uses: ./.github/init
 
       - name: Check Formatting
         uses: ./.github/run-container-command
@@ -689,7 +681,7 @@ jobs:
 
       - name: Combine contract sizes from individual examples
         run: |
-            cat downloaded_artifacts/${{github.run_id}}_artifact_*/* | \
+            cat downloaded_artifacts/${{github.run_id}}_artifact*/* | \
             sed -e 's/^integration-tests\/\(public\/\|internal\/\)\?//' | \
             sort | uniq > measurements-${{ steps.extract_branch.outputs.branch }}
             cat measurements-${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,8 +656,8 @@ jobs:
             scripts/for_all_contracts_exec2.sh --path integration-tests -- \
               scripts/build_and_determine_contract_size.sh {}
   
-              #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
-              #sed -ie 's/^integration-tests\/\(public\/\|internal\/\)\?//' ${CONTRACT_SIZE_FILE}"
+          #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
+          #sed -ie 's/^integration-tests\/\(public\/\|internal\/\)\?//' ${CONTRACT_SIZE_FILE}"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -681,7 +681,7 @@ jobs:
 
       - name: Combine contract sizes from individual examples
         run: |
-            cat downloaded_artifacts/${{github.run_id}}_artifact*/* | \
+            cat downloaded_artifacts/${{github.run_id}}_artifact | \
             sed -e 's/^integration-tests\/\(public\/\|internal\/\)\?//' | \
             sort | uniq > measurements-${{ steps.extract_branch.outputs.branch }}
             cat measurements-${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,16 +310,13 @@ jobs:
 
 ### workspace
 
-  build-std:
+  build:
     runs-on: ubuntu-latest
     needs: [set-image, check]
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     strategy:
       fail-fast: false
+      matrix:
+        type: [STD, RISCV]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -333,44 +330,29 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Build for STD
-        run: |
-          ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
-          for crate in ${ALL_CRATES}; do
-            cargo build --all-features --release --manifest-path ./crates/${crate}/Cargo.toml;
-          done
+        uses: ./.github/run-container-command
+        if: ${{ matrix.type == 'STD' }}
+        env:
+          ALL_CRATES: "${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
+        with:
+          command: |
+            for crate in ${ALL_CRATES}; do
+              cargo build --all-features --release --manifest-path ./crates/${crate}/Cargo.toml;
+            done
 
-  build-riscv:
-      runs-on: ubuntu-latest
-      needs: [set-image, check]
-      defaults:
-          run:
-              shell: bash
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
-      strategy:
-          fail-fast: false
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
-
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
-
-          - name: Build for RISC-V
-            run: |
-              for crate in ${ALSO_RISCV_CRATES}; do
-                echo ${crate};
-                RUSTFLAGS="--cfg substrate_runtime" cargo +nightly build \
-                  --no-default-features --release \
-                  --target $CLIPPY_TARGET \
-                  --manifest-path ./crates/${crate}/Cargo.toml \
-                  -Zbuild-std="core,alloc";
-              done
+      - name: Build for RISC-V
+        uses: ./.github/run-container-command
+        if: ${{ matrix.type == 'RISCV' }}
+        with:
+          command: |
+            for crate in ${ALSO_RISCV_CRATES}; do
+              echo ${crate};
+              RUSTFLAGS="--cfg substrate_runtime" cargo +nightly build \
+                --no-default-features --release \
+                --target $CLIPPY_TARGET \
+                --manifest-path ./crates/${crate}/Cargo.toml \
+                -Zbuild-std="core,alloc";
+            done
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,6 @@ jobs:
 
       - name: Dylint
         uses: ./.github/run-container-command
-        env:
-          # Setting incremental = 0 to reduce compilation artifact size.
-          # The CI otherwise fails with "no disk space"
-          CARGO_INCREMENTAL: 0
         with:
           command: |
             cd linting/
@@ -279,11 +275,6 @@ jobs:
 
         - name: Dylint
           uses: ./.github/run-container-command
-          env:
-              # Setting incremental = 0 to reduce compilation artifact size.
-              # The CI otherwise fails with "no disk space"
-              # todo Remove again at one point. This is a speed trade-off.
-              CARGO_INCREMENTAL: 0
           with:
             command: |
                 cd linting/
@@ -354,10 +345,6 @@ jobs:
       - name: Test
         uses: ./.github/run-container-command
         env:
-          # Setting incremental = 0 to reduce compilation artifact size.
-          # The CI otherwise fails with "no disk space"
-          # todo Remove again at one point. This is a speed trade-off.
-          CARGO_INCREMENTAL: 0
           # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
           RUSTFLAGS: -Clink-dead-code -Clink-arg=-z -Clink-arg=nostart-stop-gc
           # Since we run the tests with `--all-features` this implies the feature
@@ -393,10 +380,6 @@ jobs:
           #  todo check if this workspace condition is still necessary
           if: ${{ matrix.workspace == 'ink' }}
           env:
-              # Setting incremental = 0 to reduce compilation artifact size.
-              # The CI otherwise fails with "no disk space"
-              # todo Remove again at one point. This is a speed trade-off.
-              CARGO_INCREMENTAL: 0
               # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
               RUSTFLAGS: -Clink-dead-code -Clink-arg=-z -Clink-arg=nostart-stop-gc
               # Since we run the tests with `--all-features` this implies the feature
@@ -541,10 +524,6 @@ jobs:
       - name: Test Examples
         uses: ./.github/run-container-command
         env:
-            # Setting incremental = 0 to reduce compilation artifact size.
-            # The CI otherwise fails with "no disk space"
-            # todo Remove again at one point. This is a speed trade-off.
-            CARGO_INCREMENTAL: 0
             # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
             RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,11 +391,6 @@ jobs:
   test-docs:
       runs-on: ubuntu-latest
       needs: [set-image, check]
-      defaults:
-          run:
-              shell: bash
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
       strategy:
           fail-fast: false
           matrix:
@@ -413,6 +408,7 @@ jobs:
               cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Test
+            uses: ./.github/run-container-command
             #  todo check if this workspace condition is still necessary
             if: ${{ matrix.workspace == 'ink' }}
             env:
@@ -427,8 +423,9 @@ jobs:
                 # There's no way to disable a single feature while enabling all features
                 # at the same time, hence we use this workaround.
                 QUICKCHECK_TESTS:            0
-            run: |
-                cargo +nightly test --all-features --no-fail-fast --workspace --doc --locked
+            with:
+              command: |
+                  cargo +nightly test --all-features --no-fail-fast --workspace --doc --locked
 
   test-linting:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,26 +79,28 @@ jobs:
         uses: docker://evilrobot/useink:pr-4
         with:
           entrypoint: /bin/bash
-          args:
-            "rustup show
-             cargo --version
-             rustup +nightly show
-             cargo +nightly --version
-             bash --version
-             ink-node --version
-             cargo contract --version
-             git --version
-             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
+          args: >
+            -c
+            "rustup show;
+             cargo --version;
+             rustup +nightly show;
+             cargo +nightly --version;
+             bash --version;
+             ink-node --version;
+             cargo contract --version;
+             git --version;
+             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml;"
 
       - name: Check Spelling
         uses: docker://evilrobot/useink:pr-4
         with:
           entrypoint: /bin/bash
-          args:
-            "pwd
-            ls *
-            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
-            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*"
+          args: >
+            -c
+            "pwd;
+            ls *;
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .;
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*;"
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     needs: [set-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [ ALL, RISCV ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -144,8 +148,9 @@ jobs:
           cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
-      - name: Run Clippy
+      - name: Run Clippy for all crates
         uses: ./.github/run-container-command
+        if: ${{ matrix.type == 'ALL' }}
         env:
           ALL_CRATES: "${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
         with:
@@ -156,34 +161,17 @@ jobs:
                -- -D warnings -A ${CLIPPY_ALLOWED};
             done
 
-  clippy-riscv:
-      runs-on: ubuntu-latest
-      defaults:
-          run:
-              shell: bash
-      needs: [set-image]
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
-
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
-
-          - name: Run Clippy for RISC-V Crates
-            run: |
-                for crate in ${ALSO_RISCV_CRATES}; do
-                  echo $crate;
-                  cargo +nightly clippy --no-default-features --manifest-path ./crates/${crate}/Cargo.toml \
-                    --target ${CLIPPY_TARGET} \
-                    -- -D warnings -A ${CLIPPY_ALLOWED};
-                done
+      - name: Run Clippy for RISC-V Crates
+        uses: ./.github/run-container-command
+        if: ${{ matrix.type == 'RISCV' }}
+        with:
+          command: |
+            for crate in ${ALSO_RISCV_CRATES}; do
+              echo $crate;
+              cargo +nightly clippy --no-default-features --manifest-path ./crates/${crate}/Cargo.toml \
+                --target ${CLIPPY_TARGET} \
+                -- -D warnings -A ${CLIPPY_ALLOWED};
+            done
 
   clippy-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-image]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Initialize
         uses: ./.github/init
 
@@ -126,6 +131,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-image]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Initialize
         uses: ./.github/init
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,9 +230,10 @@ jobs:
       - name: Check
         uses: ./.github/run-container-command
         if: ${{ matrix.type == 'STD' }}
+        env:
+          ALL_CRATES: "${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
         with:
           command: |
-            ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
             for crate in ${ALL_CRATES}; do
               cargo check --all-features --manifest-path ./crates/${crate}/Cargo.toml;
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,31 +282,31 @@ jobs:
             cargo clippy -- -D warnings;
 
   dylint-testing:
-      runs-on: ubuntu-latest
-      needs: [set-image]
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
+    runs-on: ubuntu-latest
+    needs: [set-image]
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 1
 
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
+        - name: Initialize runner
+          uses: ./.github/init
+          with:
+            cache: true
+            cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
-          - name: Dylint
-            uses: ./.github/run-container-command
-            env:
-                # Setting incremental = 0 to reduce compilation artifact size.
-                # The CI otherwise fails with "no disk space"
-                # todo Remove again at one point. This is a speed trade-off.
-                CARGO_INCREMENTAL: 0
-            with:
-              command: |
-                  cd linting/
-                  cargo test --all-features
+        - name: Dylint
+          uses: ./.github/run-container-command
+          env:
+              # Setting incremental = 0 to reduce compilation artifact size.
+              # The CI otherwise fails with "no disk space"
+              # todo Remove again at one point. This is a speed trade-off.
+              CARGO_INCREMENTAL: 0
+          with:
+            command: |
+                cd linting/
+                cargo test --all-features
 
 ### workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             bash --version
             ink-node --version; cargo contract --version; git --version
             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml
-            echo "cargo-contract-version=$(cargo +nightly contract --version)" >> $GITHUB_OUTPUT
+            echo \"cargo-contract-version=$(cargo +nightly contract --version)\" >> $GITHUB_OUTPUT
 
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,15 @@ jobs:
 
       - name: Run Clippy
         uses: ./.github/run-container-command
+        env:
+          ALL_CRATES: "${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
         with:
           command: |
-            ALL_CRATES="${{ env.PURELY_STD_CRATES }} ${{ env.ALSO_RISCV_CRATES }}"
-             for crate in ${ALL_CRATES}; do
-               echo $crate;
-               cargo +nightly clippy --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml \
-                 -- -D warnings -A ${{ env.CLIPPY_ALLOWED }};
-             done
+            for crate in ${ALL_CRATES}; do
+             echo $crate;
+             cargo +nightly clippy --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml \
+               -- -D warnings -A ${CLIPPY_ALLOWED};
+            done
 
   clippy-riscv:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,11 +765,6 @@ jobs:
         github.ref == 'refs/heads/master'
     permissions:
       issues: write
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -783,21 +778,23 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Fuzz
+        uses: ./.github/run-container-command
         id: fuzz_test
         env:
           QUICKCHECK_TESTS:              5000
-        run: |
-          # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
-          all_tests_passed=0
-          ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
-          for crate in ${ALL_CRATES}; do
-            if grep "ink-fuzz-tests =" ./crates/${crate}/Cargo.toml;
-            then
-              cargo +nightly test --features ink-fuzz-tests --manifest-path ./crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_ || exit_code=$?;
-              all_tests_passed=$(( all_tests_passed | exit_code ));
-            fi
-          done
-          exit ${all_tests_passed}
+        with:
+          command: |
+            # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
+            all_tests_passed=0
+            ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
+            for crate in ${ALL_CRATES}; do
+              if grep "ink-fuzz-tests =" ./crates/${crate}/Cargo.toml;
+              then
+                cargo +nightly test --features ink-fuzz-tests --manifest-path ./crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_ || exit_code=$?;
+                all_tests_passed=$(( all_tests_passed | exit_code ));
+              fi
+            done
+            exit ${all_tests_passed}
 
       - name: Create Issue
         if: ${{ failure() && steps.fuzz_test.conclusion == 'failure' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,40 +67,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-image]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
       - name: Initialize
         uses: ./.github/init
 
       - name: Rust Info
-        uses: docker://evilrobot/useink:pr-4
+        uses: ./.github/run-container-command
         with:
-          entrypoint: /bin/bash
-          args: >
-            -c
-            "rustup show;
-             cargo --version;
-             rustup +nightly show;
-             cargo +nightly --version;
-             bash --version;
-             ink-node --version;
-             cargo contract --version;
-             git --version;
-             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml;"
+          command: |
+            rustup show
+            cargo --version
+            rustup +nightly show
+            cargo +nightly --version
+            bash --version
+            ink-node --version
+            cargo contract --version
+            git --version
+            echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml
 
       - name: Check Spelling
-        uses: docker://evilrobot/useink:pr-4
+        uses: ./.github/run-container-command
         with:
-          entrypoint: /bin/bash
-          args: >
-            -c
-            "pwd;
-            ls *;
-            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .;
-            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*;"
+          command: |
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
+            cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./integration-tests/*
 
   fmt:
     runs-on: ubuntu-latest
@@ -135,18 +124,8 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
       - name: Initialize
         uses: ./.github/init
         with:
@@ -154,13 +133,15 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Run Clippy
-        run: |
-          ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
-          for crate in ${ALL_CRATES}; do
-            echo $crate;
-            cargo +nightly clippy --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml \
-              -- -D warnings -A ${CLIPPY_ALLOWED};
-          done
+        uses: ./.github/run-container-command
+        with:
+          command: |
+            ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
+             for crate in ${ALL_CRATES}; do
+               echo $crate;
+               cargo +nightly clippy --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml \
+                 -- -D warnings -A ${CLIPPY_ALLOWED};
+             done
 
   clippy-riscv:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           maximize-space: 'false'
@@ -112,7 +112,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
 
       - name: Check Formatting
@@ -138,7 +138,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -169,7 +169,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -202,7 +202,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -239,7 +239,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -278,7 +278,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -311,7 +311,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -345,7 +345,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -374,7 +374,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -412,7 +412,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -453,7 +453,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -495,7 +495,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -528,7 +528,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -571,7 +571,7 @@ jobs:
 #        with:
 #          fetch-depth: 0
 #
-#      - name: Initialize
+#      - name: Initialize runner
 #        uses: ./.github/init
 #        with:
 #          cache: true
@@ -610,7 +610,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -646,7 +646,7 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Initialize
+          - name: Initialize runner
             uses: ./.github/init
             with:
               cache: true
@@ -676,7 +676,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -734,7 +734,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -807,7 +807,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true
@@ -851,7 +851,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Initialize
+      - name: Initialize runner
         uses: ./.github/init
         with:
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,43 +389,43 @@ jobs:
             cargo +nightly nextest run --all-features --no-fail-fast --workspace --locked
 
   test-docs:
-      runs-on: ubuntu-latest
-      needs: [set-image, check]
-      strategy:
-          fail-fast: false
-          matrix:
-              workspace: [ink, linting]
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
+    runs-on: ubuntu-latest
+    needs: [set-image, check]
+    strategy:
+        fail-fast: false
+        matrix:
+            workspace: [ink, linting]
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 1
 
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
+        - name: Initialize runner
+          uses: ./.github/init
+          with:
+            cache: true
+            cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
-          - name: Test
-            uses: ./.github/run-container-command
-            #  todo check if this workspace condition is still necessary
-            if: ${{ matrix.workspace == 'ink' }}
-            env:
-                # Setting incremental = 0 to reduce compilation artifact size.
-                # The CI otherwise fails with "no disk space"
-                # todo Remove again at one point. This is a speed trade-off.
-                CARGO_INCREMENTAL: 0
-                # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
-                RUSTFLAGS: -Clink-dead-code -Clink-arg=-z -Clink-arg=nostart-stop-gc
-                # Since we run the tests with `--all-features` this implies the feature
-                # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
-                # There's no way to disable a single feature while enabling all features
-                # at the same time, hence we use this workaround.
-                QUICKCHECK_TESTS:            0
-            with:
-              command: |
-                  cargo +nightly test --all-features --no-fail-fast --workspace --doc --locked
+        - name: Test
+          uses: ./.github/run-container-command
+          #  todo check if this workspace condition is still necessary
+          if: ${{ matrix.workspace == 'ink' }}
+          env:
+              # Setting incremental = 0 to reduce compilation artifact size.
+              # The CI otherwise fails with "no disk space"
+              # todo Remove again at one point. This is a speed trade-off.
+              CARGO_INCREMENTAL: 0
+              # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
+              RUSTFLAGS: -Clink-dead-code -Clink-arg=-z -Clink-arg=nostart-stop-gc
+              # Since we run the tests with `--all-features` this implies the feature
+              # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
+              # There's no way to disable a single feature while enabling all features
+              # at the same time, hence we use this workaround.
+              QUICKCHECK_TESTS:            0
+          with:
+            command: |
+                cargo +nightly test --all-features --no-fail-fast --workspace --doc --locked
 
   test-linting:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,11 +347,11 @@ jobs:
           command: |
             for crate in ${ALSO_RISCV_CRATES}; do
               echo ${crate};
-              RUSTFLAGS="--cfg substrate_runtime" cargo +nightly build \
+              RUSTFLAGS=\"--cfg substrate_runtime\" cargo +nightly build \
                 --no-default-features --release \
-                --target $CLIPPY_TARGET \
+                --target ${CLIPPY_TARGET} \
                 --manifest-path ./crates/${crate}/Cargo.toml \
-                -Zbuild-std="core,alloc";
+                -Zbuild-std=\"core,alloc\";
             done
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,7 +878,6 @@ jobs:
               GITHUB_PR_WORKFLOW_ID:   ${{ github.event.workflow_run.id }}
               PR_NUMBER:               ${{ github.event.number }}
           run: |
-              CARGO_CONTRACT_VERSION=$(cargo +nightly contract --version)
               PR_COMMENTS_URL="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
               WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_PR_WORKFLOW_ID}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,11 +724,6 @@ jobs:
   examples-docs:
     runs-on: ubuntu-latest
     needs: [set-image, build]
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -742,15 +737,17 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Create Examples Docs
+        uses: ./.github/run-container-command
         env:
           RUSTDOCFLAGS:                  -Dwarnings
-        run: |
-          # `--document-private-items` needs to be in here because currently our contract macro
-          # puts the contract functions in a private module.
-          # Once https://github.com/use-ink/ink/issues/336 has been implemented we can get rid
-          # of this flag.
-          scripts/for_all_contracts_exec.sh --path integration-tests -- cargo doc --manifest-path {} \
-            --document-private-items --no-deps
+        with:
+          command: |
+            # `--document-private-items` needs to be in here because currently our contract macro
+            # puts the contract functions in a private module.
+            # Once https://github.com/use-ink/ink/issues/336 has been implemented we can get rid
+            # of this flag.
+            scripts/for_all_contracts_exec.sh --path integration-tests -- cargo doc --manifest-path {} \
+              --document-private-items --no-deps
 
 # measurements
 #  todo delete this stage and associated files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,7 @@ jobs:
 
       - name: Combine contract sizes from individual examples
         run: |
-            cat downloaded_artifacts/${{github.run_id}}_artifact | \
+            cat downloaded_artifacts/${{github.run_id}}_artifact/* | \
             sed -e 's/^integration-tests\/\(public\/\|internal\/\)\?//' | \
             sort | uniq > measurements-${{ steps.extract_branch.outputs.branch }}
             cat measurements-${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,20 +64,6 @@ jobs:
         with:
           maximize-space: 'false'
 
-      - name: Rust Info
-        uses: ./.github/run-container-command
-        with:
-          command: |
-            rustup show
-            cargo --version
-            rustup +nightly show
-            cargo +nightly --version
-            bash --version
-            ink-node --version
-            cargo contract --version
-            git --version
-            echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml
-
       - name: Check Spelling
         uses: ./.github/run-container-command
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ on:
       - 'FILE_HEADER'
 
 env:
-  # Image can be edited at https://github.com/use-ink/docker-images
-  IMAGE:                           evilrobot/useink:pr-4
   CARGO_TARGET_DIR:                /ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
   PURELY_STD_CRATES:               ink/codegen metadata engine e2e e2e/macro ink/ir
   ALSO_RISCV_CRATES:               env storage storage/traits allocator prelude primitives ink ink/macro
@@ -53,19 +51,8 @@ concurrency:
 ### lint
 
 jobs:
-  set-image:
-    # GitHub Actions does not allow using 'env' in a container context.
-    # This workaround sets the container image for each job using the 'set-image' job output.
-    runs-on: ubuntu-latest
-    outputs:
-      IMAGE: ${{ steps.set_image.outputs.IMAGE }}
-    steps:
-      - id: set_image
-        run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
-
   spellcheck:
     runs-on: ubuntu-latest
-    needs: [set-image]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,7 +87,6 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
-    needs: [set-image]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -130,7 +116,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    needs: [set-image]
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +159,6 @@ jobs:
 
   clippy-examples:
     runs-on: ubuntu-latest
-    needs: [set-image]
     strategy:
       fail-fast: false
       matrix:
@@ -210,7 +194,6 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    needs: [set-image]
     strategy:
       fail-fast: false
       matrix:
@@ -253,7 +236,6 @@ jobs:
 
   dylint-checks:
     runs-on: ubuntu-latest
-    needs: [set-image]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -283,7 +265,6 @@ jobs:
 
   dylint-testing:
     runs-on: ubuntu-latest
-    needs: [set-image]
     steps:
         - name: Checkout
           uses: actions/checkout@v4
@@ -312,7 +293,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [set-image, check]
+    needs: [check]
     strategy:
       fail-fast: false
       matrix:
@@ -356,7 +337,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [set-image, check]
+    needs: [check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -390,7 +371,7 @@ jobs:
 
   test-docs:
     runs-on: ubuntu-latest
-    needs: [set-image, check]
+    needs: [check]
     strategy:
         fail-fast: false
         matrix:
@@ -429,7 +410,7 @@ jobs:
 
   test-linting:
     runs-on: ubuntu-latest
-    needs: [set-image, check]
+    needs: [check]
     strategy:
         fail-fast: false
         matrix:
@@ -463,7 +444,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [set-image, check, fmt, clippy, clippy-examples, dylint-checks, dylint-testing, spellcheck]
+    needs: [check, fmt, clippy, clippy-examples, dylint-checks, dylint-testing, spellcheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -574,7 +555,6 @@ jobs:
 
   examples-test-mapping:
     runs-on: ubuntu-latest
-    needs: [set-image]
     steps:
         - name: Checkout
           uses: actions/checkout@v4
@@ -601,7 +581,7 @@ jobs:
 
   examples-custom-test:
     runs-on: ubuntu-latest
-    needs: [set-image, clippy, clippy-examples]
+    needs: [clippy, clippy-examples]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -653,7 +633,7 @@ jobs:
 
   examples-contract-build-riscv:
     runs-on: ubuntu-latest
-    needs: [set-image, build]
+    needs: [build]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -723,7 +703,7 @@ jobs:
 
   examples-docs:
     runs-on: ubuntu-latest
-    needs: [set-image, build]
+    needs: [build]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -759,7 +739,7 @@ jobs:
 # fuzz
   fuzz:
     runs-on: ubuntu-latest
-    needs: [set-image, examples-docs, examples-contract-build-riscv, examples-test, examples-custom-test]
+    needs: [examples-docs, examples-contract-build-riscv, examples-test, examples-custom-test]
     if: >
       github.event_name == 'push' &&
         github.ref == 'refs/heads/master'
@@ -842,7 +822,7 @@ jobs:
 
   submit-contract-sizes:
     runs-on: ubuntu-latest
-    needs: [set-image, process-contract-sizes]
+    needs: [process-contract-sizes]
     permissions:
         pull-requests: write
     if: github.ref != 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-key: ${{ matrix.type }}
 
       - name: Run Clippy for all crates
         uses: ./.github/run-container-command
@@ -160,6 +161,7 @@ jobs:
         with:
           cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-key: ${{ matrix.type }}
 
       - name: Run Clippy for Examples
         uses: ./.github/run-container-command
@@ -195,6 +197,7 @@ jobs:
         with:
           cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-key: ${{ matrix.type }}
 
       - name: Check
         uses: ./.github/run-container-command
@@ -286,6 +289,7 @@ jobs:
         with:
           cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-key: ${{ matrix.type }}
 
       - name: Build for STD
         uses: ./.github/run-container-command
@@ -360,6 +364,7 @@ jobs:
           with:
             cache: true
             cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-key: ${{ matrix.type }}
 
         - name: Test
           uses: ./.github/run-container-command
@@ -395,6 +400,7 @@ jobs:
           with:
             cache: true
             cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-key: ${{ matrix.type }}
 
         - name: Test Linting
           uses: ./.github/run-container-command
@@ -627,7 +633,7 @@ jobs:
         with:
           command: |
             mkdir -p measurements-${{ steps.extract_branch.outputs.branch }}/
-            scripts/for_all_contracts_exec2.sh --path integration-tests --partition ${{ matrix.partition }}/30 -- \
+            scripts/for_all_contracts_exec2.sh --path integration-tests -- \
               scripts/build_and_determine_contract_size.sh {}
   
               #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
@@ -636,7 +642,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
             path: ./measurements-${{ steps.extract_branch.outputs.branch }}/*
-            name: ${{ github.run_id }}_artifact_${{ matrix.partition }}
+            name: ${{ github.run_id }}_artifact
             retention-days: 1
 
   process-contract-sizes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,6 @@ jobs:
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v5
-        with:
-          remove-android: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-          remove-dotnet: 'true'
-          remove-haskell: 'true'
-
       - id: set_image
         run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
 
@@ -86,8 +77,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Rust Info
-        uses: ./.github/rust-info
+      - name: Initialize
+        uses: ./.github/init
 
       - name: Check Spelling
         run: |
@@ -108,8 +99,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Rust Info
-        uses: ./.github/rust-info
+      - name: Initialize
+        uses: ./.github/init
 
       - name: Check Formatting
         run: |
@@ -139,14 +130,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Run Clippy
         run: |
@@ -171,14 +159,11 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Run Clippy for RISC-V Crates
             run: |
@@ -207,14 +192,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Run Clippy for Examples
         if: ${{ matrix.type == 'STD' }}
@@ -247,14 +229,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Check
         if: ${{ matrix.type == 'STD' }}
@@ -289,14 +268,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Dylint
         env:
@@ -325,14 +301,11 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Dylint
             env:
@@ -362,14 +335,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Build for STD
         run: |
@@ -394,14 +364,11 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Build for RISC-V
             run: |
@@ -435,11 +402,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
           cache-on-failure: true
 
       - name: Test
@@ -476,14 +443,11 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Test
             #  todo check if this workspace condition is still necessary
@@ -521,14 +485,11 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
           - name: Test Linting
             if: ${{ matrix.workspace == 'linting' }}
@@ -557,14 +518,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Create docs
         env:
@@ -603,15 +561,12 @@ jobs:
 #        with:
 #          fetch-depth: 0
 #
-#      - name: Rust Info
-#        uses: ./.github/rust-info
-#
-#      - name: Cache
-#        uses: Swatinem/rust-cache@v2
+#      - name: Initialize
+#        uses: ./.github/init
 #        with:
-#            cache-on-failure: true
-#            cache-directories: ${{ env.CARGO_TARGET_DIR }}
-#            cache-all-crates: true
+#          cache: true
+#          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+#          cache-on-failure: 'true'
 #
 #      - name: Generate code coverage
 #        env:
@@ -645,11 +600,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
           cache-on-failure: true
 
       - name: Test Examples
@@ -681,15 +636,12 @@ jobs:
             with:
                 fetch-depth: 1
 
-          - name: Cache
-            uses: Swatinem/rust-cache@v2
+          - name: Initialize
+            uses: ./.github/init
             with:
-                cache-directories: ${{ env.CARGO_TARGET_DIR }}
-                cache-all-crates: true
-                cache-on-failure: true
-
-          - name: Rust Info
-            uses: ./.github/rust-info
+              cache: true
+              cache-directories: ${{ env.CARGO_TARGET_DIR }}
+              cache-on-failure: true
 
           - name: Test Mapping Example
             env:
@@ -714,15 +666,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
           cache-on-failure: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Run E2E test with on-chain contract
         # todo disabled until `cargo-contract` supports mapping the account
@@ -775,15 +724,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
           cache-on-failure: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Extract branch name
         shell: bash
@@ -851,14 +797,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Create Examples Docs
         env:
@@ -898,14 +841,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Initialize
+        uses: ./.github/init
         with:
+          cache: true
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
-          cache-all-crates: true
-
-      - name: Rust Info
-        uses: ./.github/rust-info
 
       - name: Fuzz
         id: fuzz_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
 
   spellcheck:
     runs-on: ubuntu-latest
+    needs: [set-image]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,10 +75,25 @@ jobs:
       - name: Initialize
         uses: ./.github/init
 
+      - name: Rust Info
+        uses: docker://${{ env.IMAGE }}
+        with:
+          entrypoint: bash
+          args:
+            "rustup show
+             cargo --version
+             rustup +nightly show
+             cargo +nightly --version
+             bash --version
+             ink-node --version
+             cargo contract --version
+             git --version
+             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml"
+
       - name: Check Spelling
         uses: docker://${{ env.IMAGE }}
         with:
-          entrypoint: "bash"
+          entrypoint: bash
           args:
             "pwd
             ls *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,19 +356,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # todo bring back more needs, so that we only run this `tests` stage
-    # if pre-conditions are filled.
-    # needs: [set-image, check]
-    needs: [set-image]
-    defaults:
-      run:
-        shell: bash
-    container:
-        image: ${{ needs.set-image.outputs.IMAGE }}
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35]
+    needs: [set-image, check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -383,6 +371,7 @@ jobs:
           cache-on-failure: true
 
       - name: Test
+        uses: ./.github/run-container-command
         env:
           # Setting incremental = 0 to reduce compilation artifact size.
           # The CI otherwise fails with "no disk space"
@@ -395,8 +384,9 @@ jobs:
           # There's no way to disable a single feature while enabling all features
           # at the same time, hence we use this workaround.
           QUICKCHECK_TESTS: 0
-        run: |
-            cargo +nightly nextest run --all-features --no-fail-fast --workspace --locked --jobs 1 --partition count:${{ matrix.partition }}/35
+        with:
+          command: |
+            cargo +nightly nextest run --all-features --no-fail-fast --workspace --locked
 
   test-docs:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,40 +428,37 @@ jobs:
                 cargo +nightly test --all-features --no-fail-fast --workspace --doc --locked
 
   test-linting:
-      runs-on: ubuntu-latest
-      needs: [set-image, check]
-      defaults:
-          run:
-              shell: bash
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
-      strategy:
-          fail-fast: false
-          matrix:
-              workspace: [ink, linting]
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
+    runs-on: ubuntu-latest
+    needs: [set-image, check]
+    strategy:
+        fail-fast: false
+        matrix:
+            workspace: [ink, linting]
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 1
 
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
+        - name: Initialize runner
+          uses: ./.github/init
+          with:
+            cache: true
+            cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
-          - name: Test Linting
-            if: ${{ matrix.workspace == 'linting' }}
-            env:
-              # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
-              RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
-              # Since we run the tests with `--all-features` this implies the feature
-              # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
-              # There's no way to disable a single feature while enabling all features
-              # at the same time, hence we use this workaround.
-              QUICKCHECK_TESTS:            0
-            run: |
+        - name: Test Linting
+          uses: ./.github/run-container-command
+          if: ${{ matrix.workspace == 'linting' }}
+          env:
+            # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
+            RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
+            # Since we run the tests with `--all-features` this implies the feature
+            # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
+            # There's no way to disable a single feature while enabling all features
+            # at the same time, hence we use this workaround.
+            QUICKCHECK_TESTS:            0
+          with:
+            command: |
               pushd linting && cargo nextest run --all-features --no-fail-fast --workspace && popd
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,7 @@ jobs:
         with:
           # Run all tests with --all-features, which will run the `e2e-tests` feature if present.
           command: |
-            scripts/for_all_contracts_exec.sh --path integration-tests --ignore internal/static-buffer --ignore internal/mapping --partition ${{ matrix.partition }}/30 -- \
+            scripts/for_all_contracts_exec.sh --path integration-tests --ignore internal/static-buffer --ignore internal/mapping -- \
             cargo +nightly test --all-features --all --manifest-path {}
 
   examples-test-mapping:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
       - 'FILE_HEADER'
 
 env:
-  CARGO_TARGET_DIR:                ./ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
+  CARGO_TARGET_DIR:                /ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
   PURELY_STD_CRATES:               ink/codegen metadata engine e2e e2e/macro ink/ir
   ALSO_RISCV_CRATES:               env storage storage/traits allocator prelude primitives ink ink/macro
   # TODO `cargo clippy --all-targets --all-features` for this crate
@@ -131,7 +131,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-key: ${{ matrix.type }}
 
       - name: Run Clippy for all crates
@@ -176,7 +176,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-key: ${{ matrix.type }}
 
       - name: Run Clippy for Examples
@@ -213,7 +213,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-key: ${{ matrix.type }}
 
       - name: Check
@@ -253,7 +253,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
 
       - name: Dylint
         uses: ./.github/run-container-command
@@ -279,7 +279,7 @@ jobs:
           uses: ./.github/init
           with:
             cache: true
-            cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
 
         - name: Dylint
           uses: ./.github/run-container-command
@@ -307,7 +307,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-key: ${{ matrix.type }}
 
       - name: Build for STD
@@ -348,7 +348,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-on-failure: true
 
       - name: Test
@@ -382,7 +382,7 @@ jobs:
           uses: ./.github/init
           with:
             cache: true
-            cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
             cache-key: ${{ matrix.type }}
 
         - name: Test
@@ -418,7 +418,7 @@ jobs:
           uses: ./.github/init
           with:
             cache: true
-            cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
             cache-key: ${{ matrix.type }}
 
         - name: Test Linting
@@ -449,7 +449,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
 
       - name: Create docs
         uses: ./.github/run-container-command
@@ -529,7 +529,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-on-failure: true
 
       - name: Test Examples
@@ -556,7 +556,7 @@ jobs:
           uses: ./.github/init
           with:
             cache: true
-            cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
             cache-on-failure: true
 
         - name: Test Mapping Example
@@ -583,7 +583,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-on-failure: true
 
       - name: Run E2E test with on-chain contract
@@ -635,7 +635,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
           cache-on-failure: true
 
       - name: Extract branch name
@@ -705,7 +705,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
 
       - name: Create Examples Docs
         uses: ./.github/run-container-command
@@ -746,7 +746,7 @@ jobs:
         uses: ./.github/init
         with:
           cache: true
-          cache-directories: ${{ env.CARGO_TARGET_DIR }}
+          cache-directories: ${{ github.workspace}}/${{ env.CARGO_TARGET_DIR }}
 
       - name: Fuzz
         uses: ./.github/run-container-command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,7 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     strategy:
       fail-fast: false
       matrix:
@@ -234,23 +229,27 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Check
+        uses: ./.github/run-container-command
         if: ${{ matrix.type == 'STD' }}
-        run: |
-          ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
-          for crate in ${ALL_CRATES}; do
-            cargo check --all-features --manifest-path ./crates/${crate}/Cargo.toml;
-          done
+        with:
+          command: |
+            ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
+            for crate in ${ALL_CRATES}; do
+              cargo check --all-features --manifest-path ./crates/${crate}/Cargo.toml;
+            done
 
       - name: Check RISCV
+        uses: ./.github/run-container-command
         if: ${{ matrix.type == 'RISCV' }}
         env:
           RUSTC_BOOTSTRAP: 1
-        run: |
-          for crate in ${ALSO_RISCV_CRATES}; do
-            # remove `nightly` once new stable is released, currently there is an ICE in stable
-            cargo +nightly check --no-default-features --target $RISCV_TARGET -Zbuild-std="core,alloc" \
-              --manifest-path ./crates/${crate}/Cargo.toml;
-          done
+        with:
+          command: |
+            for crate in ${ALSO_RISCV_CRATES}; do
+              # remove `nightly` once new stable is released, currently there is an ICE in stable
+              cargo +nightly check --no-default-features --target $RISCV_TARGET -Zbuild-std="core,alloc" \
+                --manifest-path ./crates/${crate}/Cargo.toml;
+            done
 
   dylint-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,10 +544,6 @@ jobs:
   examples-test:
     runs-on: ubuntu-latest
     needs: [fmt]
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -562,7 +558,7 @@ jobs:
           cache-on-failure: true
 
       - name: Test Examples
-        uses: docker://useink/ci
+        uses: ./.github/run-container-command
         env:
             # Setting incremental = 0 to reduce compilation artifact size.
             # The CI otherwise fails with "no disk space"
@@ -572,9 +568,9 @@ jobs:
             RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
         with:
           # Run all tests with --all-features, which will run the `e2e-tests` feature if present.
-          args:
-            /bin/bash -c "scripts/for_all_contracts_exec.sh --path integration-tests --ignore internal/static-buffer --ignore internal/mapping --partition ${{ matrix.partition }}/30 -- \
-                cargo +nightly test --all-features --all --manifest-path {}"
+          command: |
+            scripts/for_all_contracts_exec.sh --path integration-tests --ignore internal/static-buffer --ignore internal/mapping --partition ${{ matrix.partition }}/30 -- \
+            cargo +nightly test --all-features --all --manifest-path {}
 
   examples-test-mapping:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,29 @@ concurrency:
 ### lint
 
 jobs:
+  ci-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Output environment information
+        uses: ./.github/run-container-command
+        with:
+          command: |
+            rustup show
+            cargo --version
+            rustup +nightly show
+            cargo +nightly --version
+            bash --version
+            ink-node --version; cargo contract --version; git --version
+            echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml
+
   spellcheck:
     runs-on: ubuntu-latest
+    needs: ci-image
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +94,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
+    needs: ci-image
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,6 +124,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    needs: ci-image
     strategy:
       fail-fast: false
       matrix:
@@ -146,6 +169,7 @@ jobs:
 
   clippy-examples:
     runs-on: ubuntu-latest
+    needs: ci-image
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +206,7 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    needs: ci-image
     strategy:
       fail-fast: false
       matrix:
@@ -225,6 +250,7 @@ jobs:
 
   dylint-checks:
     runs-on: ubuntu-latest
+    needs: ci-image
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -250,6 +276,7 @@ jobs:
 
   dylint-testing:
     runs-on: ubuntu-latest
+    needs: ci-image
     steps:
         - name: Checkout
           uses: actions/checkout@v4
@@ -526,6 +553,7 @@ jobs:
 
   examples-test-mapping:
     runs-on: ubuntu-latest
+    needs: ci-image
     steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,7 +758,7 @@ jobs:
 
   examples-docs:
     runs-on: ubuntu-latest
-    needs: [set-image, build-std, build-riscv]
+    needs: [set-image, build]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,72 +841,70 @@ jobs:
             console.log(`Issue created: ${issue.data.html_url}`);
 
   submit-contract-sizes:
-      runs-on: ubuntu-latest
-      needs: [set-image, process-contract-sizes]
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
-      permissions:
-          pull-requests: write
-      if: github.ref != 'refs/heads/master'
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
+    runs-on: ubuntu-latest
+    needs: [set-image, process-contract-sizes]
+    permissions:
+        pull-requests: write
+    if: github.ref != 'refs/heads/master'
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 1
 
-          - name: Extract GitHub
-            shell: bash
-            run: |
-                git config --global --add safe.directory /__w/ink/ink
-                ink_master_head=$(curl -s "https://api.github.com/repos/use-ink/ink/commits/master" | jq -r .sha)
-                head_in_branch=$(git log | grep -q $ink_master_head; echo $?)
-                echo "head_in_branch=$head_in_branch" >> $GITHUB_OUTPUT
-            id: extract_github
+        - name: Extract GitHub
+          shell: bash
+          run: |
+              git config --global --add safe.directory /__w/ink/ink
+              ink_master_head=$(curl -s "https://api.github.com/repos/use-ink/ink/commits/master" | jq -r .sha)
+              head_in_branch=$(git log | grep -q $ink_master_head; echo $?)
+              echo "head_in_branch=$head_in_branch" >> $GITHUB_OUTPUT
+          id: extract_github
 
-          - name: Extract branch name
-            shell: bash
-            run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-            id: extract_branch
+        - name: Extract branch name
+          shell: bash
+          run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+          id: extract_branch
 
-          - name: Output branch name
-            run: |
-                echo "${{ steps.extract_branch.outputs.branch }}"
-                echo "${{ steps.extract_github.outputs.head_in_branch }}"
+        - name: Output branch name
+          run: |
+              echo "${{ steps.extract_branch.outputs.branch }}"
+              echo "${{ steps.extract_github.outputs.head_in_branch }}"
 
-          - name: Download artifact from this branch
-            uses: dawidd6/action-download-artifact@v9
-            with:
-                name: measurements-${{ steps.extract_branch.outputs.branch }}
-                run_id: ${{ github.run_id }}
+        - name: Download artifact from this branch
+          uses: dawidd6/action-download-artifact@v9
+          with:
+              name: measurements-${{ steps.extract_branch.outputs.branch }}
+              run_id: ${{ github.run_id }}
 
-          - name: Download master artifact
-            uses: dawidd6/action-download-artifact@v9
-            with:
-                workflow: ci.yml
-                branch: master
-                name: measurements-master
+        - name: Download master artifact
+          uses: dawidd6/action-download-artifact@v9
+          with:
+              workflow: ci.yml
+              branch: master
+              name: measurements-master
 
-          - name: Collect Contract Sizes
-            run: |
-                # Build the comparison table
-                echo "master:"
-                cat measurements-master
-                echo "branch:"
-                cat measurements-${{ steps.extract_branch.outputs.branch }}
-                echo "---"
-                ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ steps.extract_branch.outputs.branch }} > contract_sizes_diff.md
-                cat contract_sizes_diff.md
+        - name: Collect Contract Sizes
+          run: |
+              # Build the comparison table
+              echo "master:"
+              cat measurements-master
+              echo "branch:"
+              cat measurements-${{ steps.extract_branch.outputs.branch }}
+              echo "---"
+              ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ steps.extract_branch.outputs.branch }} > contract_sizes_diff.md
+              cat contract_sizes_diff.md
 
-          - name: Submit Comment
-            env:
-                GITHUB_PR_TOKEN:         ${{ secrets.github_token }}
-                GITHUB_PR_WORKFLOW_ID:   ${{ github.event.workflow_run.id }}
-                PR_NUMBER:               ${{ github.event.number }}
-            run: |
-                CARGO_CONTRACT_VERSION=$(cargo +nightly contract --version)
-                PR_COMMENTS_URL="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
-                WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_PR_WORKFLOW_ID}"
+        - name: Submit Comment
+          env:
+              GITHUB_PR_TOKEN:         ${{ secrets.github_token }}
+              GITHUB_PR_WORKFLOW_ID:   ${{ github.event.workflow_run.id }}
+              PR_NUMBER:               ${{ github.event.number }}
+          run: |
+              CARGO_CONTRACT_VERSION=$(cargo +nightly contract --version)
+              PR_COMMENTS_URL="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
+              WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_PR_WORKFLOW_ID}"
 
-                # Submit the comparison table as a comment to the PR
-                echo "Submitting contract sizes diff to ${PR_COMMENTS_URL}"
-                GITHUB_PR_TOKEN=${GITHUB_PR_TOKEN} .github/scripts/contract_sizes_submit.sh ${PR_COMMENTS_URL} ${WORKFLOW_URL} ${CARGO_CONTRACT_VERSION} ${{ steps.extract_github.outputs.head_in_branch }}${head_in_branch} < ./contract_sizes_diff.md
+              # Submit the comparison table as a comment to the PR
+              echo "Submitting contract sizes diff to ${PR_COMMENTS_URL}"
+              GITHUB_PR_TOKEN=${GITHUB_PR_TOKEN} .github/scripts/contract_sizes_submit.sh ${PR_COMMENTS_URL} ${WORKFLOW_URL} ${CARGO_CONTRACT_VERSION} ${{ steps.extract_github.outputs.head_in_branch }}${head_in_branch} < ./contract_sizes_diff.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Rust Info
         uses: docker://evilrobot/useink:pr-4
         with:
-          entrypoint: bash
+          entrypoint: /bin/bash
           args:
             "rustup show
              cargo --version
@@ -93,7 +93,7 @@ jobs:
       - name: Check Spelling
         uses: docker://evilrobot/useink:pr-4
         with:
-          entrypoint: bash
+          entrypoint: /bin/bash
           args:
             "pwd
             ls *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,11 +464,6 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     needs: [set-image, check, fmt, clippy, clippy-examples, dylint-checks, dylint-testing, spellcheck]
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -482,16 +477,18 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Create docs
+        uses: ./.github/run-container-command
         env:
           RUSTDOCFLAGS:                  -Dwarnings
-        run: |
-          for package in $(cargo metadata --format-version 1 | jq -r '.workspace_members[]' | awk '{print $1}'); do
-            # Run cargo doc for each workspace member
-            cargo +nightly doc --no-deps --all-features -p ${package}
-          done
-          mv ${CARGO_TARGET_DIR}/doc ./crate-docs
-          # FIXME: remove me after CI image gets nonroot
-          chown -R nonroot:nonroot ./crate-docs
+        with:
+          command: |
+            for package in $(cargo metadata --format-version 1 | jq -r '.workspace_members[]' | awk '{print $1}'); do
+              # Run cargo doc for each workspace member
+              cargo +nightly doc --no-deps --all-features -p ${package}
+            done
+            mv ${CARGO_TARGET_DIR}/doc ./crate-docs
+            # FIXME: remove me after CI image gets nonroot
+            chown -R nonroot:nonroot ./crate-docs
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   # Image can be edited at https://github.com/use-ink/docker-images
-  IMAGE:                           useink/ci
+  IMAGE:                           evilrobot/useink:pr-4
   CARGO_TARGET_DIR:                /ci-cache/${{ github.repository }}/targets/${{ github.ref_name }}/${{ github.job }}
   PURELY_STD_CRATES:               ink/codegen metadata engine e2e e2e/macro ink/ir
   ALSO_RISCV_CRATES:               env storage storage/traits allocator prelude primitives ink ink/macro
@@ -64,8 +64,9 @@ jobs:
         uses: AdityaGarg8/remove-unwanted-software@v5
         with:
           remove-android: 'true'
-          remove-dotnet: 'true'
           remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-dotnet: 'true'
           remove-haskell: 'true'
 
       - id: set_image
@@ -149,9 +150,6 @@ jobs:
 
       - name: Run Clippy
         run: |
-          df -h ;
-          rustup toolchain remove nightly-2025-02-20 && rustup toolchain remove stable && rustup toolchain remove 1.85.0;
-          df -h ;
           ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"
           for crate in ${ALL_CRATES}; do
             echo $crate;
@@ -184,9 +182,6 @@ jobs:
 
           - name: Run Clippy for RISC-V Crates
             run: |
-                df -h ;
-                rustup toolchain remove nightly-2025-02-20 && rustup toolchain remove stable && rustup toolchain remove 1.85.0;
-                df -h ;
                 for crate in ${ALSO_RISCV_CRATES}; do
                   echo $crate;
                   cargo +nightly clippy --no-default-features --manifest-path ./crates/${crate}/Cargo.toml \
@@ -461,9 +456,6 @@ jobs:
           # at the same time, hence we use this workaround.
           QUICKCHECK_TESTS: 0
         run: |
-            rustup toolchain remove nightly-2025-02-20
-            rustup toolchain remove 1.85.0
-            rustup toolchain remove stable
             cargo +nightly nextest run --all-features --no-fail-fast --workspace --locked --jobs 1 --partition count:${{ matrix.partition }}/35
 
   test-docs:
@@ -628,9 +620,6 @@ jobs:
 #          INK_COVERAGE_REPORTING:        true
 #          #CARGO_INCREMENTAL:             0
 #        run: |
-#          #rustup toolchain remove nightly-2025-02-20;
-#          #rustup toolchain remove stable;
-#          #rustup toolchain remove 1.85.0;
 #          #cargo +nightly install cargo-tarpaulin
 #          curl
 #          cargo +nightly tarpaulin --verbose --tests --all-features --all-targets --workspace --locked --out xml
@@ -709,9 +698,6 @@ jobs:
                 # needed for `mapping::e2e_tests::fallible_storage_methods_work`
                 INK_STATIC_BUFFER_SIZE: 256
             run:
-                rustup toolchain remove nightly-2025-02-20;
-                rustup toolchain remove stable;
-                rustup toolchain remove 1.85.0;
                 cargo +nightly test --all --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml
 
   examples-custom-test:
@@ -926,9 +912,6 @@ jobs:
         env:
           QUICKCHECK_TESTS:              5000
         run: |
-          rustup toolchain remove nightly-2025-02-20;
-          rustup toolchain remove stable;
-          rustup toolchain remove 1.85.0;
           # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
           all_tests_passed=0
           ALL_CRATES="${PURELY_STD_CRATES} ${ALSO_RISCV_CRATES}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,7 @@ jobs:
 
   clippy-examples:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [set-image]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     strategy:
       fail-fast: false
       matrix:
@@ -198,17 +193,21 @@ jobs:
           cache-directories: ${{ env.CARGO_TARGET_DIR }}
 
       - name: Run Clippy for Examples
+        uses: ./.github/run-container-command
         if: ${{ matrix.type == 'STD' }}
-        run: |
-          scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --all-targets \
-            --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
+        with:
+          command: |
+            scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --all-targets \
+              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
 
       - name: Run Clippy for RISC-V Examples
+        uses: ./.github/run-container-command
         if: ${{ matrix.type == 'RISCV' }}
-        run: |
-          scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --no-default-features \
-            --target ${CLIPPY_TARGET} \
-            --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
+        with:
+          command: |
+            scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --no-default-features \
+              --target ${CLIPPY_TARGET} \
+              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,11 +602,6 @@ jobs:
   examples-custom-test:
     runs-on: ubuntu-latest
     needs: [set-image, clippy, clippy-examples]
-    defaults:
-      run:
-        shell: bash
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -621,31 +616,35 @@ jobs:
           cache-on-failure: true
 
       - name: Run E2E test with on-chain contract
+        uses: ./.github/run-container-command
         # todo disabled until `cargo-contract` supports mapping the account
         if: false
         env:
           # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
           RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
-        run: |
-          # run flipper E2E test with on-chain contract
-          ink-node -lruntime::revive=debug 2>&1 &
-          cargo +nightly contract build --release --manifest-path integration-tests/public/flipper/Cargo.toml
-          export CONTRACT_ADDR_HEX=$(cargo +nightly contract instantiate \
-            --manifest-path integration-tests/public/flipper/Cargo.toml \
-            --suri //Alice --args true -x -y --output-json | \
-            jq -r .contract | xargs subkey inspect | grep -o "0x.*" | head -n1)
-          CONTRACTS_NODE_URL=ws://127.0.0.1:9944 cargo +nightly test \
-            --features e2e-tests \
-            --manifest-path integration-tests/public/flipper/Cargo.toml \
-            e2e_test_deployed_contract \
-            -- --ignored --nocapture
+        with:
+          command: |
+            # run flipper E2E test with on-chain contract
+            ink-node -lruntime::revive=debug 2>&1 &
+            cargo +nightly contract build --release --manifest-path integration-tests/public/flipper/Cargo.toml
+            export CONTRACT_ADDR_HEX=$(cargo +nightly contract instantiate \
+              --manifest-path integration-tests/public/flipper/Cargo.toml \
+              --suri //Alice --args true -x -y --output-json | \
+              jq -r .contract | xargs subkey inspect | grep -o "0x.*" | head -n1)
+            CONTRACTS_NODE_URL=ws://127.0.0.1:9944 cargo +nightly test \
+              --features e2e-tests \
+              --manifest-path integration-tests/public/flipper/Cargo.toml \
+              e2e_test_deployed_contract \
+              -- --ignored --nocapture
 
       - name: Test static-buffer example
+        uses: ./.github/run-container-command
         env:
             # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
             RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
             RUST_LOG: trace
-        run: |
+        with:
+          command: |
             # run the static buffer test with a custom buffer size.
             # the readme + test comments explain why `32`, in short because the tests write
             # content into the buffer and want to provoke an exhaustion of the buffer.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,33 +573,30 @@ jobs:
             cargo +nightly test --all-features --all --manifest-path {}
 
   examples-test-mapping:
-      runs-on: ubuntu-latest
-      needs: [set-image]
-      defaults:
-          run:
-              shell: bash
-      container:
-          image: ${{ needs.set-image.outputs.IMAGE }}
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                fetch-depth: 1
+    runs-on: ubuntu-latest
+    needs: [set-image]
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 1
 
-          - name: Initialize runner
-            uses: ./.github/init
-            with:
-              cache: true
-              cache-directories: ${{ env.CARGO_TARGET_DIR }}
-              cache-on-failure: true
+        - name: Initialize runner
+          uses: ./.github/init
+          with:
+            cache: true
+            cache-directories: ${{ env.CARGO_TARGET_DIR }}
+            cache-on-failure: true
 
-          - name: Test Mapping Example
-            env:
-                # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
-                RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
-                # needed for `mapping::e2e_tests::fallible_storage_methods_work`
-                INK_STATIC_BUFFER_SIZE: 256
-            run:
+        - name: Test Mapping Example
+          uses: ./.github/run-container-command
+          env:
+              # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
+              RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
+              # needed for `mapping::e2e_tests::fallible_storage_methods_work`
+              INK_STATIC_BUFFER_SIZE: 256
+          with:
+            command: |
                 cargo +nightly test --all --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml
 
   examples-custom-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ concurrency:
 jobs:
   ci-image:
     runs-on: ubuntu-latest
+    outputs:
+      cargo-contract-version: ${{ steps.environment.outputs.cargo-contract-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,6 +62,7 @@ jobs:
           fetch-depth: 1
 
       - name: Output environment information
+        id: environment
         uses: ./.github/run-container-command
         with:
           command: |
@@ -70,6 +73,7 @@ jobs:
             bash --version
             ink-node --version; cargo contract --version; git --version
             echo -e '[registry]\nprotocol = \"sparse\"' > /usr/local/cargo/config.toml
+            echo "cargo-contract-version=$(cargo +nightly contract --version)" >> $GITHUB_OUTPUT
 
   spellcheck:
     runs-on: ubuntu-latest
@@ -814,7 +818,7 @@ jobs:
 
   submit-contract-sizes:
     runs-on: ubuntu-latest
-    needs: [process-contract-sizes]
+    needs: [ci-image, process-contract-sizes]
     permissions:
         pull-requests: write
     if: github.ref != 'refs/heads/master'
@@ -869,6 +873,7 @@ jobs:
 
         - name: Submit Comment
           env:
+              CARGO_CONTRACT_VERSION:  ${{ needs.ci-image.outputs.cargo-contract-version }}
               GITHUB_PR_TOKEN:         ${{ secrets.github_token }}
               GITHUB_PR_WORKFLOW_ID:   ${{ github.event.workflow_run.id }}
               PR_NUMBER:               ${{ github.event.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ We did a detailed write-up of the background to this development and the reasoni
 to reflect the new setup.
 
 Compatibility of this release:
-* Rust >= 1.85
+* Rust >= 1.86
 * [`cargo-contract` `v6.0.0-alpha`](https://github.com/use-ink/cargo-contract/releases/tag/v6.0.0-alpha)
-* [`substrate-contracts-node/cd94b5f`](https://github.com/use-ink/substrate-contracts-node/commit/cd94b5fa23ee04f2d541decf1ace3b9904d61cb2)
-* [`polkadot-sdk/28a7ae71cc0eac747bf346804279217a68f700da`](https://github.com/paritytech/polkadot-sdk/commit/28a7ae71cc0eac747bf346804279217a68f700da)
+* [`ink-node/5f93093`](https://github.com/use-ink/ink-node/commit/5f93093dcffbbd2c2e44bfd2e457dc418c844623)
+* [`polkadot-sdk/stable2503`](https://github.com/paritytech/polkadot-sdk/tree/stable2503)
 
 In the following we'll describe some breaking changes on a high-level. The
 context to understand them is that the `pallet-revive` team has Ethereum/Solidity
@@ -226,6 +226,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 ## Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)
 - Always use ink! ABI/ SCALE codec for constructor and instantiation related builders and utilities - [#2474](https://github.com/use-ink/ink/pull/2474)
+- CI disk usage via standardised toolchains: `stable` 1.86, `nightly` 2025-02-20 - [#2484](https://github.com/use-ink/ink/pull/2484)
 
 ## Version 5.1.0
 

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -2,11 +2,6 @@
 
 set -eu
 
-# todo remove once we have enough space in the runners again
-rustup toolchain remove nightly-2025-02-20
-rustup toolchain remove stable
-rustup toolchain remove 1.85.0
-
 script_name="${BASH_SOURCE[0]}"
 scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
 

--- a/scripts/for_all_contracts_exec2.sh
+++ b/scripts/for_all_contracts_exec2.sh
@@ -2,11 +2,6 @@
 
 set -eu
 
-# todo remove once we have enough space in the runners again
-rustup toolchain remove nightly-2025-02-20
-#rustup toolchain remove stable
-#rustup toolchain remove 1.85.0
-
 script_name="${BASH_SOURCE[0]}"
 scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
 


### PR DESCRIPTION
## Summary
Closes #2458 
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?

Updates CI workflow to use a new Docker image (https://github.com/use-ink/docker-images/pull/4) with some image optimisations, along with updates to the scripts which were removing toolchains defined in the CI image to free up space.

Requires https://github.com/use-ink/docker-images/pull/4 to be merged and a new CI docker image to be built/published.


## Description
The PR introduces two new reusable actions: `.github/init` for intializing a runner in each job and `.github/run-container-command`) for executing a batch of commands within a container. 

Each job runs in its own runner instance and therefore needs to have space cleared and caching setup. The `init` action standardises this approach in a somewhat configurable/flexible way. About 45GB is available after using the `init` action. Removing data does take a little time, so it should therefore only be used on jobs which actually require the space. The improved `useink/ci` image is 1.32GB compressed/~4.3GB uncompressed, leaving ~40GB free for jobs.  All toolchain removals, CARGO_INCREMENTAL and partitioning has been removed as a result. The action also optionally sets up Rust caching, mostly so this is defined once and it is clear that it is per runner/job. Additional caching by matrix value is possible. 

The `run-container-command` action allows commands to be run within a container AFTER space has been cleared, which is important as the same runner disk is used for both the job, the pulled docker image and then the results of the job within the container. Using the `container` attribute sadly does not allow for space to be cleared prior to the container being launched, necessitating this action. The workspace on the host is mapped into a different path in the container, requiring a few adjustments to the directory paths for effective caching.

Notes:
- Each job using a container pulls the docker image which takes about 30 secs. Attempts at caching the docker images resulted in about the same amount of time but with added complexity and additional cache storage requirements. It therefore didnt seem worth pursuing at this time.
- There are some jobs which may benefit from better caching, but that is considered out of scope for this PR.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
