### PR TITLE
ci: fix contract size submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ env:
   RISCV_TARGET:                    .github/riscv64emac-unknown-none-polkavm.json
   # Clippy doesn't support JSON files for `--target`, hence we use another RISC-V target.
   CLIPPY_TARGET:                   riscv64imac-unknown-none-elf
+  # ID used for measurements: non-`master` branches may contain '/' which is problematic for file names
+  MEASUREMENTS_ID:                 ${{ github.ref == 'refs/heads/master' && 'master' || github.run_id }}
 
 concurrency:
   # Cancel in-progress jobs triggered only on pull_requests
@@ -710,12 +712,11 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
           MANIFEST_PATH: ""
-          # `github.run_id` used as the branch name may contain '/'
-          CONTRACT_SIZE_FILE: "measurements-${{ github.run_id }}/contract_size_"
+          CONTRACT_SIZE_FILE: "measurements-${{ env.MEASUREMENTS_ID }}/contract_size_"
           CARGO_INCREMENTAL: 0
         with:
           command: |
-            mkdir -p measurements-${{ github.run_id }}/
+            mkdir -p measurements-${{ env.MEASUREMENTS_ID }}/
             scripts/for_all_contracts_exec2.sh --path integration-tests -- \
               scripts/build_and_determine_contract_size.sh {}
   
@@ -724,7 +725,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-            path: ./measurements-${{ github.run_id }}/*
+            path: ./measurements-${{ env.MEASUREMENTS_ID }}/*
             name: ${{ github.run_id }}_artifact
             retention-days: 1
 
@@ -746,13 +747,13 @@ jobs:
         run: |
             cat downloaded_artifacts/${{github.run_id}}_artifact/* | \
             sed -e 's/^integration-tests\/\(public\/\|internal\/\)\?//' | \
-            sort | uniq > measurements-${{ github.run_id }}
-            cat measurements-${{ github.run_id }}
+            sort | uniq > measurements-${{ env.MEASUREMENTS_ID }}
+            cat measurements-${{ env.MEASUREMENTS_ID }}
 
       - uses: actions/upload-artifact@v4
         with:
-            name: measurements-${{ github.run_id }}
-            path: ./measurements-${{ github.run_id }}
+            name: measurements-${{ env.MEASUREMENTS_ID }}
+            path: ./measurements-${{ env.MEASUREMENTS_ID }}
             retention-days: 31
 
   examples-docs:
@@ -908,7 +909,7 @@ jobs:
         - name: Download artifact from this branch
           uses: dawidd6/action-download-artifact@v9
           with:
-              name: measurements-${{ github.run_id }}
+              name: measurements-${{ env.MEASUREMENTS_ID }}
               run_id: ${{ github.run_id }}
 
         - name: Download master artifact
@@ -924,9 +925,9 @@ jobs:
               echo "master:"
               cat measurements-master
               echo "branch:"
-              cat measurements-${{ github.run_id }}
+              cat measurements-${{ env.MEASUREMENTS_ID }}
               echo "---"
-              ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ github.run_id }} > contract_sizes_diff.md
+              ./scripts/contract_sizes_diff.sh measurements-master measurements-${{ env.MEASUREMENTS_ID }} > contract_sizes_diff.md
               cat contract_sizes_diff.md
 
         - name: Submit Comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 - Always use ink! ABI/ SCALE codec for constructor and instantiation related builders and utilities - [#2474](https://github.com/use-ink/ink/pull/2474)
 - Get rid of "extrinsic for call failed: Pallet error: Revive::AccountAlreadyMapped" - [2483](https://github.com/use-ink/ink/pull/2483)
 - CI disk usage via standardised toolchains: `stable` 1.86, `nightly` 2025-02-20 - [#2484](https://github.com/use-ink/ink/pull/2484)
+- CI contract size submission - [#2490](https://github.com/use-ink/ink/pull/2490)
 
 ## Version 5.1.0
 


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?

Updates CI workflow to use run identifier for measurements file name when not being run on the master branch, whilst preserving the branch name when run on master. This ensures that a later step can still download results from master branch runs for contract size comparison.

## Description
Added a global environment variable to the ci workflow which defines the identifier used for the `measurements-` file throughout the workflow, affixing either `master` when run on the `master` branch or `github.run_id` otherwise. The latter is preferred over using the branch name, as a branch name could contain characters which are problematic when used for file names.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
