### PR TITLE
fix: update metadata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)
 
+### Fixed
+- Update metadata version to version 6 ‒ [#2507](https://github.com/use-ink/ink/pull/2507)
+
 ## Version 6.0.0-alpha
 
 This is our first alpha release for ink! v6. We release it together

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -73,7 +73,7 @@ use serde::{
 ///
 /// The serialized metadata format (which this represents) is different from the
 /// version of this crate or the contract for Rust semantic versioning purposes.
-const METADATA_VERSION: u64 = 5;
+const METADATA_VERSION: u64 = 6;
 
 /// An entire ink! project for metadata file generation purposes.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Fixes https://github.com/use-ink/ink/issues/2505

According to the documentation https://use.ink/docs/v6/basics/metadata/ink/#version, the generated metadata should use ABI version 6. However, when creating a new contract using the current toolchain, the generated flipper.json metadata still reports version 5.

### How to test it locally:
In your local copy of `cargo-contract`, modify all ink_metadata imports to point to the following Git repository and branch:
```
git = "https://github.com/use-ink/ink", branch = "fix/metadata-version" 
```
and  install `cargo-contracts` locally:`cargo install --path ./crates/cargo-contracts --locked`
