### PR TITLE
docs: fix typos

### DIFF
--- a/crates/e2e/sandbox/src/lib.rs
+++ b/crates/e2e/sandbox/src/lib.rs
@@ -89,7 +89,7 @@ pub type ContractResultInstantiate<Runtime> =
 pub type ContractExecResultFor<Runtime> =
     ContractResult<ExecReturnValue, BalanceOf<Runtime>>;
 
-/// Alias for the `map_acocunt` result.
+/// Alias for the `map_account` result.
 pub type MapAccountResultFor = Result<(), DispatchError>;
 
 /// Alias for the runtime of a sandbox.

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -490,7 +490,7 @@ impl AccountIdMapper {
     /// This is a stateless check that just compares the last 12 bytes. Please note that
     /// it is theoretically possible to create an ed25519 keypair that passed this
     /// filter. However, this can't be used for an attack. It also won't happen by
-    /// accident since everbody is using sr25519 where this is not a valid public key.
+    /// accident since everybody is using sr25519 where this is not a valid public key.
     //fn is_eth_derived(account_id: &[u8]) -> bool {
     fn is_eth_derived(account_bytes: &[u8]) -> bool {
         account_bytes[20..] == [0xEE; 12]

--- a/integration-tests/public/own-code-hash/lib.rs
+++ b/integration-tests/public/own-code-hash/lib.rs
@@ -62,7 +62,7 @@ mod own_code_hash {
                         )
                     })
                     .unwrap_or_else(|error| {
-                        panic!("Received a `LangError` while instatiating: {:?}", error)
+                        panic!("Received a `LangError` while instantiating: {:?}", error)
                     });
                 ink::ToAddr::to_addr(&cr)
             };


### PR DESCRIPTION
## Summary
- [n] | Does it introduce breaking changes?
- [n] | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
Fix various typos in comments and error messages across the codebase

## Description
This PR fixes several typos in comments and error messages:

1. In comments: Changed "map accout" to "map_account"
2. In comments: Corrected "everbody" to "everybody"
3. In error message: Fixed "instatiating" to "instantiating"

These changes improve readability and code quality without affecting any functionality.

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules