### PR TITLE
Use marker trait for finding ink! storage struct during code analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Changed
+
+- Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)
+
 ## Version 6.0.0-alpha
 
 This is our first alpha release for ink! v6. We release it together

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,12 +214,12 @@ As before, it functions as a simple local development node.
 It contains `pallet-revive` in a default configuration.
 You can find binary releases of the node [here](https://github.com/use-ink/ink-node/releases).
 
-## Changed
+### Changed
 - Restrict which `cfg` attributes can be used ‒ [#2313](https://github.com/use-ink/ink/pull/2313)
 - More idiomatic return types for metadata getters - [#2398](https://github.com/use-ink/ink/pull/2398)
 - Define static distributed events slice in `ink` crate - [#2487](https://github.com/use-ink/ink/pull/2487)
 
-## Added
+### Added
 - Support for `caller_is_root` - [#2332](https://github.com/use-ink/ink/pull/2332)
 - Allow setting features for contract build in E2E tests - [#2460](https://github.com/use-ink/ink/pull/2460)
 - Improve support for Solidity ABI calling conventions - [#2411](https://github.com/use-ink/ink/pull/2411)
@@ -228,7 +228,7 @@ You can find binary releases of the node [here](https://github.com/use-ink/ink-n
 - Documentation for contract abi arg and provided Rust/ink! to Solidity type mappings - [2463](https://github.com/use-ink/ink/pull/2463)
 - Implement `SolDecode`, `SolTypeDecode` and support `SolBytes` for boxed slices - [2476](https://github.com/use-ink/ink/pull/2476)
 
-## Fixed
+### Fixed
 - [E2E] Have port parsing handle comma-separated list ‒ [#2336](https://github.com/use-ink/ink/pull/2336)
 - Always use ink! ABI/ SCALE codec for constructor and instantiation related builders and utilities - [#2474](https://github.com/use-ink/ink/pull/2474)
 - Get rid of "extrinsic for call failed: Pallet error: Revive::AccountAlreadyMapped" - [2483](https://github.com/use-ink/ink/pull/2483)


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

ink! codegen currently adds a `cfg` attribute `#[cfg(not(target_vendor = "fortanix"))]` to the `#[ink::storage]` annotated `struct` to allow code analysis stages that run after macro expansion (i.e. after the `#[ink::storage]`  attribute is removed) to find/identify the ink! storage struct for a smart contract. 

ink! 5.0.0 also previously used `#[cfg(not(feature = "__ink_dylint_Storage"))]` for the same purpose, but that causes "undeclared feature" warnings since rust (and cargo) 1.80 ([see here](https://blog.rust-lang.org/2024/05/06/check-cfg/)), so that was replaced with the above with the rationale that "`fortanix` seems like an obscure vendor, for which it is highly unlikely that someone will ever compile a contract for"

However, a better/more idiomatic approach here is to use a "marker" trait, similar to Rust's own use of [marker](https://doc.rust-lang.org/std/marker/index.html) traits to express that a type satisfies some property. 

This PR introduces an `__ink_StorageMarker` trait that marks the `struct` generated  by the `#[ink::storage]` attribute macro as the ink! storage `struct`, so that it can be found/identified by code analysis stages running after macro expansion.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
