### PR TITLE
Improve Solidity ABI support in `codegen`, `ink_env` and `ink_e2e`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
       fail-fast: false
       matrix:
         type: [STD, RISCV]
+    env:
+      # TODO: (@davidsemakula) Update all manifests for integration-tests and remove this
+      RUSTFLAGS: --check-cfg cfg(ink_abi,values("ink","sol","all"))
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -806,7 +809,8 @@ jobs:
       - name: Create Examples Docs
         uses: ./.github/run-container-command
         env:
-          RUSTDOCFLAGS:                  -Dwarnings
+          # TODO: (@davidsemakula) Update all manifests for integration-tests and remove `--check-cfg` flag
+          RUSTDOCFLAGS: -Dwarnings --check-cfg cfg(ink_abi,values("ink","sol","all"))
         with:
           command: |
             # `--document-private-items` needs to be in here because currently our contract macro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,7 @@ jobs:
             --ignore internal/mapping --ignore public/debugging-strategies --ignore public/wildcard-selector \
             --ignore solidity-abi/sol-cross-contract --ignore solidity-abi/sol-encoding \
             --ignore solidity-abi/solidity-calls-flipper --ignore solidity-abi/events \
+            --ignore solidity-abi/trait-flipper --ignore solidity-abi/trait-dyn-cross-contract-calls \
             --partition ${{ matrix.partition }}/4 -- \
             cargo contract test --all-features --manifest-path {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,8 @@ jobs:
         type: [STD, RISCV]
     env:
       # TODO: (@davidsemakula) Update all manifests for integration-tests and remove this
-      RUSTFLAGS: --check-cfg cfg(ink_abi,values("ink","sol","all"))
+      # i.e. update with equivalent of setting `--check-cfg cfg(ink_abi,values("ink","sol","all"))`
+      ALLOWED_LINTS: -A unexpected_cfgs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -194,7 +195,7 @@ jobs:
         with:
           command: |
             scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --all-targets \
-              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
+              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED $ALLOWED_LINTS
 
       - name: Run Clippy for RISC-V Examples
         uses: ./.github/run-container-command
@@ -203,7 +204,7 @@ jobs:
           command: |
             scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --no-default-features \
               --target ${CLIPPY_TARGET} \
-              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
+              --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED $ALLOWED_LINTS
 
   check:
     runs-on: ubuntu-latest
@@ -745,18 +746,35 @@ jobs:
       - name: Build Contract Examples for RISC-V
         uses: ./.github/run-container-command
         env:
-          RUSTC_BOOTSTRAP: 1
           MANIFEST_PATH: ""
           CONTRACT_SIZE_FILE: "measurements-${{ env.MEASUREMENTS_ID }}/contract_size_"
           CARGO_INCREMENTAL: 0
         with:
           command: |
             mkdir -p measurements-${{ env.MEASUREMENTS_ID }}/
-            scripts/for_all_contracts_exec2.sh --path integration-tests -- \
+            scripts/for_all_contracts_exec2.sh --path integration-tests \
+              --ignore solidity-abi/sol-cross-contract --ignore solidity-abi/sol-encoding \
+              --ignore solidity-abi/solidity-calls-flipper --ignore solidity-abi/events \
+              --ignore solidity-abi/trait-flipper --ignore solidity-abi/trait-dyn-cross-contract-calls -- \
               scripts/build_and_determine_contract_size.sh {}
   
           #bash -c "scripts/build_and_determine_contract_size.sh {} >> ${CONTRACT_SIZE_FILE} && \
           #sed -ie 's/^integration-tests\/\(public\/\|internal\/\)\?//' ${CONTRACT_SIZE_FILE}"
+
+      # NOTE: Sharing build artifacts (i.e. via a shared cargo target directory) with other contracts
+      # that don't have the same ABI set makes the builds fail.
+      - name: Build Contract Examples for RISC-V (Solidity ABI)
+        uses: ./.github/run-container-command
+        env:
+          MANIFEST_PATH: ""
+          CONTRACT_SIZE_FILE: "measurements-${{ env.MEASUREMENTS_ID }}/contract_size_"
+          CARGO_INCREMENTAL: 0
+          CARGO_TARGET_DIR: ${{ env.CARGO_TARGET_DIR }}/sol-abi
+        with:
+          command: |
+            mkdir -p measurements-${{ env.MEASUREMENTS_ID }}/
+            scripts/for_all_contracts_exec2.sh --path integration-tests/solidity-abi -- \
+              scripts/build_and_determine_contract_size.sh {}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support ABI `cfg` flag in codegen - [#2501](https://github.com/use-ink/ink/pull/2501)
 - Generate Solidity ABI compatibility metadata - [#2510](https://github.com/use-ink/ink/pull/2510)
+- Improve Solidity ABI support in `codegen`, `ink_env` and `ink_e2e` - [#2517](https://github.com/use-ink/ink/pull/2517)
 
 ### Changed
 - Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -12,6 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_env::{
+    DefaultEnvironment,
+    Environment,
+};
+use ink_primitives::{
+    reflect::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+        ScaleEncoding,
+    },
+    DepositLimit,
+};
+use jsonrpsee::core::async_trait;
+use pallet_revive::evm::CallTrace;
+use sp_weights::Weight;
+use subxt::dynamic::Value;
+
 use super::{
     InstantiateDryRunResult,
     Keypair,
@@ -30,22 +47,6 @@ use crate::{
     CallDryRunResult,
     UploadResult,
 };
-use ink_env::{
-    DefaultEnvironment,
-    Environment,
-};
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-        ScaleEncoding,
-    },
-    DepositLimit,
-};
-use jsonrpsee::core::async_trait;
-use pallet_revive::evm::CallTrace;
-use sp_weights::Weight;
-use subxt::dynamic::Value;
 
 /// Full E2E testing backend: combines general chain API and contract-specific operations.
 #[async_trait]
@@ -271,7 +272,7 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         message: &CallBuilderFinal<E, Args, RetType, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<CallDryRunResult<E, RetType>, Self::Error>
+    ) -> Result<CallDryRunResult<E, RetType, Abi>, Self::Error>
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone;
 

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -17,10 +17,10 @@ use ink_env::{
     Environment,
 };
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiDecodeWith,
         AbiEncodeWith,
-        ScaleEncoding,
+        Ink,
     },
     DepositLimit,
 };
@@ -135,7 +135,7 @@ pub trait ContractsBackend<E: Environment> {
     fn instantiate<
         'a,
         Contract: Clone,
-        Args: Send + Clone + AbiEncodeWith<ScaleEncoding> + Sync,
+        Args: Send + Clone + AbiEncodeWith<Ink> + Sync,
         R,
     >(
         &'a mut self,
@@ -312,7 +312,7 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
     /// instance is reused!
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,
@@ -327,7 +327,7 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
     /// Dry run contract instantiation.
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::marker::PhantomData;
+
+use ink_env::Environment;
+use ink_primitives::{
+    reflect::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+        ScaleEncoding,
+    },
+    DepositLimit,
+};
+use sp_weights::Weight;
+
 use super::{
     balance_to_deposit_limit,
     InstantiateDryRunResult,
@@ -28,17 +41,6 @@ use crate::{
     UploadResult,
     H256,
 };
-use ink_env::Environment;
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-        ScaleEncoding,
-    },
-    DepositLimit,
-};
-use sp_weights::Weight;
-use std::marker::PhantomData;
 
 /// Allows to build an end-to-end call using a builder pattern.
 pub struct CallBuilder<'a, E, Args, RetType, B, Abi>
@@ -46,7 +48,6 @@ where
     E: Environment,
     Args: AbiEncodeWith<Abi> + Clone,
     RetType: Send + AbiDecodeWith<Abi>,
-
     B: BuilderClient<E>,
     Abi: Clone,
 {
@@ -141,7 +142,7 @@ where
     /// to add a margin to the gas limit.
     pub async fn submit(
         &mut self,
-    ) -> Result<CallResult<E, RetType, B::EventLog>, B::Error>
+    ) -> Result<CallResult<E, RetType, B::EventLog, Abi>, B::Error>
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone,
     {
@@ -184,7 +185,7 @@ where
     }
 
     /// Dry run the call.
-    pub async fn dry_run(&mut self) -> Result<CallDryRunResult<E, RetType>, B::Error>
+    pub async fn dry_run(&mut self) -> Result<CallDryRunResult<E, RetType, Abi>, B::Error>
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone,
     {

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -16,10 +16,10 @@ use std::marker::PhantomData;
 
 use ink_env::Environment;
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiDecodeWith,
         AbiEncodeWith,
-        ScaleEncoding,
+        Ink,
     },
     DepositLimit,
 };
@@ -204,7 +204,7 @@ where
 pub struct InstantiateBuilder<'a, E, Contract, Args, R, B>
 where
     E: Environment,
-    Args: AbiEncodeWith<ScaleEncoding> + Clone,
+    Args: AbiEncodeWith<Ink> + Clone,
     Contract: Clone,
 
     B: ContractsBackend<E>,
@@ -222,7 +222,7 @@ where
 impl<'a, E, Contract, Args, R, B> InstantiateBuilder<'a, E, Contract, Args, R, B>
 where
     E: Environment,
