### PR TITLE
ci: relax criteria for measurements-master artifact lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,6 +918,9 @@ jobs:
               workflow: ci.yml
               branch: master
               name: measurements-master
+              # Use any workflow that contains the artifact, regardless of the workflow conclusion
+              workflow_conclusion: ""
+              search_artifacts: true
 
         - name: Collect Contract Sizes
           run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 - Get rid of "extrinsic for call failed: Pallet error: Revive::AccountAlreadyMapped" - [2483](https://github.com/use-ink/ink/pull/2483)
 - CI disk usage via standardised toolchains: `stable` 1.86, `nightly` 2025-02-20 - [#2484](https://github.com/use-ink/ink/pull/2484)
 - CI contract size submission - [#2490](https://github.com/use-ink/ink/pull/2490)
+- CI relax criteria for `measurements-master` artifact lookup - [#2491](https://github.com/use-ink/ink/pull/2491)
 
 ## Version 5.1.0
 


### PR DESCRIPTION
## Summary

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?

Relaxes the criteria for searching for prior `measurements-master` artifact within the `submit-contract-sizes` job of the CI workflow. Artifact may still be available and valid in a failed workflow, which may have failed for some other reason completely.

## Description
Updates CI workflow to search for artifacts by name in prior runs on master, regardless of workflow conclusion. 

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