-    Args: AbiEncodeWith<ScaleEncoding> + Clone + Send + Sync,
+    Args: AbiEncodeWith<Ink> + Clone + Send + Sync,
     Contract: Clone,
     B: BuilderClient<E>,
 {

--- a/crates/e2e/src/builders.rs
+++ b/crates/e2e/src/builders.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::H256;
 use ink_env::{
     call::{
         utils::{
@@ -25,10 +24,12 @@ use ink_env::{
     },
     Environment,
 };
-use ink_primitives::reflect::{
+use ink_primitives::abi::{
     AbiEncodeWith,
-    ScaleEncoding,
+    Ink,
 };
+
+use crate::H256;
 
 /// The type returned from `ContractRef` constructors, partially initialized with the
 /// execution input arguments.
@@ -36,12 +37,12 @@ pub type CreateBuilderPartial<E, ContractRef, Args, R> = CreateBuilder<
     E,
     ContractRef,
     Set<LimitParamsV2>,
-    Set<ExecutionInput<Args, ScaleEncoding>>,
+    Set<ExecutionInput<Args, Ink>>,
     Set<ReturnType<R>>,
 >;
 
 /// Get the encoded constructor arguments from the partially initialized `CreateBuilder`
-pub fn constructor_exec_input<E, ContractRef, Args: AbiEncodeWith<ScaleEncoding>, R>(
+pub fn constructor_exec_input<E, ContractRef, Args: AbiEncodeWith<Ink>, R>(
     builder: CreateBuilderPartial<E, ContractRef, Args, R>,
 ) -> Vec<u8>
 where

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{
+    fmt,
+    fmt::Debug,
+    marker::PhantomData,
+};
+
 use frame_support::pallet_prelude::{
     Decode,
     Encode,
@@ -22,9 +28,14 @@ use ink_env::{
     Environment,
 };
 use ink_primitives::{
+    reflect::{
+        ScaleEncoding,
+        SolEncoding,
+    },
     Address,
     ConstructorResult,
     MessageResult,
+    SolDecode,
     H256,
 };
 use pallet_revive::{
@@ -37,11 +48,6 @@ use pallet_revive::{
 use sp_runtime::{
     DispatchError,
     Weight,
-};
-use std::{
-    fmt,
-    fmt::Debug,
-    marker::PhantomData,
 };
 
 /// Alias for the contract instantiate result.
@@ -198,9 +204,9 @@ where
 }
 
 /// Result of a contract call.
-pub struct CallResult<E: Environment, V, EventLog> {
+pub struct CallResult<E: Environment, V, EventLog, Abi = ScaleEncoding> {
     /// The result of the dry run, contains debug messages if there were any.
-    pub dry_run: CallDryRunResult<E, V>,
+    pub dry_run: CallDryRunResult<E, V, Abi>,
     /// Events that happened with the contract instantiation.
     pub events: EventLog,
     /// todo
@@ -253,17 +259,18 @@ where
 }
 
 /// Result of the dry run of a contract call.
-pub struct CallDryRunResult<E: Environment, V> {
+pub struct CallDryRunResult<E: Environment, V, Abi> {
     /// The result of the dry run, contains debug messages if there were any.
     pub exec_result: ContractExecResultFor<E>,
-    pub _marker: PhantomData<V>,
-    /// todo
+    /// The execution trace (if any).
     pub trace: Option<CallTrace>,
+    /// Phantom data for return type and its ABI encoding.
+    pub _marker: PhantomData<(V, Abi)>,
 }
 
 /// We implement a custom `Debug` here, as to avoid requiring the trait bound `Debug` for
 /// `E`.
-impl<E: Environment, V> Debug for CallDryRunResult<E, V>
+impl<E: Environment, V, Abi> Debug for CallDryRunResult<E, V, Abi>
 where
     E::Balance: Debug,
     E::EventRecord: Debug,
@@ -275,7 +282,7 @@ where
     }
 }
 
-impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
+impl<E: Environment, V, Abi> CallDryRunResult<E, V, Abi> {
     /// Returns true if the dry-run execution resulted in an error.
     pub fn is_err(&self) -> bool {
         self.exec_result.result.is_err() || self.did_revert()
@@ -291,6 +298,21 @@ impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
             .unwrap_or_else(|call_err| panic!("Call dry-run failed: {call_err:?}"))
     }
 
+    /// Returns true if the message call reverted.
+    pub fn did_revert(&self) -> bool {
+        let res = self.exec_result.result.clone().expect("no result found");
+        res.did_revert()
+    }
+
+    /// Returns the return value as raw bytes of the message from the dry-run.
+    ///
+    /// Panics if the dry-run message call failed to execute.
+    pub fn return_data(&self) -> &[u8] {
+        &self.exec_return_value().data
+    }
+}
+
+impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V, ScaleEncoding> {
     /// Returns the [`MessageResult`] from the execution of the dry-run message call.
     ///
     /// # Panics
@@ -310,7 +332,7 @@ impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
     ///
     /// Panics if the value could not be decoded. The raw bytes can be accessed via
     /// [`CallResult::return_data`].
-    pub fn return_value(self) -> V {
+    pub fn return_value(&self) -> V {
         self.message_result()
             .unwrap_or_else(|lang_err| {
                 panic!(
@@ -318,18 +340,36 @@ impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
                 )
             })
     }
+}
 
-    /// todo
-    pub fn did_revert(&self) -> bool {
-        let res = self.exec_result.result.clone().expect("no result found");
-        res.did_revert()
+impl<E: Environment, V: SolDecode> CallDryRunResult<E, V, SolEncoding> {
+    /// Returns the [`MessageResult`] from the execution of the dry-run message call.
+    ///
+    /// # Panics
+    /// - if the dry-run message call failed to execute.
+    /// - if message result cannot be decoded into the expected return value type.
+    pub fn message_result(&self) -> MessageResult<V> {
+        Ok(self.return_value())
     }
 
-    /// Returns the return value as raw bytes of the message from the dry-run.
+    /// Returns the decoded return value of the message from the dry-run.
     ///
-    /// Panics if the dry-run message call failed to execute.
-    pub fn return_data(&self) -> &[u8] {
-        &self.exec_return_value().data
+    /// Panics if the value could not be decoded. The raw bytes can be accessed via
+    /// [`CallResult::return_data`].
+    pub fn return_value(&self) -> V {
+        // Solidity ABI encoded message calls return data without wrapping it in
+        // `MessageResult`.
+        let data = &self.exec_return_value().data;
+        if self.is_err() {
+            // For Solidity ABI encoded message calls,
+            // the return value is only meaningful if the message call was successful.
+            panic!("Could not decode the dry run result because the message call failed to execute")
+        }
+        SolDecode::decode(data.as_ref()).unwrap_or_else(|err| {
+            panic!(
+                "Encountered an error while decoding dry run result to ink! message: {err:?}"
+            )
+        })
     }
 }
 

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -148,12 +148,30 @@ pub struct InstantiationResult<E: Environment, EventLog> {
 
 impl<E: Environment, EventLog> InstantiationResult<E, EventLog> {
     /// Returns a call builder for the contract which was instantiated.
-    pub fn call_builder<Contract>(&self) -> <Contract as ContractCallBuilder>::Type
+    ///
+    /// # Note
+    ///
+    /// This uses the "default" ABI for the instantiated contract.
+    pub fn call_builder<Contract>(
+        &self,
+    ) -> <Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi>
     where
         Contract: ContractCallBuilder,
-        Contract::Type: FromAddr,
+        <Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi>: FromAddr,
     {
-        <<Contract as ContractCallBuilder>::Type as FromAddr>::from_addr(self.addr)
+        <<Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi> as FromAddr>::from_addr(self.addr)
+    }
+
+    /// Returns a call builder for the specified ABI for the contract which was
+    /// instantiated.
+    pub fn call_builder_abi<Contract, Abi>(
+        &self,
+    ) -> <Contract as ContractCallBuilder>::Type<Abi>
+    where
+        Contract: ContractCallBuilder,
+        <Contract as ContractCallBuilder>::Type<Abi>: FromAddr,
+    {
+        <<Contract as ContractCallBuilder>::Type<Abi> as FromAddr>::from_addr(self.addr)
     }
 }
 

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -28,9 +28,9 @@ use ink_env::{
     Environment,
 };
 use ink_primitives::{
-    reflect::{
-        ScaleEncoding,
-        SolEncoding,
+    abi::{
+        Ink,
+        Sol,
     },
     Address,
     ConstructorResult,
@@ -222,7 +222,7 @@ where
 }
 
 /// Result of a contract call.
-pub struct CallResult<E: Environment, V, EventLog, Abi = ScaleEncoding> {
+pub struct CallResult<E: Environment, V, EventLog, Abi = Ink> {
     /// The result of the dry run, contains debug messages if there were any.
     pub dry_run: CallDryRunResult<E, V, Abi>,
     /// Events that happened with the contract instantiation.
@@ -330,7 +330,7 @@ impl<E: Environment, V, Abi> CallDryRunResult<E, V, Abi> {
     }
 }
 
-impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V, ScaleEncoding> {
+impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V, Ink> {
     /// Returns the [`MessageResult`] from the execution of the dry-run message call.
     ///
     /// # Panics
@@ -360,7 +360,7 @@ impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V, ScaleEncoding> {
     }
 }
 
-impl<E: Environment, V: SolDecode> CallDryRunResult<E, V, SolEncoding> {
+impl<E: Environment, V: SolDecode> CallDryRunResult<E, V, Sol> {
     /// Returns the [`MessageResult`] from the execution of the dry-run message call.
     ///
     /// # Panics

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -151,7 +151,10 @@ impl<E: Environment, EventLog> InstantiationResult<E, EventLog> {
     ///
     /// # Note
     ///
-    /// This uses the "default" ABI for the instantiated contract.
+    /// This uses the "default" ABI for calls for the instantiated contract.
+    ///
+    /// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+    /// in the ink! project's manifest file (i.e. `Cargo.toml`).
     pub fn call_builder<Contract>(
         &self,
     ) -> <Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi>

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -155,14 +155,27 @@ pub fn address<E: Environment>(account: Sr25519Keyring) -> Address {
 /// Creates a call builder for `Contract`, based on an account id.
 pub fn create_call_builder<Contract>(
     acc_id: Address,
-) -> <Contract as ContractCallBuilder>::Type
+) -> <Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi>
 where
     <Contract as ContractEnv>::Env: Environment,
-    Contract: ContractCallBuilder,
-    Contract: ContractEnv,
-    Contract::Type: FromAddr,
+    Contract: ContractCallBuilder + ContractEnv,
+    <Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi>: FromAddr,
 {
-    <<Contract as ContractCallBuilder>::Type as FromAddr>::from_addr(acc_id)
+    <<Contract as ContractCallBuilder>::Type<ink::env::DefaultAbi> as FromAddr>::from_addr(
+        acc_id,
+    )
+}
+
+/// Creates a call builder for `Contract` for the specified ABI, based on an account id.
+pub fn create_call_builder_abi<Contract, Abi>(
+    acc_id: Address,
+) -> <Contract as ContractCallBuilder>::Type<Abi>
+where
+    <Contract as ContractEnv>::Env: Environment,
+    Contract: ContractCallBuilder + ContractEnv,
+    <Contract as ContractCallBuilder>::Type<Abi>: FromAddr,
+{
+    <<Contract as ContractCallBuilder>::Type<Abi> as FromAddr>::from_addr(acc_id)
 }
 
 fn balance_to_deposit_limit<E: Environment>(

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -450,7 +450,7 @@ where
         message: &CallBuilderFinal<E, Args, RetType, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<CallDryRunResult<E, RetType>, Self::Error>
+    ) -> Result<CallDryRunResult<E, RetType, Abi>, Self::Error>
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone,
     {
@@ -491,8 +491,8 @@ where
                 storage_deposit: result.storage_deposit,
                 result: result.result,
             },
-            _marker: Default::default(),
             trace: None, // todo
+            _marker: Default::default(),
         })
     }
 

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -12,32 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    backend::BuilderClient,
-    builders::{
-        constructor_exec_input,
-        CreateBuilderPartial,
-    },
-    client_utils::{
-        salt,
-        ContractsRegistry,
-    },
-    contract_results::{
-        BareInstantiationResult,
-        ContractExecResultFor,
-        ContractResult,
-    },
-    error::SandboxErr,
-    log_error,
-    CallBuilderFinal,
-    CallDryRunResult,
-    ChainBackend,
-    ContractsBackend,
-    E2EBackend,
-    InstantiateDryRunResult,
-    UploadResult,
-    H256,
+use std::{
+    marker::PhantomData,
+    path::PathBuf,
 };
+
 use frame_support::{
     dispatch::RawOrigin,
     pallet_prelude::DispatchError,
@@ -48,10 +27,10 @@ use frame_support::{
 };
 use ink_env::Environment;
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiDecodeWith,
         AbiEncodeWith,
-        ScaleEncoding,
+        Ink,
     },
     DepositLimit,
 };
@@ -83,15 +62,38 @@ use sp_core::{
     Pair as _,
 };
 use sp_runtime::traits::Bounded;
-use std::{
-    marker::PhantomData,
-    path::PathBuf,
-};
 use subxt::{
     dynamic::Value,
     tx::Payload,
 };
 use subxt_signer::sr25519::Keypair;
+
+use crate::{
+    backend::BuilderClient,
+    builders::{
+        constructor_exec_input,
+        CreateBuilderPartial,
+    },
+    client_utils::{
+        salt,
+        ContractsRegistry,
+    },
+    contract_results::{
+        BareInstantiationResult,
+        ContractExecResultFor,
+        ContractResult,
+    },
+    error::SandboxErr,
+    log_error,
+    CallBuilderFinal,
+    CallDryRunResult,
+    ChainBackend,
+    ContractsBackend,
+    E2EBackend,
+    InstantiateDryRunResult,
+    UploadResult,
+    H256,
+};
 
 type BalanceOf<R> = <R as pallet_balances::Config>::Balance;
 type ContractsBalanceOf<R> =
@@ -247,7 +249,7 @@ where
 {
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,
@@ -306,7 +308,7 @@ where
 
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -133,7 +133,6 @@ where
     C::Signature: From<sr25519::Signature>,
     <C::ExtrinsicParams as ExtrinsicParams<C>>::Params:
         From<<DefaultExtrinsicParams<C> as ExtrinsicParams<C>>::Params>,
-
     E: Environment,
     E::AccountId: Debug,
     E::EventRecord: Debug,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -12,6 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "std")]
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+use ink::H160;
+use ink_env::{
+    call::{
+        utils::{
+            ReturnType,
+            Set,
+        },
+        Call,
+        ExecutionInput,
+    },
+    Environment,
+};
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+        Ink,
+    },
+    types::AccountIdMapper,
+    DepositLimit,
+};
+use jsonrpsee::core::async_trait;
+use pallet_revive::evm::CallTrace;
+use scale::{
+    Decode,
+    Encode,
+};
+use sp_weights::Weight;
+use subxt::{
+    blocks::ExtrinsicEvents,
+    config::{
+        DefaultExtrinsicParams,
+        ExtrinsicParams,
+        HashFor,
+    },
+    error::DispatchError,
+    events::EventDetails,
+    ext::scale_value::{
+        Composite,
+        Value,
+        ValueDef,
+    },
+    tx::Signer,
+};
+
 use super::{
     builders::{
         constructor_exec_input,
@@ -50,53 +99,6 @@ use crate::{
     events,
     ContractsBackend,
     E2EBackend,
-};
-use ink::H160;
-use ink_env::{
-    call::{
-        utils::{
-            ReturnType,
-            Set,
-        },
-        Call,
-        ExecutionInput,
-    },
-    Environment,
-};
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-        ScaleEncoding,
-    },
-    types::AccountIdMapper,
-    DepositLimit,
-};
-use jsonrpsee::core::async_trait;
-use pallet_revive::evm::CallTrace;
-use scale::{
-    Decode,
-    Encode,
-};
-use sp_weights::Weight;
-#[cfg(feature = "std")]
-use std::fmt::Debug;
-use std::path::PathBuf;
-use subxt::{
-    blocks::ExtrinsicEvents,
-    config::{
-        DefaultExtrinsicParams,
-        ExtrinsicParams,
-        HashFor,
-    },
-    error::DispatchError,
-    events::EventDetails,
-    ext::scale_value::{
-        Composite,
-        Value,
-        ValueDef,
-    },
-    tx::Signer,
 };
 
 pub type Error = crate::error::Error<DispatchError>;
@@ -534,7 +536,7 @@ where
 {
     async fn bare_instantiate<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,
@@ -557,7 +559,7 @@ where
 
     async fn bare_instantiate_dry_run<
         Contract: Clone,
-        Args: Send + Sync + AbiEncodeWith<ScaleEncoding> + Clone,
+        Args: Send + Sync + AbiEncodeWith<Ink> + Clone,
         R,
     >(
         &mut self,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -703,7 +703,7 @@ where
         message: &CallBuilderFinal<E, Args, RetType, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<CallDryRunResult<E, RetType>, Self::Error>
+    ) -> Result<CallDryRunResult<E, RetType, Abi>, Self::Error>
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone,
     {

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -105,4 +105,5 @@ unstable-hostfn = []
 level = "warn"
 check-cfg = [
     'cfg(feature, values(any()))',
+    'cfg(ink_abi, values("ink", "sol", "all"))'
 ]

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -15,6 +15,21 @@
 //! The public raw interface towards the host engine.
 
 #[cfg(feature = "unstable-hostfn")]
+use ink_primitives::abi::Ink;
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    Address,
+    SolEncode,
+    H256,
+    U256,
+};
+use ink_storage_traits::Storable;
+use pallet_revive_uapi::ReturnFlags;
+
+#[cfg(feature = "unstable-hostfn")]
 use crate::call::{
     ConstructorReturnType,
     CreateParams,
@@ -49,20 +64,6 @@ use crate::{
     DispatchError,
     Result,
 };
-#[cfg(feature = "unstable-hostfn")]
-use ink_primitives::reflect::ScaleEncoding;
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    Address,
-    SolEncode,
-    H256,
-    U256,
-};
-use ink_storage_traits::Storable;
-use pallet_revive_uapi::ReturnFlags;
 
 /// Returns the address of the caller of the executed contract.
 ///
@@ -360,7 +361,7 @@ where
     <ContractRef as crate::ContractReverseReference>::Type:
         crate::reflect::ContractConstructorDecoder,
 
-    Args: AbiEncodeWith<ScaleEncoding>,
+    Args: AbiEncodeWith<Ink>,
     R: ConstructorReturnType<ContractRef>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -13,6 +13,22 @@
 // limitations under the License.
 
 #[cfg(feature = "unstable-hostfn")]
+use ink_primitives::abi::Ink;
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    types::Environment,
+    Address,
+    SolEncode,
+    H256,
+    U256,
+};
+use ink_storage_traits::Storable;
+pub use pallet_revive_uapi::ReturnFlags;
+
+#[cfg(feature = "unstable-hostfn")]
 use crate::call::{
     ConstructorReturnType,
     CreateParams,
@@ -35,21 +51,6 @@ use crate::{
     DispatchError,
     Result,
 };
-#[cfg(feature = "unstable-hostfn")]
-use ink_primitives::reflect::ScaleEncoding;
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    types::Environment,
-    Address,
-    SolEncode,
-    H256,
-    U256,
-};
-use ink_storage_traits::Storable;
-pub use pallet_revive_uapi::ReturnFlags;
 
 /// Environmental contract functionality that does not require `Environment`.
 pub trait EnvBackend {
@@ -380,7 +381,7 @@ pub trait TypedEnvBackend: EnvBackend {
         ContractRef: FromAddr + crate::ContractReverseReference,
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
-        Args: AbiEncodeWith<ScaleEncoding>,
+        Args: AbiEncodeWith<Ink>,
         R: ConstructorReturnType<ContractRef>;
 
     /// Terminates a smart contract.

--- a/crates/env/src/call/call_builder/call.rs
+++ b/crates/env/src/call/call_builder/call.rs
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    Address,
+    U256,
+};
+use pallet_revive_uapi::CallFlags;
+
 use crate::{
     call::{
         common::{
@@ -31,15 +41,6 @@ use crate::{
     },
     Error,
 };
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    Address,
-    U256,
-};
-use pallet_revive_uapi::CallFlags;
 
 /// The default call type for cross-contract calls, for calling into the latest `call`
 /// host function. This adds the additional weight limit parameter `proof_size_limit` as

--- a/crates/env/src/call/call_builder/delegate.rs
+++ b/crates/env/src/call/call_builder/delegate.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    Address,
+};
+use pallet_revive_uapi::CallFlags;
+
 use crate::{
     call::{
         common::{
@@ -28,14 +37,6 @@ use crate::{
     types::Environment,
     Error,
 };
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    Address,
-};
-use pallet_revive_uapi::CallFlags;
 
 /// The `delegatecall` call type. Performs a call with the given code hash.
 #[derive(Clone)]

--- a/crates/env/src/call/call_builder/mod.rs
+++ b/crates/env/src/call/call_builder/mod.rs
@@ -228,6 +228,26 @@ where
     }
 }
 
+/// Returns a new [`CallBuilder`] for the specified ABI to build up the parameters to a
+/// cross-contract call. See [`build_call`] for more details on usage.
+#[allow(clippy::type_complexity)]
+pub fn build_call_abi<E, Abi>() -> CallBuilder<
+    E,
+    Unset<Call>,
+    Unset<ExecutionInput<EmptyArgumentList<Abi>, Abi>>,
+    Unset<ReturnType<()>>,
+>
+where
+    E: Environment,
+{
+    CallBuilder {
+        call_type: Default::default(),
+        exec_input: Default::default(),
+        return_type: Default::default(),
+        _phantom: Default::default(),
+    }
+}
+
 /// Returns a new [`CallBuilder`] to build up the parameters to a cross-contract call
 /// that uses Solidity ABI Encoding.
 /// See [`build_call`] for more details on usage.

--- a/crates/env/src/call/call_builder/mod.rs
+++ b/crates/env/src/call/call_builder/mod.rs
@@ -18,6 +18,16 @@ mod delegate;
 pub use call::Call;
 pub use delegate::DelegateCall;
 
+use core::marker::PhantomData;
+
+use ink_primitives::{
+    abi::{
+        Ink,
+        Sol,
+    },
+    Address,
+};
+
 use crate::{
     call::{
         utils::{
@@ -30,14 +40,6 @@ use crate::{
         ExecutionInput,
     },
     types::Environment,
-};
-use core::marker::PhantomData;
-use ink_primitives::{
-    reflect::{
-        ScaleEncoding,
-        SolEncoding,
-    },
-    Address,
 };
 
 /// The final parameters to the cross-contract call.
@@ -214,7 +216,7 @@ where
 pub fn build_call<E>() -> CallBuilder<
     E,
     Unset<Call>,
-    Unset<ExecutionInput<EmptyArgumentList<ScaleEncoding>, ScaleEncoding>>,
+    Unset<ExecutionInput<EmptyArgumentList<Ink>, Ink>>,
     Unset<ReturnType<()>>,
 >
 where
@@ -255,7 +257,7 @@ where
 pub fn build_call_solidity<E>() -> CallBuilder<
     E,
     Unset<Call>,
-    Unset<ExecutionInput<EmptyArgumentList<SolEncoding>, SolEncoding>>,
+    Unset<ExecutionInput<EmptyArgumentList<Sol>, Sol>>,
     Unset<ReturnType<()>>,
 >
 where

--- a/crates/env/src/call/call_builder/mod.rs
+++ b/crates/env/src/call/call_builder/mod.rs
@@ -67,7 +67,12 @@ where
 }
 
 /// Returns a new [`CallBuilder`] to build up the parameters to a cross-contract call
-/// that uses the "default" ABI.
+/// that uses the "default" ABI for calls for the ink! project.
+///
+/// # Note
+///
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 ///
 /// # Example
 ///

--- a/crates/env/src/call/call_builder/mod.rs
+++ b/crates/env/src/call/call_builder/mod.rs
@@ -21,10 +21,7 @@ pub use delegate::DelegateCall;
 use core::marker::PhantomData;
 
 use ink_primitives::{
-    abi::{
-        Ink,
-        Sol,
-    },
+    abi::Sol,
     Address,
 };
 
@@ -70,7 +67,7 @@ where
 }
 
 /// Returns a new [`CallBuilder`] to build up the parameters to a cross-contract call
-/// that uses the ink! ABI (SCALE Encoding).
+/// that uses the "default" ABI.
 ///
 /// # Example
 ///
@@ -216,7 +213,7 @@ where
 pub fn build_call<E>() -> CallBuilder<
     E,
     Unset<Call>,
-    Unset<ExecutionInput<EmptyArgumentList<Ink>, Ink>>,
+    Unset<ExecutionInput<EmptyArgumentList<crate::DefaultAbi>, crate::DefaultAbi>>,
     Unset<ReturnType<()>>,
 >
 where

--- a/crates/env/src/call/call_builder/mod.rs
+++ b/crates/env/src/call/call_builder/mod.rs
@@ -233,7 +233,8 @@ where
 }
 
 /// Returns a new [`CallBuilder`] for the specified ABI to build up the parameters to a
-/// cross-contract call. See [`build_call`] for more details on usage.
+/// cross-contract call.
+/// See [`build_call`] for more details on usage.
 #[allow(clippy::type_complexity)]
 pub fn build_call_abi<E, Abi>() -> CallBuilder<
     E,

--- a/crates/env/src/call/common.rs
+++ b/crates/env/src/call/common.rs
@@ -15,11 +15,12 @@
 //! Utilities, types and abstractions common to call and instantiation routines.
 
 use core::marker::PhantomData;
+
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiDecodeWith,
-        ScaleEncoding,
-        SolEncoding,
+        Ink,
+        Sol,
     },
     MessageResult,
     SolDecode,
@@ -130,7 +131,7 @@ pub trait DecodeMessageResult<Abi>: Sized {
     fn decode_output(buffer: &[u8]) -> crate::Result<MessageResult<Self>>;
 }
 
-impl<R> DecodeMessageResult<ScaleEncoding> for R
+impl<R> DecodeMessageResult<Ink> for R
 where
     R: Decode,
     MessageResult<R>: Decode,
@@ -141,7 +142,7 @@ where
     }
 }
 
-impl<R> DecodeMessageResult<SolEncoding> for R
+impl<R> DecodeMessageResult<Sol> for R
 where
     R: SolDecode,
 {

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -15,9 +15,9 @@
 use core::marker::PhantomData;
 
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiEncodeWith,
-        ScaleEncoding,
+        Ink,
     },
     Address,
     H256,
@@ -192,7 +192,7 @@ pub struct CreateParams<E, ContractRef, Limits, Args, R> {
     /// todo: is this correct? or is the value here `U256`?
     endowment: U256,
     /// The input data for the instantiation.
-    exec_input: ExecutionInput<Args, ScaleEncoding>,
+    exec_input: ExecutionInput<Args, Ink>,
     /// The salt for determining the hash for the contract account ID.
     salt_bytes: Option<[u8; 32]>,
     /// The return type of the target contract's constructor method.
@@ -219,7 +219,7 @@ where
 
     /// The raw encoded input data.
     #[inline]
-    pub fn exec_input(&self) -> &ExecutionInput<Args, ScaleEncoding> {
+    pub fn exec_input(&self) -> &ExecutionInput<Args, Ink> {
         &self.exec_input
     }
 
@@ -275,7 +275,7 @@ where
         crate::reflect::ContractConstructorDecoder,
     <ContractRef as crate::ContractReverseReference>::Type:
         crate::reflect::ContractMessageDecoder,
-    Args: AbiEncodeWith<ScaleEncoding>,
+    Args: AbiEncodeWith<Ink>,
     R: ConstructorReturnType<ContractRef>,
 {
     /// todo
@@ -441,7 +441,7 @@ pub fn build_create<ContractRef>() -> CreateBuilder<
     <ContractRef as ContractEnv>::Env,
     ContractRef,
     Set<LimitParamsV2>,
-    Unset<ExecutionInput<EmptyArgumentList<ScaleEncoding>, ScaleEncoding>>,
+    Unset<ExecutionInput<EmptyArgumentList<Ink>, Ink>>,
     Unset<ReturnType<()>>,
 >
 where
@@ -643,7 +643,7 @@ impl<E, ContractRef, Limits, Args, RetType>
         E,
         ContractRef,
         Set<Limits>,
-        Set<ExecutionInput<Args, ScaleEncoding>>,
+        Set<ExecutionInput<Args, Ink>>,
         Set<ReturnType<RetType>>,
     >
 where
@@ -669,7 +669,7 @@ impl<E, ContractRef, Args, RetType>
         E,
         ContractRef,
         Set<LimitParamsV2>,
-        Set<ExecutionInput<Args, ScaleEncoding>>,
+        Set<ExecutionInput<Args, Ink>>,
         Set<ReturnType<RetType>>,
     >
 where
@@ -679,7 +679,7 @@ where
         crate::reflect::ContractConstructorDecoder,
     <ContractRef as crate::ContractReverseReference>::Type:
         crate::reflect::ContractMessageDecoder,
-    Args: AbiEncodeWith<ScaleEncoding>,
+    Args: AbiEncodeWith<Ink>,
     RetType: ConstructorReturnType<ContractRef>,
 {
     /// todo check comment

--- a/crates/env/src/call/execution.rs
+++ b/crates/env/src/call/execution.rs
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::marker::PhantomData;
+
+use ink_prelude::vec::Vec;
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+        Ink,
+        Sol,
+    },
+    SolEncode,
+};
+
 use super::{
     utils::ReturnType,
     Selector,
@@ -19,17 +32,6 @@ use super::{
 use crate::{
     call::utils::DecodeMessageResult,
     Environment,
-};
-use core::marker::PhantomData;
-use ink_prelude::vec::Vec;
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-        ScaleEncoding,
-        SolEncoding,
-    },
-    SolEncode,
 };
 
 /// The input data and the expected return type of a contract execution.
@@ -270,7 +272,7 @@ where
     }
 }
 
-impl scale::Encode for EmptyArgumentList<ScaleEncoding> {
+impl scale::Encode for EmptyArgumentList<Ink> {
     #[inline]
     fn size_hint(&self) -> usize {
         0
@@ -280,7 +282,7 @@ impl scale::Encode for EmptyArgumentList<ScaleEncoding> {
     fn encode_to<O: scale::Output + ?Sized>(&self, _output: &mut O) {}
 }
 
-impl<Head, Rest> scale::Encode for ArgumentList<Argument<Head>, Rest, ScaleEncoding>
+impl<Head, Rest> scale::Encode for ArgumentList<Argument<Head>, Rest, Ink>
 where
     Head: scale::Encode,
     Rest: scale::Encode,
@@ -303,7 +305,7 @@ where
     }
 }
 
-impl<Args> scale::Encode for ExecutionInput<Args, ScaleEncoding>
+impl<Args> scale::Encode for ExecutionInput<Args, Ink>
 where
     Args: scale::Encode,
 {
@@ -332,7 +334,7 @@ where
     }
 }
 
-impl SolEncode<'_> for EmptyArgumentList<SolEncoding> {
+impl SolEncode<'_> for EmptyArgumentList<Sol> {
     type SolType = ();
 
     fn encode(&self) -> Vec<u8> {
@@ -343,7 +345,7 @@ impl SolEncode<'_> for EmptyArgumentList<SolEncoding> {
     fn to_sol_type(&self) {}
 }
 
-impl<'a, Head, Rest> SolEncode<'a> for ArgumentList<Argument<Head>, Rest, SolEncoding>
+impl<'a, Head, Rest> SolEncode<'a> for ArgumentList<Argument<Head>, Rest, Sol>
 where
     Head: SolEncode<'a>,
     Rest: SolEncode<'a>,

--- a/crates/env/src/call/mod.rs
+++ b/crates/env/src/call/mod.rs
@@ -43,6 +43,7 @@ pub mod utils {
 pub use self::{
     call_builder::{
         build_call,
+        build_call_abi,
         build_call_solidity,
         Call,
         CallBuilder,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -12,6 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_engine::ext::Engine;
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::abi::Ink;
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::types::AccountIdMapper;
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    types::Environment,
+    Address,
+    SolEncode,
+    H256,
+    U256,
+};
+use ink_storage_traits::{
+    decode_all,
+    Storable,
+};
+use pallet_revive_uapi::{
+    ReturnErrorCode,
+    ReturnFlags,
+};
+#[cfg(feature = "unstable-hostfn")]
+use schnorrkel::{
+    PublicKey,
+    Signature,
+};
+
 use super::EnvInstance;
 use crate::{
     call::{
@@ -50,36 +80,6 @@ use crate::{
     },
     test::callee,
     Clear,
-};
-use ink_engine::ext::Engine;
-#[cfg(feature = "unstable-hostfn")]
-use ink_primitives::{
-    reflect::ScaleEncoding,
-    types::AccountIdMapper,
-};
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    types::Environment,
-    Address,
-    SolEncode,
-    H256,
-    U256,
-};
-use ink_storage_traits::{
-    decode_all,
-    Storable,
-};
-use pallet_revive_uapi::{
-    ReturnErrorCode,
-    ReturnFlags,
-};
-#[cfg(feature = "unstable-hostfn")]
-use schnorrkel::{
-    PublicKey,
-    Signature,
 };
 
 /// The capacity of the static buffer.
@@ -656,7 +656,7 @@ impl TypedEnvBackend for EnvInstance {
         ContractRef: FromAddr + crate::ContractReverseReference,
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
-        Args: AbiEncodeWith<ScaleEncoding>,
+        Args: AbiEncodeWith<Ink>,
         R: ConstructorReturnType<ContractRef>,
     {
         let endowment = params.endowment();

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -12,6 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::abi::Ink;
+use ink_primitives::{
+    abi::{
+        AbiDecodeWith,
+        AbiEncodeWith,
+    },
+    Address,
+    SolEncode,
+    H256,
+    U256,
+};
+use ink_storage_traits::{
+    decode_all,
+    Storable,
+};
+use pallet_revive_uapi::{
+    CallFlags,
+    HostFn,
+    HostFnImpl as ext,
+    ReturnErrorCode,
+    ReturnFlags,
+    StorageFlags,
+};
+#[cfg(feature = "unstable-hostfn")]
+use xcm::VersionedXcm;
+
 use crate::{
     call::{
         utils::DecodeMessageResult,
@@ -56,32 +83,6 @@ use crate::{
     },
     Clear,
 };
-#[cfg(feature = "unstable-hostfn")]
-use ink_primitives::reflect::ScaleEncoding;
-use ink_primitives::{
-    reflect::{
-        AbiDecodeWith,
-        AbiEncodeWith,
-    },
-    Address,
-    SolEncode,
-    H256,
-    U256,
-};
-use ink_storage_traits::{
-    decode_all,
-    Storable,
-};
-use pallet_revive_uapi::{
-    CallFlags,
-    HostFn,
-    HostFnImpl as ext,
-    ReturnErrorCode,
-    ReturnFlags,
-    StorageFlags,
-};
-#[cfg(feature = "unstable-hostfn")]
-use xcm::VersionedXcm;
 
 #[cfg(feature = "unstable-hostfn")]
 impl CryptoHash for Blake2x128 {
@@ -611,7 +612,7 @@ impl TypedEnvBackend for EnvInstance {
     where
         E: Environment,
         ContractRef: FromAddr,
-        Args: AbiEncodeWith<ScaleEncoding>,
+        Args: AbiEncodeWith<Ink>,
         RetType: ConstructorReturnType<ContractRef>,
     {
         let mut scoped = self.scoped_buffer();

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -145,10 +145,22 @@ pub use pallet_revive_uapi::{
     ReturnFlags,
 };
 
+/// A convenience type alias to the marker type representing the "default" ABI for calls.
+///
+/// # Note
+///
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 #[cfg(not(ink_abi = "sol"))]
 #[doc(hidden)]
 pub type DefaultAbi = ink_primitives::abi::Ink;
 
+/// A convenience type alias to the marker type representing the "default" ABI for calls.
+///
+/// # Note
+///
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 #[cfg(ink_abi = "sol")]
 #[doc(hidden)]
 pub type DefaultAbi = ink_primitives::abi::Sol;

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -147,8 +147,8 @@ pub use pallet_revive_uapi::{
 
 #[cfg(not(ink_abi = "sol"))]
 #[doc(hidden)]
-pub type DefaultAbi = ink_primitives::reflect::ScaleEncoding;
+pub type DefaultAbi = ink_primitives::abi::Ink;
 
 #[cfg(ink_abi = "sol")]
 #[doc(hidden)]
-pub type DefaultAbi = ink_primitives::reflect::SolEncoding;
+pub type DefaultAbi = ink_primitives::abi::Sol;

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -144,3 +144,11 @@ pub use pallet_revive_uapi::{
     ReturnErrorCode,
     ReturnFlags,
 };
+
+#[cfg(not(ink_abi = "sol"))]
+#[doc(hidden)]
+pub type DefaultAbi = ink_primitives::reflect::ScaleEncoding;
+
+#[cfg(ink_abi = "sol")]
+#[doc(hidden)]
+pub type DefaultAbi = ink_primitives::reflect::SolEncoding;

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -513,7 +513,7 @@ impl ContractRef<'_> {
 
         let arg_list = generator::generate_argument_list(
             input_types.iter().cloned(),
-            quote!(::ink::reflect::ScaleEncoding),
+            quote!(::ink::abi::Ink),
         );
 
         quote_spanned!(span =>
@@ -526,7 +526,7 @@ impl ContractRef<'_> {
                 Environment,
                 Self,
                 ::ink::env::call::utils::Set<::ink::env::call::LimitParamsV2 >,
-                ::ink::env::call::utils::Set<::ink::env::call::ExecutionInput<#arg_list, ::ink::reflect::ScaleEncoding>>,
+                ::ink::env::call::utils::Set<::ink::env::call::ExecutionInput<#arg_list, ::ink::abi::Ink>>,
                 ::ink::env::call::utils::Set<::ink::env::call::utils::ReturnType<#ret_type>>,
             > {
                 ::ink::env::call::build_create::<Self>()

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -269,17 +269,7 @@ impl Dispatch<'_> {
             .impls()
             .filter(|item_impl| item_impl.trait_path().is_none())
             .flat_map(|item_impl| item_impl.iter_messages())
-            .flat_map(|message| {
-                let mut message_infos = Vec::new();
-
-                #[cfg(not(ink_abi = "sol"))]
-                message_infos.push(self.dispatchable_inherent_message_infos(&message));
-
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                message_infos.push(self.solidity_message_info(&message, None));
-
-                message_infos
-            });
+            .map(|message| self.dispatchable_inherent_message_infos(&message));
         let trait_message_infos = self
             .contract
             .module()
@@ -295,17 +285,8 @@ impl Dispatch<'_> {
                     })
             })
             .flatten()
-            .flat_map(|((trait_ident, trait_path), message)| {
-                let mut message_infos = Vec::new();
-
-                #[cfg(not(ink_abi = "sol"))]
-                message_infos.push(self.dispatchable_trait_message_infos(&message, trait_ident, trait_path));
-
-                // NOTE: Solidity selectors are always computed from the call signature and input types.
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                message_infos.push(self.solidity_message_info(&message, Some((trait_ident, trait_path))));
-
-                message_infos
+            .map(|((trait_ident, trait_path), message)| {
+                self.dispatchable_trait_message_infos(&message, trait_ident, trait_path)
             });
         quote_spanned!(span=>
             #( #inherent_message_infos )*
@@ -317,7 +298,6 @@ impl Dispatch<'_> {
     ///
     /// These trait implementations store relevant dispatch information for every
     /// inherent dispatchable ink! message of the ink! smart contract.
-    #[cfg(not(ink_abi = "sol"))]
     fn dispatchable_inherent_message_infos(
         &self,
         message: &CallableWithSelector<Message>,
@@ -338,48 +318,90 @@ impl Dispatch<'_> {
         let input_tuple_type = generator::input_types_tuple(message.inputs());
         let input_tuple_bindings = generator::input_bindings_tuple(message.inputs());
 
-        let selector_id = message
-            .composed_selector()
-            .into_be_u32()
-            .hex_padded_suffixed();
-        let selector_bytes = message.composed_selector().hex_lits();
-
         #[cfg(feature = "std")]
         let return_type = quote! { () };
         #[cfg(not(feature = "std"))]
         let return_type = quote! { ! };
 
-        quote_spanned!(message_span=>
-            #( #cfg_attrs )*
-            impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
-                type Input = #input_tuple_type;
-                type Output = #output_tuple_type;
-                type Storage = #storage_ident;
+        let mut message_infos = Vec::new();
 
-                const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
-                    |storage, #input_tuple_bindings| {
-                        #storage_ident::#message_ident( storage #( , #input_bindings )* )
-                    };
-                const DECODE: fn(&mut &[::core::primitive::u8]) -> ::core::result::Result<Self::Input, ::ink::env::DispatchError> =
-                    |input| {
-                        <Self::Input as ::ink::scale::Decode>::decode(input)
-                            .map_err(|_| ::ink::env::DispatchError::InvalidParameters)
-                    };
-                const RETURN: fn(::ink::env::ReturnFlags, Self::Output) -> #return_type =
-                    |flags, output| {
-                        ::ink::env::return_value::<::ink::MessageResult::<Self::Output>>(
-                            flags,
-                            // Currently no `LangError`s are raised at this level of the
-                            // dispatch logic so `Ok` is always returned to the caller.
-                            &::ink::MessageResult::Ok(output),
-                        )
-                    };
-                const SELECTOR: [::core::primitive::u8; 4usize] = [ #( #selector_bytes ),* ];
-                const PAYABLE: ::core::primitive::bool = #payable;
-                const MUTATES: ::core::primitive::bool = #mutates;
-                const LABEL: &'static ::core::primitive::str = ::core::stringify!(#message_ident);
-                const ENCODING: ::ink::reflect::Encoding = ::ink::reflect::Encoding::Scale;
-            }
+        let generate_info = |selector_id: TokenStream2,
+                             selector_bytes: TokenStream2,
+                             encoding_strategy: TokenStream2,
+                             decode_trait: TokenStream2,
+                             return_expr: TokenStream2| {
+            quote_spanned!(message_span=>
+                #( #cfg_attrs )*
+                impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
+                    type Input = #input_tuple_type;
+                    type Output = #output_tuple_type;
+                    type Storage = #storage_ident;
+
+                    const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
+                        |storage, #input_tuple_bindings| {
+                            #storage_ident::#message_ident( storage #( , #input_bindings )* )
+                        };
+                    const DECODE: fn(&mut &[::core::primitive::u8]) -> ::core::result::Result<Self::Input, ::ink::env::DispatchError> =
+                        |input| {
+                            <Self::Input as #decode_trait>::decode(input)
+                                .map_err(|_| ::ink::env::DispatchError::InvalidParameters)
+                        };
+                    const RETURN: fn(::ink::env::ReturnFlags, Self::Output) -> #return_type =
+                        |flags, output| {
+                            #return_expr
+                        };
+                    const SELECTOR: [::core::primitive::u8; 4usize] = #selector_bytes;
+                    const PAYABLE: ::core::primitive::bool = #payable;
+                    const MUTATES: ::core::primitive::bool = #mutates;
+                    const LABEL: &'static ::core::primitive::str = ::core::stringify!(#message_ident);
+                    const ENCODING: ::ink::reflect::Encoding = #encoding_strategy;
+                }
+            )
+        };
+
+        #[cfg(not(ink_abi = "sol"))]
+        {
+            let selector_id = message
+                .composed_selector()
+                .into_be_u32()
+                .hex_padded_suffixed();
+            let selector_bytes = message.composed_selector().hex_lits();
+            message_infos.push(generate_info(
+                quote!(#selector_id),
+                quote!([ #( #selector_bytes ),* ]),
+                quote!(::ink::reflect::Encoding::Scale),
+                quote!(::ink::scale::Decode),
+                quote! {
+                    ::ink::env::return_value::<::ink::MessageResult::<Self::Output>>(
+                        flags,
+                        // Currently no `LangError`s are raised at this level of the
+                        // dispatch logic so `Ok` is always returned to the caller.
+                        &::ink::MessageResult::Ok(output),
+                    )
+                },
+            ));
+        }
+
+        #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+        {
+            let selector_id = sol::utils::selector_id(message);
+            let selector_bytes = sol::utils::selector(message);
+            message_infos.push(generate_info(
+                selector_id,
+                selector_bytes,
+                quote!(::ink::reflect::Encoding::Solidity),
+                quote!(::ink::SolDecode),
+                quote! {
+                    ::ink::env::return_value_solidity::<Self::Output>(
+                        flags,
+                        &output,
+                    )
+                },
+            ));
+        }
+
+        quote_spanned!(message_span=>
+            #( #message_infos )*
         )
     }
 
@@ -387,7 +409,6 @@ impl Dispatch<'_> {
     ///
     /// These trait implementations store relevant dispatch information for every
     /// trait implementation dispatchable ink! message of the ink! smart contract.
-    #[cfg(not(ink_abi = "sol"))]
     fn dispatchable_trait_message_infos(
         &self,
         message: &CallableWithSelector<Message>,
@@ -399,20 +420,6 @@ impl Dispatch<'_> {
         let message_span = message.span();
         let message_ident = message.ident();
         let mutates = message.receiver().is_ref_mut();
-        let local_id = message.local_id().hex_padded_suffixed();
-        let payable = quote! {{
-            <<::ink::reflect::TraitDefinitionRegistry<<#storage_ident as ::ink::env::ContractEnv>::Env>
-                as #trait_path>::__ink_TraitInfo
-                as ::ink::reflect::TraitMessageInfo<#local_id>>::PAYABLE
-        }};
-        let selector = quote! {{
-            <<::ink::reflect::TraitDefinitionRegistry<<#storage_ident as ::ink::env::ContractEnv>::Env>
-                as #trait_path>::__ink_TraitInfo
-                as ::ink::reflect::TraitMessageInfo<#local_id>>::SELECTOR
-        }};
-        let selector_id = quote! {{
-            ::core::primitive::u32::from_be_bytes(#selector)
-        }};
         let output_tuple_type = message
             .output()
             .map(quote::ToTokens::to_token_stream)
@@ -428,119 +435,93 @@ impl Dispatch<'_> {
         #[cfg(not(feature = "std"))]
         let return_type = quote! { ! };
 
-        quote_spanned!(message_span=>
-            #( #cfg_attrs )*
-            impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
-                type Input = #input_tuple_type;
-                type Output = #output_tuple_type;
-                type Storage = #storage_ident;
+        let mut message_infos = Vec::new();
 
-                const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
-                    |storage, #input_tuple_bindings| {
-                        <#storage_ident as #trait_path>::#message_ident( storage #( , #input_bindings )* )
-                    };
-                const DECODE: fn(&mut &[::core::primitive::u8]) -> ::core::result::Result<Self::Input, ::ink::env::DispatchError> =
-                    |input| {
-                        <Self::Input as ::ink::scale::Decode>::decode(input)
-                            .map_err(|_| ::ink::env::DispatchError::InvalidParameters)
-                    };
-                const RETURN: fn(::ink::env::ReturnFlags, Self::Output) -> #return_type =
-                    |flags, output| {
-                        ::ink::env::return_value::<::ink::MessageResult::<Self::Output>>(
-                            flags,
-                            // Currently no `LangError`s are raised at this level of the
-                            // dispatch logic so `Ok` is always returned to the caller.
-                            &::ink::MessageResult::Ok(output),
-                        )
-                    };
-                const SELECTOR: [::core::primitive::u8; 4usize] = #selector;
-                const PAYABLE: ::core::primitive::bool = #payable;
-                const MUTATES: ::core::primitive::bool = #mutates;
-                const LABEL: &'static ::core::primitive::str = #label;
-                const ENCODING: ::ink::reflect::Encoding = ::ink::reflect::Encoding::Scale;
-            }
-        )
-    }
+        let generate_info = |local_id: TokenStream2,
+                             encoding_strategy: TokenStream2,
+                             decode_trait: TokenStream2,
+                             return_expr: TokenStream2| {
+            let payable = quote! {{
+                <<::ink::reflect::TraitDefinitionRegistry<<#storage_ident as ::ink::env::ContractEnv>::Env>
+                    as #trait_path>::__ink_TraitInfo
+                    as ::ink::reflect::TraitMessageInfo<#local_id>>::PAYABLE
+            }};
+            let selector = quote! {{
+                <<::ink::reflect::TraitDefinitionRegistry<<#storage_ident as ::ink::env::ContractEnv>::Env>
+                    as #trait_path>::__ink_TraitInfo
+                    as ::ink::reflect::TraitMessageInfo<#local_id>>::SELECTOR
+            }};
+            let selector_id = quote! {{
+                ::core::primitive::u32::from_be_bytes(#selector)
+            }};
 
-    /// Generate code for [`ink::DispatchableMessageInfo`] trait implementations for
-    /// Solidity ABI compatible calls.
-    #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-    fn solidity_message_info(
-        &self,
-        message: &CallableWithSelector<Message>,
-        trait_info: Option<(&Ident, &syn::Path)>,
-    ) -> TokenStream2 {
-        let storage_ident = self.contract.module().storage().ident();
-        let message_span = message.span();
-        let message_ident = message.ident();
-        let payable = message.is_payable();
-        let mutates = message.receiver().is_ref_mut();
+            quote_spanned!(message_span=>
+                #( #cfg_attrs )*
+                impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
+                    type Input = #input_tuple_type;
+                    type Output = #output_tuple_type;
+                    type Storage = #storage_ident;
 
-        let cfg_attrs = message.get_cfg_attrs(message_span);
-        let output_tuple_type = message
-            .output()
-            .map(quote::ToTokens::to_token_stream)
-            .unwrap_or_else(|| quote! { () });
-        let input_bindings = generator::input_bindings(message.inputs());
-        let input_tuple_type = generator::input_types_tuple(message.inputs());
-        let input_tuple_bindings = generator::input_bindings_tuple(message.inputs());
-
-        let selector_id = sol::utils::selector_id(message);
-        let selector_bytes = sol::utils::selector(message);
-
-        let (call_prefix, label) = match trait_info {
-            None => {
-                (
-                    quote! {
-                        #storage_ident
-                    },
-                    message_ident.to_string(),
-                )
-            }
-            Some((trait_ident, trait_path)) => {
-                (
-                    quote! {
-                        <#storage_ident as #trait_path>
-                    },
-                    format!("{trait_ident}::{message_ident}"),
-                )
-            }
+                    const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
+                        |storage, #input_tuple_bindings| {
+                            <#storage_ident as #trait_path>::#message_ident( storage #( , #input_bindings )* )
+                        };
+                    const DECODE: fn(&mut &[::core::primitive::u8]) -> ::core::result::Result<Self::Input, ::ink::env::DispatchError> =
+                        |input| {
+                            <Self::Input as #decode_trait>::decode(input)
+                                .map_err(|_| ::ink::env::DispatchError::InvalidParameters)
+                        };
+                    const RETURN: fn(::ink::env::ReturnFlags, Self::Output) -> #return_type =
+                        |flags, output| {
+                            #return_expr
+                        };
+                    const SELECTOR: [::core::primitive::u8; 4usize] = #selector;
+                    const PAYABLE: ::core::primitive::bool = #payable;
+                    const MUTATES: ::core::primitive::bool = #mutates;
+                    const LABEL: &'static ::core::primitive::str = #label;
+                    const ENCODING: ::ink::reflect::Encoding = #encoding_strategy;
+                }
+            )
         };
 
-        #[cfg(feature = "std")]
-        let return_type = quote! { () };
-        #[cfg(not(feature = "std"))]
-        let return_type = quote! { ! };
+        #[cfg(not(ink_abi = "sol"))]
+        {
+            let local_id = message.local_id().hex_padded_suffixed();
+            message_infos.push(generate_info(
+                quote!(#local_id),
+                quote!(::ink::reflect::Encoding::Scale),
+                quote!(::ink::scale::Decode),
+                quote! {
+                    ::ink::env::return_value::<::ink::MessageResult::<Self::Output>>(
+                        flags,
+                        // Currently no `LangError`s are raised at this level of the
+                        // dispatch logic so `Ok` is always returned to the caller.
+                        &::ink::MessageResult::Ok(output),
+                    )
+                },
+            ));
+        }
+
+        #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+        {
+            // NOTE: Solidity selectors are always computed from the call signature and
+            // input types.
+            let local_id = sol::utils::selector_id(message);
+            message_infos.push(generate_info(
+                local_id,
+                quote!(::ink::reflect::Encoding::Solidity),
+                quote!(::ink::SolDecode),
+                quote! {
+                    ::ink::env::return_value_solidity::<Self::Output>(
+                        flags,
+                        &output,
+                    )
+                },
+            ));
+        }
 
         quote_spanned!(message_span=>
-            #( #cfg_attrs )*
-            impl ::ink::reflect::DispatchableMessageInfo<#selector_id> for #storage_ident {
-                type Input = #input_tuple_type;
-                type Output = #output_tuple_type;
-                type Storage = #storage_ident;
-
-                const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
-                    |storage, #input_tuple_bindings| {
-                        #call_prefix::#message_ident( storage #( , #input_bindings )* )
-                    };
-                const DECODE: fn(&mut &[::core::primitive::u8]) -> ::core::result::Result<Self::Input, ::ink::env::DispatchError> =
-                    |input| {
-                        <Self::Input as ::ink::SolDecode>::decode(input)
-                            .map_err(|_| ::ink::env::DispatchError::InvalidParameters)
-                    };
-                const RETURN: fn(::ink::env::ReturnFlags, Self::Output) -> #return_type =
-                    |flags, output| {
-                        ::ink::env::return_value_solidity::<Self::Output>(
-                            flags,
-                            &output,
-                        )
-                    };
-                const SELECTOR: [::core::primitive::u8; 4usize] = #selector_bytes;
-                const PAYABLE: ::core::primitive::bool = #payable;
-                const MUTATES: ::core::primitive::bool = #mutates;
-                const LABEL: &'static ::core::primitive::str = #label;
-                const ENCODING: ::ink::reflect::Encoding = ::ink::reflect::Encoding::Solidity;
-            }
+            #( #message_infos )*
         )
     }
 

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -336,11 +336,16 @@ impl Dispatch<'_> {
                     )
                 }
                 Abi::Sol => {
+                    let decode_trait = if input_bindings.len() == 1 {
+                        quote!(::ink::SolDecode)
+                    } else {
+                        quote!(::ink::primitives::sol::SolParamsDecode)
+                    };
                     (
                         sol::utils::selector_id(message),
                         sol::utils::selector(message),
                         quote!(::ink::abi::Abi::Sol),
-                        quote!(::ink::SolDecode),
+                        decode_trait,
                         quote! {
                             ::ink::env::return_value_solidity::<Self::Output>(
                                 flags,
@@ -429,10 +434,15 @@ impl Dispatch<'_> {
                     )
                 }
                 Abi::Sol => {
+                    let decode_trait = if input_bindings.len() == 1 {
+                        quote!(::ink::SolDecode)
+                    } else {
+                        quote!(::ink::primitives::sol::SolParamsDecode)
+                    };
                     (
                         sol::utils::selector_id(message),
                         quote!(::ink::abi::Abi::Sol),
-                        quote!(::ink::SolDecode),
+                        decode_trait,
                         quote! {
                             ::ink::env::return_value_solidity::<Self::Output>(
                                 flags,

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -249,7 +249,6 @@ impl Dispatch<'_> {
     ///
     /// These trait implementations store relevant dispatch information for every
     /// dispatchable ink! message of the ink! smart contract.
-    #[allow(clippy::vec_init_then_push)] // due to ABI conditional push to `message_infos` vec.
     fn generate_dispatchable_message_infos(&self) -> TokenStream2 {
         let span = self.contract.module().storage().span();
 

--- a/crates/ink/codegen/src/generator/item_impls.rs
+++ b/crates/ink/codegen/src/generator/item_impls.rs
@@ -91,16 +91,7 @@ impl ItemImpls<'_> {
                 #[cfg(ink_abi = "sol")]
                 let message_local_id = {
                     use crate::generator::sol;
-                    let ident_str = message.ident().to_string();
-                    let signature = sol::utils::call_signature(ident_str, message.inputs());
-                    let selector_bytes = quote! {
-                        ::ink::codegen::sol_selector_bytes(#signature)
-                    };
-                    quote!(
-                        {
-                            ::core::primitive::u32::from_be_bytes(#selector_bytes)
-                        }
-                    )
+                    sol::utils::selector_id(&message)
                 };
 
                 let message_guard_payable = message.is_payable().then(|| {

--- a/crates/ink/codegen/src/generator/macros.rs
+++ b/crates/ink/codegen/src/generator/macros.rs
@@ -20,9 +20,9 @@
 macro_rules! default_abi {
     () => {{
         if cfg!(ink_abi = "sol") {
-            quote!(::ink::reflect::SolEncoding)
+            quote!(::ink::abi::Sol)
         } else {
-            quote!(::ink::reflect::ScaleEncoding)
+            quote!(::ink::abi::Ink)
         }
     }};
 }
@@ -32,8 +32,8 @@ macro_rules! default_abi {
 /// # Note
 ///
 /// The ABI is passed to the callback function as an argument.
-/// The argument value can be either as an `ink_primitives::reflect::Encoding` variant,
-/// or tokens for `::ink::reflect::ScaleEncoding` or `::ink::reflect::SolEncoding`.
+/// The argument value can be either as an `ink_primitives::abi::Abi` variant,
+/// or tokens for `::ink::abi::Ink` or `::ink::abi::Sol`.
 macro_rules! for_each_abi {
     ($callback: expr, $ink_abi: expr, $sol_abi: expr) => {{
         #[cfg(not(ink_abi = "sol"))]
@@ -43,17 +43,13 @@ macro_rules! for_each_abi {
         $callback($sol_abi);
     }};
     (@tokens $callback: expr) => {
-        for_each_abi!(
-            $callback,
-            quote!(::ink::reflect::ScaleEncoding),
-            quote!(::ink::reflect::SolEncoding)
-        )
+        for_each_abi!($callback, quote!(::ink::abi::Ink), quote!(::ink::abi::Sol))
     };
     (@type $callback: expr) => {
         for_each_abi!(
             $callback,
-            ink_primitives::reflect::Encoding::Scale,
-            ink_primitives::reflect::Encoding::Solidity
+            ink_primitives::abi::Abi::Ink,
+            ink_primitives::abi::Abi::Sol
         )
     };
 }
@@ -65,17 +61,17 @@ macro_rules! for_each_abi {
 /// # Note
 ///
 /// The ABI is passed to the generator function as an argument.
-/// The argument value can be either as an `ink_primitives::reflect::Encoding` variant,
-/// or tokens for `::ink::reflect::ScaleEncoding` or `::ink::reflect::SolEncoding`.
+/// The argument value can be either as an `ink_primitives::abi::Abi` variant,
+/// or tokens for `::ink::abi::Ink` or `::ink::abi::Sol`.
 macro_rules! generate_abi_impls {
     ($generator: expr, $ink_abi: expr, $sol_abi: expr) => {{
         let mut abi_impls = Vec::new();
         for_each_abi!(@type |abi| {
             match abi {
-                ink_primitives::reflect::Encoding::Scale => {
+                ink_primitives::abi::Abi::Ink => {
                     abi_impls.push($generator($ink_abi));
                 },
-                ink_primitives::reflect::Encoding::Solidity => {
+                ink_primitives::abi::Abi::Sol => {
                     abi_impls.push($generator($sol_abi));
                 },
             }
@@ -87,15 +83,15 @@ macro_rules! generate_abi_impls {
     (@tokens $callback: expr) => {
         generate_abi_impls!(
             $callback,
-            quote!(::ink::reflect::ScaleEncoding),
-            quote!(::ink::reflect::SolEncoding)
+            quote!(::ink::abi::Ink),
+            quote!(::ink::abi::Sol)
         )
     };
     (@type $callback: expr) => {
         generate_abi_impls!(
             $callback,
-            ink_primitives::reflect::Encoding::Scale,
-            ink_primitives::reflect::Encoding::Solidity
+            ink_primitives::abi::Abi::Ink,
+            ink_primitives::abi::Abi::Sol
         )
     };
 }

--- a/crates/ink/codegen/src/generator/macros.rs
+++ b/crates/ink/codegen/src/generator/macros.rs
@@ -1,0 +1,101 @@
+// Copyright (C) Use Ink (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Returns the "default" ABI.
+///
+/// # Note
+///
+/// The "default" ABI is "ink" unless the ABI is specifically set to "sol".
+macro_rules! default_abi {
+    () => {{
+        if cfg!(ink_abi = "sol") {
+            quote!(::ink::reflect::SolEncoding)
+        } else {
+            quote!(::ink::reflect::ScaleEncoding)
+        }
+    }};
+}
+
+/// Calls the given callback function once for each enabled ABI.
+///
+/// # Note
+///
+/// The ABI is passed to the callback function as an argument.
+/// The argument value can be either as an `ink_primitives::reflect::Encoding` variant,
+/// or tokens for `::ink::reflect::ScaleEncoding` or `::ink::reflect::SolEncoding`.
+macro_rules! for_each_abi {
+    ($callback: expr, $ink_abi: expr, $sol_abi: expr) => {{
+        #[cfg(not(ink_abi = "sol"))]
+        $callback($ink_abi);
+
+        #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+        $callback($sol_abi);
+    }};
+    (@tokens $callback: expr) => {
+        for_each_abi!(
+            $callback,
+            quote!(::ink::reflect::ScaleEncoding),
+            quote!(::ink::reflect::SolEncoding)
+        )
+    };
+    (@type $callback: expr) => {
+        for_each_abi!(
+            $callback,
+            ink_primitives::reflect::Encoding::Scale,
+            ink_primitives::reflect::Encoding::Solidity
+        )
+    };
+}
+
+/// Generates code for all enabled ABIs by calling the given generator function for each
+/// enabled ABI, and returns a `TokenStream` combining all generated ABI specific code.
+/// with the ABI as an argument.
+///
+/// # Note
+///
+/// The ABI is passed to the generator function as an argument.
+/// The argument value can be either as an `ink_primitives::reflect::Encoding` variant,
+/// or tokens for `::ink::reflect::ScaleEncoding` or `::ink::reflect::SolEncoding`.
+macro_rules! generate_abi_impls {
+    ($generator: expr, $ink_abi: expr, $sol_abi: expr) => {{
+        let mut abi_impls = Vec::new();
+        for_each_abi!(@type |abi| {
+            match abi {
+                ink_primitives::reflect::Encoding::Scale => {
+                    abi_impls.push($generator($ink_abi));
+                },
+                ink_primitives::reflect::Encoding::Solidity => {
+                    abi_impls.push($generator($sol_abi));
+                },
+            }
+        });
+        quote! {
+            #( #abi_impls )*
+        }
+    }};
+    (@tokens $callback: expr) => {
+        generate_abi_impls!(
+            $callback,
+            quote!(::ink::reflect::ScaleEncoding),
+            quote!(::ink::reflect::SolEncoding)
+        )
+    };
+    (@type $callback: expr) => {
+        generate_abi_impls!(
+            $callback,
+            ink_primitives::reflect::Encoding::Scale,
+            ink_primitives::reflect::Encoding::Solidity
+        )
+    };
+}

--- a/crates/ink/codegen/src/generator/macros.rs
+++ b/crates/ink/codegen/src/generator/macros.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Returns the "default" ABI.
+/// Returns the "default" ABI for calls.
 ///
 /// # Note
 ///
-/// The "default" ABI is "ink" unless the ABI is specifically set to "sol".
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 macro_rules! default_abi {
     () => {{
         if cfg!(ink_abi = "sol") {

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -49,9 +49,7 @@ impl GenerateCode for Metadata<'_> {
         quote! {
             #[cfg(feature = "std")]
             #[cfg(not(feature = "ink-as-dependency"))]
-            // TODO: (@davidsemakula) Re-enable `cfg` gate when cargo contract is updated to use
-            // not use `scale_info::TypeInfo` for Solidity compatible metadata generation
-            //#[cfg(not(ink_abi = "sol"))]
+            #[cfg(not(ink_abi = "sol"))]
             const _: () = {
                 #[no_mangle]
                 pub fn __ink_generate_metadata() -> ::ink::metadata::InkProject  {

--- a/crates/ink/codegen/src/generator/mod.rs
+++ b/crates/ink/codegen/src/generator/mod.rs
@@ -26,6 +26,9 @@ macro_rules! impl_as_ref_for_generator {
     };
 }
 
+#[macro_use]
+mod macros;
+
 mod arg_list;
 mod as_dependency;
 mod blake2b;
@@ -38,7 +41,6 @@ mod ink_test;
 mod item_impls;
 mod metadata;
 mod selector;
-#[cfg(any(ink_abi = "sol", ink_abi = "all"))]
 mod sol;
 mod storage;
 mod storage_item;

--- a/crates/ink/codegen/src/generator/sol/utils.rs
+++ b/crates/ink/codegen/src/generator/sol/utils.rs
@@ -14,17 +14,12 @@
 
 use ir::{
     Callable,
-    CallableWithSelector,
     InputsIter,
     IsDocAttribute,
     Message,
 };
-use proc_macro2::{
-    Ident,
-    TokenStream as TokenStream2,
-};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{
-    format_ident,
     quote,
     quote_spanned,
 };
@@ -42,22 +37,20 @@ pub fn sol_type(ty: &Type) -> TokenStream2 {
 }
 
 /// Returns Solidity ABI compatible selector of an ink! message.
-pub fn selector(message: &CallableWithSelector<Message>) -> TokenStream2 {
-    let ident = call_info_type_ident(message);
-    quote!(
-        {
-            <__ink_sol_interop__::#ident>::SELECTOR
-        }
-    )
+pub fn selector(message: &Message) -> TokenStream2 {
+    let signature = call_signature(message.ident().to_string(), message.inputs());
+    quote! {
+        ::ink::codegen::sol::selector_bytes(#signature)
+    }
 }
 
 /// Returns a `u32` representation of the Solidity ABI compatible selector of an ink!
 /// message.
-pub fn selector_id(message: &CallableWithSelector<Message>) -> TokenStream2 {
-    let ident = call_info_type_ident(message);
+pub fn selector_id(message: &Message) -> TokenStream2 {
+    let selector_bytes = selector(message);
     quote!(
         {
-            <__ink_sol_interop__::#ident>::SELECTOR_ID
+            ::core::primitive::u32::from_be_bytes(#selector_bytes)
         }
     )
 }
@@ -83,15 +76,8 @@ pub fn call_signature(name: String, inputs: InputsIter) -> TokenStream2 {
         .join(",");
     let sig_fmt_lit = format!("{{}}({})", sig_arg_fmt_params);
     quote! {
-        ::ink::codegen::const_format!(#sig_fmt_lit, #name #(,#sig_param_tys)*)
+        ::ink::codegen::utils::const_format!(#sig_fmt_lit, #name #(,#sig_param_tys)*)
     }
-}
-
-/// Returns the Solidity call info type identifier for an ink! message.
-pub fn call_info_type_ident(message: &CallableWithSelector<Message>) -> Ident {
-    let ident = message.ident();
-    let id = message.composed_selector().into_be_u32();
-    format_ident!("{ident}{id}Call")
 }
 
 /// Returns the rustdoc string from the given item attributes.

--- a/crates/ink/codegen/src/generator/sol/utils.rs
+++ b/crates/ink/codegen/src/generator/sol/utils.rs
@@ -40,7 +40,9 @@ pub fn sol_type(ty: &Type) -> TokenStream2 {
 pub fn selector(message: &Message) -> TokenStream2 {
     let signature = call_signature(message.ident().to_string(), message.inputs());
     quote! {
-        ::ink::codegen::sol::selector_bytes(#signature)
+        const {
+            ::ink::codegen::sol::selector_bytes(#signature)
+        }
     }
 }
 
@@ -50,7 +52,9 @@ pub fn selector_id(message: &Message) -> TokenStream2 {
     let selector_bytes = selector(message);
     quote!(
         {
-            ::core::primitive::u32::from_be_bytes(#selector_bytes)
+            const {
+                ::core::primitive::u32::from_be_bytes(#selector_bytes)
+            }
         }
     )
 }

--- a/crates/ink/codegen/src/generator/trait_def/message_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/message_builder.rs
@@ -251,7 +251,7 @@ impl MessageBuilder<'_> {
             let signature =
                 sol::utils::call_signature(message_ident.to_string(), message.inputs());
             let selector_bytes = quote! {
-                ::ink::codegen::sol_selector_bytes(#signature)
+                ::ink::codegen::sol::selector_bytes(#signature)
             };
             call_builders.push(generate_builder(
                 &sol_message_ident,

--- a/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
@@ -360,7 +360,7 @@ impl TraitRegistry<'_> {
             let ident_str = message.ident().to_string();
             let signature = sol::utils::call_signature(ident_str, message.inputs());
             let selector_bytes = quote! {
-                ::ink::codegen::sol_selector_bytes(#signature)
+                ::ink::codegen::sol::selector_bytes(#signature)
             };
             let selector_id = quote!(
                 {

--- a/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
@@ -20,7 +20,7 @@
 //! types for the trait's respective call builder and call forwarder.
 
 use derive_more::From;
-use ink_primitives::reflect::Encoding;
+use ink_primitives::abi::Abi;
 use proc_macro2::{
     Span,
     TokenStream as TokenStream2,
@@ -338,7 +338,7 @@ impl TraitRegistry<'_> {
         let is_payable = message.ink_attrs().is_payable();
         generate_abi_impls!(@type |abi| {
             let (local_id, selector_bytes) = match abi {
-                Encoding::Scale => {
+                Abi::Ink => {
                     let local_id = message.local_id();
                     let selector_bytes = selector.hex_lits();
                     (
@@ -346,7 +346,7 @@ impl TraitRegistry<'_> {
                         quote!([ #( #selector_bytes ),* ])
                     )
                 }
-                Encoding::Solidity => {
+                Abi::Sol => {
                     let ident_str = message.ident().to_string();
                     let signature = sol::utils::call_signature(ident_str, message.inputs());
                     let selector_bytes = quote! {

--- a/crates/ink/ir/src/ir/config.rs
+++ b/crates/ink/ir/src/ir/config.rs
@@ -112,32 +112,6 @@ impl Default for Environment {
     }
 }
 
-/// ABI spec for encoding/decoding contract calls.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Abi {
-    /// ink! ABI spec (the default, uses the SCALE codec for input/output encode/decode).
-    #[default]
-    Ink,
-    /// Solidity ABI spec.
-    Solidity,
-    /// Support both ink! and Solidity ABI specs for each contract entry point.
-    All,
-}
-
-impl Abi {
-    pub fn is_ink(&self) -> bool {
-        matches!(self, Self::Ink | Self::All)
-    }
-
-    pub fn is_solidity(&self) -> bool {
-        matches!(self, Self::Solidity | Self::All)
-    }
-
-    pub fn is_all(&self) -> bool {
-        matches!(self, Self::All)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ink/ir/src/ir/mod.rs
+++ b/crates/ink/ir/src/ir/mod.rs
@@ -69,10 +69,7 @@ pub use self::{
         ChainExtensionMethod,
         ExtensionId,
     },
-    config::{
-        Abi,
-        Config,
-    },
+    config::Config,
     contract::Contract,
     event::{
         Event,

--- a/crates/ink/ir/src/lib.rs
+++ b/crates/ink/ir/src/lib.rs
@@ -44,7 +44,6 @@ pub use self::{
         blake2b_256,
         marker,
         utils,
-        Abi,
         Blake2x256Macro,
         Callable,
         CallableKind,

--- a/crates/ink/src/codegen/dispatch/info.rs
+++ b/crates/ink/src/codegen/dispatch/info.rs
@@ -18,5 +18,5 @@
 /// for all inherent or trait ink! messages.
 pub trait ContractCallBuilder {
     /// The generated contract call builder type.
-    type Type;
+    type Type<Abi>;
 }

--- a/crates/ink/src/codegen/dispatch/mod.rs
+++ b/crates/ink/src/codegen/dispatch/mod.rs
@@ -21,6 +21,8 @@ pub use self::{
     info::ContractCallBuilder,
     type_check::{
         DispatchInput,
+        DispatchInputSol,
         DispatchOutput,
+        DispatchOutputSol,
     },
 };

--- a/crates/ink/src/codegen/dispatch/type_check.rs
+++ b/crates/ink/src/codegen/dispatch/type_check.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_primitives::{
+    SolDecode,
+    SolEncode,
+};
+
 /// Used to check if `T` is allowed as ink! input parameter type.
 ///
 /// # Note
@@ -67,3 +72,59 @@ where
 pub struct DispatchOutput<T>(T)
 where
     T: scale::Encode + 'static;
+
+/// Used to check if `T` is allowed as ink! input parameter type.
+///
+/// # Note
+///
+/// An ink! input parameter type must implement [`ink::SolDecode`]
+/// and must have a `'static` lifetime.
+///
+/// # Example
+///
+/// This compiles since `i32` fulfills the requirements of an ink! input.
+///
+/// ```
+/// # use ink::codegen::DispatchInputSol;
+/// const _: () = ink::codegen::utils::consume_type::<DispatchInputSol<i32>>();
+/// ```
+///
+/// This fails to compile since `Foo` does not fulfill all requirements.
+///
+/// ```compile_fail
+/// # use ink::codegen::DispatchInputSol;
+/// // Foo is missing scale codec implementations.
+/// struct Foo {}
+/// const _: () = ink::codegen::utils::consume_type::<DispatchInputSol<Foo>>();
+/// ```
+pub struct DispatchInputSol<T>(T)
+where
+    T: SolDecode + 'static;
+
+/// Used to check if `T` is allowed as ink! output parameter type.
+///
+/// # Note
+///
+/// An ink! input parameter type must implement [`ink::SolEncode`]
+/// and must have a `'static` lifetime.
+///
+/// # Example
+///
+/// This compiles since `i32` fulfills the requirements of an ink! output.
+///
+/// ```
+/// # use ink::codegen::DispatchOutputSol;
+/// const _: () = ink::codegen::utils::consume_type::<DispatchOutputSol<i32>>();
+/// ```
+///
+/// This fails to compile since `Foo` does not fulfill all requirements.
+///
+/// ```compile_fail
+/// # use ink::codegen::DispatchOutputSol;
+/// // Foo is missing scale codec implementations.
+/// struct Foo {}
+/// const _: () = ink::codegen::utils::consume_type::<DispatchOutputSol<Foo>>();
+/// ```
+pub struct DispatchOutputSol<T>(T)
+where
+    T: for<'a> SolEncode<'a> + 'static;

--- a/crates/ink/src/codegen/mod.rs
+++ b/crates/ink/src/codegen/mod.rs
@@ -26,7 +26,9 @@ pub use self::{
         deny_payment,
         ContractCallBuilder,
         DispatchInput,
+        DispatchInputSol,
         DispatchOutput,
+        DispatchOutputSol,
     },
     env::{
         Env,

--- a/crates/ink/src/codegen/mod.rs
+++ b/crates/ink/src/codegen/mod.rs
@@ -17,7 +17,7 @@
 mod dispatch;
 mod env;
 mod implies_return;
-mod solidity_compat;
+pub mod sol;
 mod trait_def;
 pub mod utils;
 
@@ -33,10 +33,6 @@ pub use self::{
         StaticEnv,
     },
     implies_return::ImpliesReturn,
-    solidity_compat::{
-        const_format,
-        sol_selector_bytes,
-    },
     trait_def::{
         TraitCallBuilder,
         TraitCallForwarder,

--- a/crates/ink/src/codegen/sol.rs
+++ b/crates/ink/src/codegen/sol.rs
@@ -14,20 +14,11 @@
 
 use keccak_const::Keccak256;
 
-/// Compile-time `format!`-like macro that returns `&'static str`.
-///
-/// The first argument is a format string which can be a `String` (i.e. doesn't have
-/// to be a literal). Like `format!` the format string can contain `{}`s which are
-/// replace by the additional parameters which must all be constant expressions.
-///
-/// See [`const_format::formatc`] for details.
-pub use const_format::formatc as const_format;
-
 /// Compile-time Solidity selector computation.
 ///
 /// Takes function signature as a string and returns a 4 byte representation of the
 /// selector.
-pub const fn sol_selector_bytes(sig: &str) -> [u8; 4] {
+pub const fn selector_bytes(sig: &str) -> [u8; 4] {
     let hash = Keccak256::new().update(sig.as_bytes()).finalize();
     [hash[0], hash[1], hash[2], hash[3]]
 }

--- a/crates/ink/src/codegen/trait_def/call_builder.rs
+++ b/crates/ink/src/codegen/trait_def/call_builder.rs
@@ -15,7 +15,7 @@
 /// Access the trait message builder implementation.
 pub trait TraitMessageBuilder {
     /// The message builder type.
-    type MessageBuilder: Default;
+    type MessageBuilder<Abi>: Default;
 }
 
 /// The global call builder type for an ink! trait definition.
@@ -42,7 +42,7 @@ pub trait TraitCallBuilder {
 /// to this trait in `ink-as-dependency` configuration.
 pub trait TraitCallForwarder {
     /// The call forwarder type.
-    type Forwarder: TraitCallBuilder;
+    type Forwarder<Abi>: TraitCallBuilder;
 }
 
 /// Implemented by call builders of smart contracts.

--- a/crates/ink/src/codegen/utils/mod.rs
+++ b/crates/ink/src/codegen/utils/mod.rs
@@ -21,3 +21,12 @@ pub use self::{
     identity_type::consume_type,
     same_type::IsSameType,
 };
+
+/// Compile-time `format!`-like macro that returns `&'static str`.
+///
+/// The first argument is a format string which can be a `String` (i.e. doesn't have
+/// to be a literal). Like `format!` the format string can contain `{}`s which are
+/// replace by the additional parameters which must all be constant expressions.
+///
+/// See [`const_format::formatc`] for details.
+pub use const_format::formatc as const_format;

--- a/crates/ink/src/contract_ref.rs
+++ b/crates/ink/src/contract_ref.rs
@@ -117,11 +117,16 @@ use ink_primitives::Address;
 ///
 /// # Usage outside the `#[ink::contract]` context
 ///
-/// The macro expects two arguments:
+/// The macro expects up to three arguments:
 /// - The first argument is the path to the trait, e.g. `Erc20` or `erc20::Erc20`.
 /// - The second argument is the type of the [`ink_env::Environment`].
+/// - The third argument is the marker type for the ABI (i.e. [`ink::abi::Ink`] or
+///   [`ink::abi::Sol`]).
 ///
 /// If the second argument is not specified, the macro uses the `Environment` type alias.
+/// If the third argument is not specified, the macro uses the "default" ABI,
+/// which depending on the ABI specified in the project's manifest
+/// (see https://use.ink/docs/v6/basics/abi/ for details).
 ///
 /// ```rust
 /// use ink::contract_ref;
@@ -156,6 +161,7 @@ use ink_primitives::Address;
 /// type AliasWithDefaultEnv = contract_ref!(Erc20, DefaultEnvironment);
 /// type AliasWithCustomEnv = contract_ref!(Erc20, CustomEnv);
 /// type AliasWithGenericEnv<E> = contract_ref!(Erc20, E);
+/// type AliasWithCustomAbi = contract_ref!(Erc20, DefaultEnvironment, ink::abi::Ink);
 ///
 /// fn default(mut contract: contract_ref!(Erc20, DefaultEnvironment)) {
 ///     let total_supply = contract.total_supply();
@@ -192,6 +198,15 @@ use ink_primitives::Address;
 ///     A: Into<Address> + Clone,
 /// {
 ///     generic(contract)
+/// }
+///
+/// fn custom_abi(mut contract: contract_ref!(Erc20, DefaultEnvironment, ink::abi::Ink)) {
+///     let total_supply = contract.total_supply();
+///     contract.transfer(total_supply, contract.as_ref().clone());
+/// }
+///
+/// fn custom_alias_abi(mut contract: AliasWithCustomAbi) {
+///     custom_abi(contract)
 /// }
 ///
 /// type Environment = DefaultEnvironment;

--- a/crates/ink/src/contract_ref.rs
+++ b/crates/ink/src/contract_ref.rs
@@ -204,14 +204,18 @@ use ink_primitives::Address;
 /// ```
 #[macro_export]
 macro_rules! contract_ref {
-    // The case of the default `Environment`
+    // The case of the default `Environment` and ABI
     ( $trait_path:path ) => {
         $crate::contract_ref!($trait_path, Environment)
     };
-    // The case of the custom `Environment`
+    // The case of the custom `Environment` and default ABI
     ( $trait_path:path, $env:ty ) => {
+        $crate::contract_ref!($trait_path, $env, $crate::env::DefaultAbi)
+    };
+    // The case of the custom `Environment` and ABI
+    ( $trait_path:path, $env:ty, $abi:ty ) => {
         <<$crate::reflect::TraitDefinitionRegistry<$env> as $trait_path>
-                    ::__ink_TraitInfo as $crate::codegen::TraitCallForwarder>::Forwarder
+                    ::__ink_TraitInfo as $crate::codegen::TraitCallForwarder>::Forwarder<$abi>
     };
 }
 

--- a/crates/ink/src/contract_ref.rs
+++ b/crates/ink/src/contract_ref.rs
@@ -124,9 +124,13 @@ use ink_primitives::Address;
 ///   [`ink::abi::Sol`]).
 ///
 /// If the second argument is not specified, the macro uses the `Environment` type alias.
-/// If the third argument is not specified, the macro uses the "default" ABI,
-/// which depending on the ABI specified in the project's manifest
-/// (see https://use.ink/docs/v6/basics/abi/ for details).
+/// If the third argument is not specified, the macro uses the "default" ABI for calls
+/// for the ink! project.
+///
+/// # Note
+///
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 ///
 /// ```rust
 /// use ink::contract_ref;

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ChainExtensionInstance;
 use core::marker::PhantomData;
+
 #[cfg(feature = "unstable-hostfn")]
 use ink_env::call::{
     ConstructorReturnType,
@@ -36,9 +36,9 @@ use ink_env::{
     Result,
 };
 #[cfg(feature = "unstable-hostfn")]
-use ink_primitives::reflect::ScaleEncoding;
+use ink_primitives::abi::Ink;
 use ink_primitives::{
-    reflect::{
+    abi::{
         AbiDecodeWith,
         AbiEncodeWith,
     },
@@ -47,6 +47,8 @@ use ink_primitives::{
     U256,
 };
 use pallet_revive_uapi::ReturnErrorCode;
+
+use crate::ChainExtensionInstance;
 
 /// The API behind the `self.env()` and `Self::env()` syntax in ink!.
 ///
@@ -501,7 +503,7 @@ where
         <ContractRef as ink_env::ContractReverseReference>::Type:
             ink_env::reflect::ContractConstructorDecoder,
 
-        Args: AbiEncodeWith<ScaleEncoding>,
+        Args: AbiEncodeWith<Ink>,
         R: ConstructorReturnType<ContractRef>,
     {
         ink_env::instantiate_contract::<E, ContractRef, Args, R>(params)

--- a/crates/ink/src/lib.rs
+++ b/crates/ink/src/lib.rs
@@ -41,6 +41,7 @@ pub use ink_env as env;
 pub use ink_metadata as metadata;
 pub use ink_prelude as prelude;
 pub use ink_primitives as primitives;
+pub use ink_primitives::abi;
 pub use scale;
 #[cfg(feature = "std")]
 pub use scale_info;

--- a/crates/ink/src/message_builder.rs
+++ b/crates/ink/src/message_builder.rs
@@ -101,8 +101,8 @@
 ///         input: &ExecutionInput<Args, Abi>,
 ///     ) -> Result<MessageResult<Output>, Self::Error>
 ///     where
-///         Args: ink::reflect::AbiEncodeWith<Abi>,
-///         Output: ink::reflect::AbiDecodeWith<Abi>,
+///         Args: ink::abi::AbiEncodeWith<Abi>,
+///         Output: ink::abi::AbiDecodeWith<Abi>,
 ///     {
 ///         println!("Executing contract with input: {:?}", input.encode());
 ///         unimplemented!("Decode contract execution output")

--- a/crates/ink/src/message_builder.rs
+++ b/crates/ink/src/message_builder.rs
@@ -35,9 +35,13 @@
 ///
 /// If the second argument is not specified, the macro uses the
 /// [`ink_env::DefaultEnvironment`].
-/// If the third argument is not specified, the macro uses the "default" ABI,
-/// which depending on the ABI specified in the project's manifest
-/// (see https://use.ink/docs/v6/basics/abi/ for details).
+/// If the third argument is not specified, the macro uses the "default" ABI for calls
+/// for the ink! project.
+///
+/// # Note
+///
+/// The "default" ABI for calls is "ink", unless the ABI is set to "sol"
+/// in the ink! project's manifest file (i.e. `Cargo.toml`).
 ///
 /// ```rust
 /// use ink::message_builder;

--- a/crates/ink/src/message_builder.rs
+++ b/crates/ink/src/message_builder.rs
@@ -135,15 +135,19 @@
 /// ```
 #[macro_export]
 macro_rules! message_builder {
-    // The case of the default `Environment`
+    // The case of the default `Environment` and ABI
     ( $trait_path:path ) => {
         $crate::message_builder!($trait_path, $crate::env::DefaultEnvironment)
     };
-    // The case of the custom `Environment`
+    // The case of the custom `Environment` and default ABI
     ( $trait_path:path, $env:ty ) => {
+        $crate::message_builder!($trait_path, $env, $crate::env::DefaultAbi)
+    };
+    // The case of the custom `Environment` and ABI
+    ( $trait_path:path, $env:ty, $abi:ty ) => {
         <<<$crate::reflect::TraitDefinitionRegistry<$env>
                             as $trait_path>::__ink_TraitInfo
-                            as $crate::codegen::TraitMessageBuilder>::MessageBuilder
+                            as $crate::codegen::TraitMessageBuilder>::MessageBuilder<$abi>
                             as ::core::default::Default>::default()
     };
 }

--- a/crates/ink/src/message_builder.rs
+++ b/crates/ink/src/message_builder.rs
@@ -27,12 +27,17 @@
 ///
 /// # Usage
 ///
-/// The macro expects two arguments:
+/// The macro expects up to three arguments:
 /// - The first argument is the path to the trait, e.g. `Erc20` or `erc20::Erc20`.
 /// - The second argument is the type of the [`ink_env::Environment`].
+/// - The third argument is the marker type for the ABI (i.e. [`ink::abi::Ink`] or
+///   [`ink::abi::Sol`]).
 ///
 /// If the second argument is not specified, the macro uses the
 /// [`ink_env::DefaultEnvironment`].
+/// If the third argument is not specified, the macro uses the "default" ABI,
+/// which depending on the ABI specified in the project's manifest
+/// (see https://use.ink/docs/v6/basics/abi/ for details).
 ///
 /// ```rust
 /// use ink::message_builder;
@@ -119,6 +124,13 @@
 /// fn custom(to: Address) {
 ///     let executor = ExampleExecutor::<CustomEnv>::new();
 ///     let mut contract = message_builder!(Erc20, CustomEnv);
+///     let total_supply = contract.total_supply().exec(&executor).unwrap().unwrap();
+///     contract.transfer(total_supply, to).exec(&executor).unwrap();
+/// }
+///
+/// fn custom_abi(to: Address) {
+///     let executor = ExampleExecutor::<DefaultEnvironment>::new();
+///     let mut contract = message_builder!(Erc20, DefaultEnvironment, ink::abi::Ink);
 ///     let total_supply = contract.total_supply().exec(&executor).unwrap().unwrap();
 ///     contract.transfer(total_supply, to).exec(&executor).unwrap();
 /// }

--- a/crates/ink/tests/ui/contract/fail/message/message-input-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message/message-input-non-codec.stderr
@@ -50,7 +50,7 @@ note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, Arg
    |         T: AbiEncodeWith<Abi>,
    |            ^^^^^^^^^^^^^^^^^^ required by this bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd, Abi>, Abi>::push_arg`
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call>, Set<ExecutionInput<ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>, ScaleEncoding>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call>, Set<ExecutionInput<ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, Ink>, Ink>, Ink>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
   --> tests/ui/contract/fail/message/message-input-non-codec.rs:18:9
    |
 18 |         pub fn message(&self, _input: NonCodecType) {}
@@ -59,8 +59,8 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
   ::: $WORKSPACE/crates/env/src/call/execution.rs
    |
    | pub struct ArgumentList<Head, Rest, Abi> {
-   | ---------------------------------------- doesn't satisfy `_: AbiEncodeWith<ScaleEncoding>` or `_: Encode`
+   | ---------------------------------------- doesn't satisfy `_: AbiEncodeWith<Ink>` or `_: Encode`
    |
    = note: the following trait bounds were not satisfied:
-           `ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>: Encode`
-           which is required by `ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>: AbiEncodeWith<ScaleEncoding>`
+           `ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>: Encode`
+           which is required by `ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>: AbiEncodeWith<ink::abi::Ink>`

--- a/crates/ink/tests/ui/contract/fail/message/message-returns-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message/message-returns-non-codec.stderr
@@ -25,28 +25,27 @@ note: required by a bound in `DispatchOutput`
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
 error[E0277]: the trait bound `Result<NonCodecType, LangError>: Encode` is not satisfied
-  --> tests/ui/contract/fail/message/message-returns-non-codec.rs:18:9
-   |
-18 | /         pub fn message(&self) -> NonCodecType {
-19 | |             NonCodecType
-20 | |         }
-   | |_________^ the trait `Encode` is not implemented for `Result<NonCodecType, LangError>`
-   |
-   = help: the trait `Encode` is implemented for `Result<T, E>`
+ --> tests/ui/contract/fail/message/message-returns-non-codec.rs:3:1
+  |
+3 | #[ink::contract]
+  | ^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Result<NonCodecType, LangError>`
+  |
+  = help: the trait `Encode` is implemented for `Result<T, E>`
 note: required by a bound in `return_value`
-  --> $WORKSPACE/crates/env/src/api.rs
-   |
-   | pub fn return_value<R>(return_flags: ReturnFlags, return_value: &R)
-   |        ------------ required by a bound in this function
-   | where
-   |     R: scale::Encode,
-   |        ^^^^^^^^^^^^^ required by this bound in `return_value`
+ --> $WORKSPACE/crates/env/src/api.rs
+  |
+  | pub fn return_value<R>(return_flags: ReturnFlags, return_value: &R)
+  |        ------------ required by a bound in this function
+  | where
+  |     R: scale::Encode,
+  |        ^^^^^^^^^^^^^ required by this bound in `return_value`
+  = note: this error originates in the attribute macro `ink::contract` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd, Ink>, Ink>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
   --> tests/ui/contract/fail/message/message-returns-non-codec.rs:18:9
    |
 6  |       pub struct NonCodecType;
-   |       ----------------------- doesn't satisfy `NonCodecType: AbiDecodeWith<ScaleEncoding>`, `NonCodecType: DecodeMessageResult<ScaleEncoding>` or `NonCodecType: WrapperTypeDecode`
+   |       ----------------------- doesn't satisfy `NonCodecType: AbiDecodeWith<ink::abi::Ink>`, `NonCodecType: DecodeMessageResult<ink::abi::Ink>` or `NonCodecType: WrapperTypeDecode`
 ...
 18 | /         pub fn message(&self) -> NonCodecType {
 19 | |             NonCodecType
@@ -60,9 +59,9 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
    |
    = note: the following trait bounds were not satisfied:
            `Result<NonCodecType, LangError>: ink::parity_scale_codec::Decode`
-           which is required by `NonCodecType: DecodeMessageResult<ScaleEncoding>`
+           which is required by `NonCodecType: DecodeMessageResult<ink::abi::Ink>`
            `NonCodecType: WrapperTypeDecode`
-           which is required by `NonCodecType: AbiDecodeWith<ScaleEncoding>`
+           which is required by `NonCodecType: AbiDecodeWith<ink::abi::Ink>`
 note: the trait `WrapperTypeDecode` must be implemented
   --> $CARGO/parity-scale-codec-3.7.4/src/codec.rs
    |

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-1.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-1.stderr
@@ -7,7 +7,7 @@ error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1083
 43 |         fn message(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
 
-error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1083895717>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1083895717>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-1.rs:41:5
    |
 36 | /     impl TraitDefinition1 for Contract {
@@ -20,7 +20,7 @@ error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<108389
 42 | |         #[ink(message)]
 43 | |         fn message(&self) {}
 44 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+   | |_____^ conflicting implementation for `contract::_::CallBuilder<ink::abi::Ink>`
 
 error[E0283]: type annotations needed
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-1.rs:19:1

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-2.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-2.stderr
@@ -7,7 +7,7 @@ error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1518
 43 |         fn message(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
 
-error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1518209067>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1518209067>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-2.rs:41:5
    |
 36 | /     impl TraitDefinition1 for Contract {
@@ -20,7 +20,7 @@ error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<151820
 42 | |         #[ink(message)]
 43 | |         fn message(&self) {}
 44 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+   | |_____^ conflicting implementation for `contract::_::CallBuilder<ink::abi::Ink>`
 
 error[E0283]: type annotations needed
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-2.rs:19:1

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-3.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-3.stderr
@@ -7,7 +7,7 @@ error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<42>`
 43 |         fn message2(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
 
-error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<42>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<42>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-3.rs:41:5
    |
 36 | /     impl TraitDefinition1 for Contract {
@@ -20,7 +20,7 @@ error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<42>` f
 42 | |         #[ink(message)]
 43 | |         fn message2(&self) {}
 44 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+   | |_____^ conflicting implementation for `contract::_::CallBuilder<ink::abi::Ink>`
 
 error[E0283]: type annotations needed
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-3.rs:19:1

--- a/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
@@ -38,18 +38,18 @@ note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, Arg
   |         T: AbiEncodeWith<Abi>,
   |            ^^^^^^^^^^^^^^^^^^ required by this bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd, Abi>, Abi>::push_arg`
 
-error[E0277]: the trait bound `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>: AbiEncodeWith<ScaleEncoding>` is not satisfied
+error[E0277]: the trait bound `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>: AbiEncodeWith<ink::abi::Ink>` is not satisfied
  --> tests/ui/trait_def/fail/message_input_non_codec.rs:5:5
   |
 5 | /     #[ink(message)]
 6 | |     fn message(&self, input: NonCodec);
   | |_______________________________________^ unsatisfied trait bound
   |
-  = help: the trait `Encode` is not implemented for `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>`
+  = help: the trait `Encode` is not implemented for `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>`
   = help: the following other types implement trait `Encode`:
-            ArgumentList<Argument<Head>, Rest, ScaleEncoding>
-            ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>
-  = note: required for `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>` to implement `AbiEncodeWith<ScaleEncoding>`
+            ArgumentList<Argument<Head>, Rest, ink::abi::Ink>
+            ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>
+  = note: required for `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>` to implement `AbiEncodeWith<ink::abi::Ink>`
 note: required by a bound in `Execution::<Args, Output, Abi>::new`
  --> $WORKSPACE/crates/env/src/call/execution.rs
   |
@@ -59,7 +59,7 @@ note: required by a bound in `Execution::<Args, Output, Abi>::new`
   |     pub fn new(input: ExecutionInput<Args, Abi>) -> Self {
   |            --- required by a bound in this associated function
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call>, Set<ExecutionInput<ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>, ScaleEncoding>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call>, Set<ExecutionInput<ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, Ink>, Ink>, Ink>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
  --> tests/ui/trait_def/fail/message_input_non_codec.rs:5:5
   |
 5 |       #[ink(message)]
@@ -70,8 +70,8 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
  ::: $WORKSPACE/crates/env/src/call/execution.rs
   |
   |   pub struct ArgumentList<Head, Rest, Abi> {
-  |   ---------------------------------------- doesn't satisfy `_: AbiEncodeWith<ScaleEncoding>` or `_: Encode`
+  |   ---------------------------------------- doesn't satisfy `_: AbiEncodeWith<Ink>` or `_: Encode`
   |
   = note: the following trait bounds were not satisfied:
-          `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>: Encode`
-          which is required by `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>: AbiEncodeWith<ScaleEncoding>`
+          `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>: Encode`
+          which is required by `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd, ink::abi::Ink>, ink::abi::Ink>: AbiEncodeWith<ink::abi::Ink>`

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `Result<NonCodec, LangError>: ink::parity_scale_co
   | |__________________________________^ the trait `ink::parity_scale_codec::Decode` is not implemented for `Result<NonCodec, LangError>`
   |
   = help: the trait `ink::parity_scale_codec::Decode` is implemented for `Result<T, E>`
-  = note: required for `NonCodec` to implement `DecodeMessageResult<ScaleEncoding>`
+  = note: required for `NonCodec` to implement `DecodeMessageResult<ink::abi::Ink>`
 note: required by a bound in `Execution::<Args, Output, Abi>::new`
  --> $WORKSPACE/crates/env/src/call/execution.rs
   |
@@ -42,7 +42,7 @@ note: required by a bound in `Execution::<Args, Output, Abi>::new`
   |     pub fn new(input: ExecutionInput<Args, Abi>) -> Self {
   |            --- required by a bound in this associated function
 
-error[E0277]: the trait bound `NonCodec: AbiDecodeWith<ScaleEncoding>` is not satisfied
+error[E0277]: the trait bound `NonCodec: AbiDecodeWith<ink::abi::Ink>` is not satisfied
  --> tests/ui/trait_def/fail/message_output_non_codec.rs:5:5
   |
 5 | /     #[ink(message)]
@@ -55,7 +55,7 @@ error[E0277]: the trait bound `NonCodec: AbiDecodeWith<ScaleEncoding>` is not sa
             Rc<T>
             sp_core::Bytes
   = note: required for `NonCodec` to implement `ink::parity_scale_codec::Decode`
-  = note: required for `NonCodec` to implement `AbiDecodeWith<ScaleEncoding>`
+  = note: required for `NonCodec` to implement `AbiDecodeWith<ink::abi::Ink>`
 note: required by a bound in `Execution::<Args, Output, Abi>::new`
  --> $WORKSPACE/crates/env/src/call/execution.rs
   |
@@ -65,11 +65,11 @@ note: required by a bound in `Execution::<Args, Output, Abi>::new`
   |     pub fn new(input: ExecutionInput<Args, Abi>) -> Self {
   |            --- required by a bound in this associated function
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd, ScaleEncoding>, ScaleEncoding>>, Set<ReturnType<NonCodec>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd, Ink>, Ink>>, Set<ReturnType<NonCodec>>>`, but its trait bounds were not satisfied
  --> tests/ui/trait_def/fail/message_output_non_codec.rs:5:5
   |
 1 |   pub struct NonCodec;
-  |   ------------------- doesn't satisfy `NonCodec: AbiDecodeWith<ScaleEncoding>`, `NonCodec: DecodeMessageResult<ScaleEncoding>` or `NonCodec: WrapperTypeDecode`
+  |   ------------------- doesn't satisfy `NonCodec: AbiDecodeWith<ink::abi::Ink>`, `NonCodec: DecodeMessageResult<ink::abi::Ink>` or `NonCodec: WrapperTypeDecode`
 ...
 5 |       #[ink(message)]
   |  _____^
@@ -83,9 +83,9 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   |
   = note: the following trait bounds were not satisfied:
           `Result<NonCodec, LangError>: ink::parity_scale_codec::Decode`
-          which is required by `NonCodec: DecodeMessageResult<ScaleEncoding>`
+          which is required by `NonCodec: DecodeMessageResult<ink::abi::Ink>`
           `NonCodec: WrapperTypeDecode`
-          which is required by `NonCodec: AbiDecodeWith<ScaleEncoding>`
+          which is required by `NonCodec: AbiDecodeWith<ink::abi::Ink>`
 note: the trait `WrapperTypeDecode` must be implemented
  --> $CARGO/parity-scale-codec-3.7.4/src/codec.rs
   |

--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -22,7 +22,7 @@ use crate::sol::{
 };
 
 /// ABI spec for encoding/decoding contract calls.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Abi {
     /// ink! ABI spec (uses Parity's SCALE codec for input/output encode/decode).
     Ink,

--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -1,0 +1,115 @@
+// Copyright (C) ink! contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Abstractions for ABI representation and encoding/decoding.
+
+use ink_prelude::vec::Vec;
+
+use crate::sol::{
+    SolDecode,
+    SolEncode,
+};
+
+/// ABI spec for encoding/decoding contract calls.
+#[derive(Debug, Clone, Copy)]
+pub enum Abi {
+    /// ink! ABI spec (uses Parity's SCALE codec for input/output encode/decode).
+    Ink,
+    /// Solidity ABI encoding.
+    Sol,
+}
+
+/// Marker type for ink! ABI and SCALE encoding.
+///
+/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Ink;
+
+/// Marker type for Solidity ABI.
+///
+/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Sol;
+
+/// Trait for ABI-specific encoding with support for both slice and vector buffers.
+pub trait AbiEncodeWith<Abi> {
+    /// Encodes the data into a fixed-size buffer, returning the number of bytes written.
+    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize;
+
+    /// Encodes the data into a dynamically resizing vector.
+    fn encode_to_vec(&self, buffer: &mut Vec<u8>);
+}
+
+/// Trait for ABI-specific decoding.
+pub trait AbiDecodeWith<Abi>: Sized {
+    /// The error type that can occur during decoding.
+    type Error: core::fmt::Debug;
+    /// Decodes the data from a buffer using the provided ABI.
+    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error>;
+}
+
+impl<T: scale::Encode> AbiEncodeWith<Ink> for T {
+    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize {
+        let encoded = scale::Encode::encode(self);
+        let len = encoded.len();
+        debug_assert!(
+            len <= buffer.len(),
+            "encode scope buffer overflowed, encoded len is {} but buffer len is {}",
+            len,
+            buffer.len()
+        );
+        buffer[..len].copy_from_slice(&encoded);
+        len
+    }
+
+    fn encode_to_vec(&self, buffer: &mut Vec<u8>) {
+        scale::Encode::encode_to(self, buffer);
+    }
+}
+
+impl<T: scale::Decode> AbiDecodeWith<Ink> for T {
+    type Error = scale::Error;
+    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error> {
+        scale::Decode::decode(&mut &buffer[..])
+    }
+}
+
+impl<T> AbiEncodeWith<Sol> for T
+where
+    T: for<'a> SolEncode<'a>,
+{
+    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize {
+        let encoded = T::encode(self);
+        let len = encoded.len();
+        debug_assert!(
+            len <= buffer.len(),
+            "encode scope buffer overflowed, encoded len is {} but buffer len is {}",
+            len,
+            buffer.len()
+        );
+        buffer[..len].copy_from_slice(&encoded);
+        len
+    }
+
+    fn encode_to_vec(&self, buffer: &mut Vec<u8>) {
+        buffer.extend_from_slice(&T::encode(self));
+    }
+}
+
+impl<T: SolDecode> AbiDecodeWith<Sol> for T {
+    type Error = alloy_sol_types::Error;
+    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error> {
+        T::decode(buffer)
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -28,6 +28,7 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod abi;
 mod arithmetic;
 pub mod contract;
 mod key;

--- a/crates/primitives/src/reflect/dispatch.rs
+++ b/crates/primitives/src/reflect/dispatch.rs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ink_prelude::vec::Vec;
 use pallet_revive_uapi::ReturnFlags;
 
-use crate::sol::{
-    self,
-    SolDecode,
-    SolEncode,
-};
+use crate::abi::Abi;
 
 /// Stores various information of the respective dispatchable ink! message.
 ///
@@ -135,12 +130,12 @@ pub trait DispatchableMessageInfo<const ID: u32> {
     const MUTATES: bool;
     /// Yields `true` if the dispatchable ink! message is payable.
     const PAYABLE: bool;
-    /// The selectors of the dispatchable ink! message.
+    /// The selector of the dispatchable ink! message.
     const SELECTOR: [u8; 4];
     /// The label of the dispatchable ink! message.
     const LABEL: &'static str;
-    /// The encoding of input and output data for the message
-    const ENCODING: Encoding;
+    /// The ABI spec for the decoding the message call.
+    const ABI: Abi;
 }
 
 /// Stores various information of the respective dispatchable ink! constructor.
@@ -235,99 +230,6 @@ pub trait DispatchableConstructorInfo<const ID: u32> {
 
     /// The label of the dispatchable ink! constructor.
     const LABEL: &'static str;
-}
-
-/// The ABI encoding/decoding scheme.
-#[derive(Debug, Clone, Copy)]
-pub enum Encoding {
-    /// Parity's SCALE codec.
-    Scale,
-    /// Solidity ABI encoding.
-    Solidity,
-}
-
-/// Marker type for SCALE encoding.
-///
-/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ScaleEncoding;
-
-/// Marker type for Solidity ABI encoding.
-///
-/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct SolEncoding;
-
-/// Trait for ABI-specific encoding with support for both slice and vector buffers.
-pub trait AbiEncodeWith<Abi> {
-    /// Encodes the data into a fixed-size buffer, returning the number of bytes written.
-    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize;
-
-    /// Encodes the data into a dynamically resizing vector.
-    fn encode_to_vec(&self, buffer: &mut Vec<u8>);
-}
-
-/// Trait for ABI-specific decoding.
-pub trait AbiDecodeWith<Abi>: Sized {
-    /// The error type that can occur during decoding.
-    type Error: core::fmt::Debug;
-    /// Decodes the data from a buffer using the provided ABI.
-    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error>;
-}
-
-impl<T: scale::Encode> AbiEncodeWith<ScaleEncoding> for T {
-    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize {
-        let encoded = scale::Encode::encode(self);
-        let len = encoded.len();
-        debug_assert!(
-            len <= buffer.len(),
-            "encode scope buffer overflowed, encoded len is {} but buffer len is {}",
-            len,
-            buffer.len()
-        );
-        buffer[..len].copy_from_slice(&encoded);
-        len
-    }
-
-    fn encode_to_vec(&self, buffer: &mut Vec<u8>) {
-        scale::Encode::encode_to(self, buffer);
-    }
-}
-
-impl<T: scale::Decode> AbiDecodeWith<ScaleEncoding> for T {
-    type Error = scale::Error;
-    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error> {
-        scale::Decode::decode(&mut &buffer[..])
-    }
-}
-
-impl<T> AbiEncodeWith<SolEncoding> for T
-where
-    T: for<'a> SolEncode<'a>,
-{
-    fn encode_to_slice(&self, buffer: &mut [u8]) -> usize {
-        let encoded = T::encode(self);
-        let len = encoded.len();
-        debug_assert!(
-            len <= buffer.len(),
-            "encode scope buffer overflowed, encoded len is {} but buffer len is {}",
-            len,
-            buffer.len()
-        );
-        buffer[..len].copy_from_slice(&encoded);
-        len
-    }
-
-    fn encode_to_vec(&self, buffer: &mut Vec<u8>) {
-        buffer.extend_from_slice(&T::encode(self));
-    }
-}
-
-impl<T: SolDecode> AbiDecodeWith<SolEncoding> for T {
-    type Error = sol::Error;
-    fn decode_with(buffer: &[u8]) -> Result<Self, Self::Error> {
-        T::decode(buffer)
-    }
 }
 
 mod private {

--- a/crates/primitives/src/reflect/dispatch.rs
+++ b/crates/primitives/src/reflect/dispatch.rs
@@ -237,20 +237,25 @@ pub trait DispatchableConstructorInfo<const ID: u32> {
     const LABEL: &'static str;
 }
 
-/// todo: comment
+/// The ABI encoding/decoding scheme.
+#[derive(Debug, Clone, Copy)]
 pub enum Encoding {
+    /// Parity's SCALE codec.
     Scale,
+    /// Solidity ABI encoding.
     Solidity,
 }
 
-/// Marker type for SCALE encoding. Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and
-/// `DecodeMessageResult`.
-#[derive(Debug, Default, Clone)]
+/// Marker type for SCALE encoding.
+///
+/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ScaleEncoding;
 
-/// Marker type for Solidity ABI encoding. Used with [`AbiEncodeWith`],
-/// [`AbiDecodeWith`] and `DecodeMessageResult`.
-#[derive(Debug, Default, Clone)]
+/// Marker type for Solidity ABI encoding.
+///
+/// Used with [`AbiEncodeWith`], [`AbiDecodeWith`] and `DecodeMessageResult`.
+#[derive(Debug, Default, Clone, Copy)]
 pub struct SolEncoding;
 
 /// Trait for ABI-specific encoding with support for both slice and vector buffers.

--- a/crates/primitives/src/reflect/mod.rs
+++ b/crates/primitives/src/reflect/mod.rs
@@ -30,8 +30,6 @@ mod trait_def;
 pub use self::{
     contract::ContractName,
     dispatch::{
-        AbiDecodeWith,
-        AbiEncodeWith,
         ConstructorOutput,
         ConstructorOutputValue,
         ContractConstructorDecoder,
@@ -40,10 +38,7 @@ pub use self::{
         DispatchError,
         DispatchableConstructorInfo,
         DispatchableMessageInfo,
-        Encoding,
         ExecuteDispatchable,
-        ScaleEncoding,
-        SolEncoding,
     },
     trait_def::{
         TraitDefinitionRegistry,

--- a/crates/primitives/src/sol.rs
+++ b/crates/primitives/src/sol.rs
@@ -15,6 +15,7 @@
 //! Abstractions for implementing Solidity ABI encoding/decoding for arbitrary Rust types.
 
 mod bytes;
+mod params;
 mod types;
 
 #[cfg(test)]
@@ -40,6 +41,10 @@ use primitive_types::{
 
 pub use self::{
     bytes::SolBytes,
+    params::{
+        SolParamsDecode,
+        SolParamsEncode,
+    },
     types::{
         SolTypeDecode,
         SolTypeEncode,
@@ -148,6 +153,11 @@ pub trait SolEncode<'a> {
     /// Name of equivalent Solidity ABI type.
     const SOL_NAME: &'static str =
         <<Self::SolType as SolTypeEncode>::AlloyType as AlloySolType>::SOL_NAME;
+
+    /// Whether the ABI encoded size is dynamic.
+    #[doc(hidden)]
+    const DYNAMIC: bool =
+        <<Self::SolType as SolTypeEncode>::AlloyType as AlloySolType>::DYNAMIC;
 
     /// Solidity ABI encode the value.
     fn encode(&'a self) -> Vec<u8> {

--- a/crates/primitives/src/sol/params.rs
+++ b/crates/primitives/src/sol/params.rs
@@ -1,0 +1,81 @@
+// Copyright (C) ink! contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloy_sol_types::{
+    abi,
+    SolType as AlloySolType,
+};
+use impl_trait_for_tuples::impl_for_tuples;
+use ink_prelude::vec::Vec;
+
+use super::{
+    SolDecode,
+    SolEncode,
+    SolTypeDecode,
+    SolTypeEncode,
+};
+
+/// Solidity ABI decode function parameters.
+///
+/// # Note
+///
+/// This trait is sealed and cannot be implemented for types outside `ink_primitives`.
+pub trait SolParamsDecode: Sized + private::Sealed {
+    /// Solidity ABI decode function parameters into this type.
+    fn decode(data: &[u8]) -> Result<Self, alloy_sol_types::Error>;
+}
+
+/// Solidity ABI encode function parameters.
+///
+/// # Note
+///
+/// This trait is sealed and cannot be implemented for types outside `ink_primitives`.
+pub trait SolParamsEncode: private::Sealed {
+    /// Solidity ABI encode the value as function parameters.
+    fn encode(&self) -> Vec<u8>;
+}
+
+// We follow the Rust standard library's convention of implementing traits for tuples up
+// to twelve items long.
+// Ref: <https://doc.rust-lang.org/std/primitive.tuple.html#trait-implementations>
+#[impl_for_tuples(12)]
+#[tuple_types_custom_trait_bound(SolDecode)]
+impl SolParamsDecode for Tuple {
+    fn decode(data: &[u8]) -> Result<Self, alloy_sol_types::Error> {
+        abi::decode_params::<
+            <<<Self as SolDecode>::SolType as SolTypeDecode>::AlloyType as AlloySolType>::Token<'_>,
+        >(data)
+            .and_then(<<Self as SolDecode>::SolType as SolTypeDecode>::detokenize)
+            .map(<Self as SolDecode>::from_sol_type)
+    }
+}
+
+#[impl_for_tuples(12)]
+#[tuple_types_custom_trait_bound(for<'a> SolEncode<'a>)]
+impl SolParamsEncode for Tuple {
+    fn encode(&self) -> Vec<u8> {
+        abi::encode_params(&<<Self as SolEncode>::SolType as SolTypeEncode>::tokenize(
+            &self.to_sol_type(),
+        ))
+    }
+}
+
+#[impl_for_tuples(12)]
+#[tuple_types_no_default_trait_bound]
+impl private::Sealed for Tuple {}
+
+mod private {
+    /// Seals implementations of `SolParamsEncode` and `SolParamsDecode`.
+    pub trait Sealed {}
+}

--- a/integration-tests/public/runtime-call-contract/sandbox-runtime/pallet-revive-caller/src/executor.rs
+++ b/integration-tests/public/runtime-call-contract/sandbox-runtime/pallet-revive-caller/src/executor.rs
@@ -14,7 +14,7 @@ use ink::{
         Environment,
     },
     primitives::U256,
-    reflect::{
+    abi::{
         AbiDecodeWith,
         AbiEncodeWith,
     },

--- a/integration-tests/public/wildcard-selector/lib.rs
+++ b/integration-tests/public/wildcard-selector/lib.rs
@@ -67,7 +67,7 @@ pub mod wildcard_selector {
                 ArgumentList,
                 EmptyArgumentList,
             },
-            primitives::reflect::ScaleEncoding,
+            primitives::abi::Ink,
         };
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -81,11 +81,11 @@ pub mod wildcard_selector {
             Environment,
             ArgumentList<
                 Argument<String>,
-                EmptyArgumentList<ScaleEncoding>,
-                ScaleEncoding,
+                EmptyArgumentList<Ink>,
+                Ink,
             >,
             (),
-            ScaleEncoding,
+            Ink,
         > {
             ink::env::call::build_call::<Environment>()
                 .call(addr)

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "trait-incrementer-caller"
+version = "6.0.0-alpha"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../crates/ink", default-features = false }
+
+dyn-traits = { path = "./traits", default-features = false }
+
+[dev-dependencies]
+ink_e2e = { path = "../../../crates/e2e" }
+trait-incrementer = { path = "./contracts/incrementer", default-features = false, features = ["ink-as-dependency"] }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "dyn-traits/std",
+]
+e2e-tests = []
+ink-as-dependency = []
+
+# Required to be able to run e2e test with sub-contracts
+[workspace]
+members = [
+    "contracts/incrementer",
+]
+
+[package.metadata.ink-lang]
+abi = "sol"

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "trait-incrementer"
+version = "6.0.0-alpha"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../../../crates/ink", default-features = false }
+
+dyn-traits = { path = "../../traits", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "dyn-traits/std",
+]
+ink-as-dependency = []
+
+[package.metadata.ink-lang]
+abi = "sol"

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
@@ -1,0 +1,56 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+#![allow(clippy::new_without_default)]
+
+#[ink::contract]
+pub mod incrementer {
+    use dyn_traits::Increment;
+
+    /// A concrete incrementer smart contract.
+    #[ink(storage)]
+    pub struct Incrementer {
+        value: u64,
+    }
+
+    impl Incrementer {
+        /// Creates a new incrementer smart contract initialized with zero.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {
+                value: u64::default(),
+            }
+        }
+
+        /// Increases the value of the incrementer by an amount.
+        #[ink(message)]
+        pub fn inc_by(&mut self, delta: u64) {
+            self.value = self.value.checked_add(delta).unwrap();
+        }
+    }
+
+    impl Increment for Incrementer {
+        #[ink(message)]
+        fn inc(&mut self) {
+            self.inc_by(1)
+        }
+
+        #[ink(message)]
+        fn get(&self) -> u64 {
+            self.value
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn it_works() {
+            let mut incrementer = Incrementer::new();
+            // Can call using universal call syntax using the trait.
+            assert_eq!(<Incrementer as Increment>::get(&incrementer), 0);
+            <Incrementer as Increment>::inc(&mut incrementer);
+            // Normal call syntax possible to as long as the trait is in scope.
+            assert_eq!(incrementer.get(), 1);
+        }
+    }
+}

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/lib.rs
@@ -1,0 +1,135 @@
+//! This crate contains the `Caller` contract with no functionality except forwarding
+//! all calls to the `trait_incrementer::Incrementer` contract.
+//!
+//! The `Caller` doesn't use the `trait_incrementer::IncrementerRef`. Instead,
+//! all interactions with the `Incrementer` is done through the wrapper from
+//! `ink::contract_ref!` and the trait `dyn_traits::Increment`.
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+#![allow(clippy::new_without_default)]
+
+#[ink::contract]
+pub mod caller {
+    use dyn_traits::Increment;
+
+    /// The caller of the incrementer smart contract.
+    #[ink(storage)]
+    pub struct Caller {
+        /// Here we accept a type which implements the `Incrementer` ink! trait.
+        incrementer: ink::contract_ref!(Increment),
+    }
+
+    impl Caller {
+        /// Creates a new caller smart contract around the `incrementer` account id.
+        #[ink(constructor)]
+        pub fn new(incrementer: Address) -> Self {
+            Self {
+                incrementer: incrementer.into(),
+            }
+        }
+    }
+
+    impl Increment for Caller {
+        #[ink(message)]
+        fn inc(&mut self) {
+            self.incrementer.inc()
+        }
+
+        #[ink(message)]
+        fn get(&self) -> u64 {
+            self.incrementer.get()
+        }
+    }
+}
+
+#[cfg(all(test, feature = "e2e-tests"))]
+mod e2e_tests {
+    use super::caller::{
+        Caller,
+        CallerRef,
+    };
+    use dyn_traits::Increment;
+    use ink_e2e::ContractsBackend;
+    use trait_incrementer::incrementer::{
+        Incrementer,
+        IncrementerRef,
+    };
+
+    type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+    /// A test deploys and instantiates the `trait_incrementer::Incrementer` and
+    /// `trait_incrementer_caller::Caller` contracts, where the `Caller` uses the account
+    /// id of the `Incrementer` for instantiation.
+    ///
+    /// The test verifies that we can increment the value of the `Incrementer` contract
+    /// through the `Caller` contract.
+    #[ink_e2e::test]
+    async fn e2e_cross_contract_calls<Client: E2EBackend>(
+        mut client: Client,
+    ) -> E2EResult<()> {
+        let _ = client
+            .upload("trait-incrementer", &ink_e2e::alice())
+            .submit()
+            .await
+            .expect("uploading `trait-incrementer` failed")
+            .code_hash;
+
+        let _ = client
+            .upload("trait-incrementer-caller", &ink_e2e::alice())
+            .submit()
+            .await
+            .expect("uploading `trait-incrementer-caller` failed")
+            .code_hash;
+
+        let mut constructor = IncrementerRef::new();
+
+        let incrementer = client
+            .instantiate("trait-incrementer", &ink_e2e::alice(), &mut constructor)
+            .submit()
+            .await
+            .expect("instantiate failed");
+        let incrementer_call = incrementer.call_builder::<Incrementer>();
+
+        let mut constructor = CallerRef::new(incrementer.addr.clone());
+
+        let caller = client
+            .instantiate(
+                "trait-incrementer-caller",
+                &ink_e2e::alice(),
+                &mut constructor,
+            )
+            .submit()
+            .await
+            .expect("instantiate failed");
+        let mut caller_call = caller.call_builder::<Caller>();
+
+        // Check through the caller that the value of the incrementer is zero
+        let get = caller_call.get();
+        let value = client
+            .call(&ink_e2e::alice(), &get)
+            .dry_run()
+            .await?
+            .return_value();
+        assert_eq!(value, 0);
+
+        // Increment the value of the incrementer via the caller
+        let inc = caller_call.inc();
+        let _ = client
+            .call(&ink_e2e::alice(), &inc)
+            .submit()
+            .await
+            .expect("calling `inc` failed");
+
+        // Ask the `trait-increment` about a value. It should be updated by the caller.
+        // Also use `contract_ref!(Increment)` instead of `IncrementerRef`
+        // to check that it also works with e2e testing.
+        let get = incrementer_call.get();
+        let value = client
+            .call(&ink_e2e::alice(), &get)
+            .dry_run()
+            .await?
+            .return_value();
+        assert_eq!(value, 1);
+
+        Ok(())
+    }
+}

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dyn-traits"
+version = "6.0.0-alpha"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../../crates/ink", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+
+[package.metadata.ink-lang]
+abi = "sol"

--- a/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/traits/lib.rs
+++ b/integration-tests/solidity-abi/trait-dyn-cross-contract-calls/traits/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+//! The trait is extracted into a separate crate to show how to do cross-contract
+//! calls only with traits without importing the contract.
+
+/// Allows to increment and get the current value.
+#[ink::trait_definition]
+pub trait Increment {
+    /// Increments the current value of the implementer by one (1).
+    #[ink(message)]
+    fn inc(&mut self);
+
+    /// Returns the current value of the implementer.
+    #[ink(message)]
+    fn get(&self) -> u64;
+}

--- a/integration-tests/solidity-abi/trait-flipper/Cargo.toml
+++ b/integration-tests/solidity-abi/trait-flipper/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "trait_flipper"
+version = "6.0.0-alpha"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../crates/ink", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+
+[package.metadata.ink-lang]
+abi = "sol"

--- a/integration-tests/solidity-abi/trait-flipper/lib.rs
+++ b/integration-tests/solidity-abi/trait-flipper/lib.rs
@@ -1,0 +1,64 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+#![allow(clippy::new_without_default)]
+
+#[::ink::trait_definition]
+pub trait Flip {
+    /// Flips the current value of the Flipper's boolean.
+    #[ink(message)]
+    fn flip(&mut self);
+
+    /// Returns the current value of the Flipper's boolean.
+    #[ink(message)]
+    fn get(&self) -> bool;
+}
+
+#[::ink::contract]
+pub mod flipper {
+    use super::Flip;
+
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        /// Creates a new flipper smart contract initialized to `false`.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self { value: true }
+        }
+    }
+
+    impl Flip for Flipper {
+        #[ink(message)]
+        fn flip(&mut self) {
+            self.value = !self.value;
+        }
+
+        #[ink(message)]
+        fn get(&self) -> bool {
+            self.value
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[::ink::test]
+        fn default_works() {
+            let flipper = Flipper::new();
+            assert!(flipper.get());
+        }
+
+        #[::ink::test]
+        fn it_works() {
+            let mut flipper = Flipper::new();
+            // Can call using universal call syntax using the trait.
+            assert!(<Flipper as Flip>::get(&flipper));
+            <Flipper as Flip>::flip(&mut flipper);
+            // Normal call syntax possible to as long as the trait is in scope.
+            assert!(!flipper.get());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

- Update trait definitions `codegen` to properly support Solidity ABI (i.e. generate trait info for Solidity selectors, and update related generated message builders, call builders and call forwarders)
- Make generated contract references, trait message builders and call forwarders generic over "ink" and "sol" ABI marker types, and update related macros (i.e. `ink::contract_ref!` and `ink::message_builder!`) to support ABI parameters
- More consistent naming of ABI marker types and corresponding generic type parameters (i.e. `Abi` for the generic type param and enum, and `Ink` and `Sol` for the marker types)
- Refactor Solidity selector computation utilities (prefer compile-time overhead over generating intermediate code)
- Add Solidity ABI encoding/decoding input and output guards for message and constructors parameter types and message return types (see `ink::codegen::DispatchInputSol` and `ink::codegen::DispatchOutputSol` docs)
- Introduce `ink_env::build_call_abi<Environment, Abi>`, `ink_e2e::call_builder_abi<Contract, Abi>` and `ink_e2e::InstantiationResult::call_builder_abi<Contract, Abi>` utilities
- Update call results abstractions in `ink_e2e` to support Solidity ABI encoded message calls (i.e. `CallDryRunResult::message_result` and `CallDryRunResult::return_value`)
- Don't generate ink! metadata generator (i.e. `__ink_generate_metadata`) for Solidity ABI only contracts
- Fix `SolEncode` implementation for `ArgumentList`s including dynamic types.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
