### PR TITLE
chore: update `pallet-revive` in e2e crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
 dependencies = [
- "alloy-primitives 1.0.0",
- "alloy-sol-type-parser 1.0.0",
+ "alloy-primitives 1.2.0",
+ "alloy-sol-type-parser 1.2.0",
  "serde",
  "serde_json",
 ]
@@ -131,7 +131,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "indexmap 2.8.0",
  "itoa",
  "k256",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -158,7 +158,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "indexmap 2.8.0",
  "itoa",
  "k256",
@@ -199,12 +199,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
 dependencies = [
- "alloy-sol-macro-expander 1.0.0",
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-expander 1.2.0",
+ "alloy-sol-macro-input 1.2.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -231,11 +231,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
 dependencies = [
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-input 1.2.0",
  "const-hex",
  "heck",
  "indexmap 2.8.0",
@@ -243,7 +243,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn-solidity 1.0.0",
+ "syn-solidity 1.2.0",
  "tiny-keccak",
 ]
 
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
 dependencies = [
  "const-hex",
  "dunce",
@@ -276,7 +276,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn-solidity 1.0.0",
+ "syn-solidity 1.2.0",
 ]
 
 [[package]]
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
 dependencies = [
  "serde",
  "winnow",
@@ -314,14 +314,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
 dependencies = [
- "alloy-json-abi 1.0.0",
- "alloy-primitives 1.0.0",
- "alloy-sol-macro 1.0.0",
- "const-hex",
+ "alloy-json-abi 1.2.0",
+ "alloy-primitives 1.2.0",
+ "alloy-sol-macro 1.2.0",
  "serde",
 ]
 
@@ -493,7 +492,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -664,7 +663,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1587,12 +1586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
-
-[[package]]
 name = "contract-build"
 version = "6.0.0-alpha.1"
 source = "git+https://github.com/use-ink/cargo-contract?branch=master#f742baba08ee746ae137bc4f2fbf37befac7e560"
@@ -2453,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.0.0"
+version = "40.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b0892434d3cc61fab58b2e48b27b12fc162465c5af48fa283ed15bb86dbfb2"
+checksum = "4a9e5fcdb30bb83b2d97d7e718127230e0fbbad82b9c32dedf63971f08709def"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2631,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.0"
+version = "33.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bc18090aa96a5e69cd566fb755b5be08964b926864b2101dd900f64a870437"
+checksum = "bcb3c16c8fe1b4edc6df122212b50f776dfce31a94fa63305100841ba4eb7c93"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2969,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3108,6 +3101,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -3443,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -3520,7 +3529,7 @@ dependencies = [
  "ink_sandbox",
  "itertools 0.14.0",
  "jsonrpsee",
- "pallet-revive",
+ "pallet-revive 0.6.1",
  "pallet-revive-mock-network",
  "parity-scale-codec",
  "regex",
@@ -3569,7 +3578,7 @@ dependencies = [
  "derive_more 2.0.1",
  "hex-literal 1.0.0",
  "ink_primitives 6.0.0-alpha",
- "pallet-revive",
+ "pallet-revive 0.6.1",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "secp256k1 0.30.0",
@@ -3593,7 +3602,7 @@ dependencies = [
  "ink_primitives 6.0.0-alpha",
  "ink_storage_traits",
  "num-traits",
- "pallet-revive",
+ "pallet-revive 0.5.0",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "polkavm-derive 0.22.0",
@@ -3695,7 +3704,7 @@ dependencies = [
 name = "ink_primitives"
 version = "6.0.0-alpha"
 dependencies = [
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.2.0",
  "cfg-if",
  "derive_more 2.0.1",
  "impl-trait-for-tuples",
@@ -3704,7 +3713,7 @@ dependencies = [
  "ink_prelude 6.0.0-alpha",
  "itertools 0.14.0",
  "num-traits",
- "pallet-revive",
+ "pallet-revive 0.5.0",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "paste",
@@ -3724,14 +3733,14 @@ name = "ink_primitives"
 version = "6.0.0-alpha"
 source = "git+https://github.com/use-ink/ink?branch=master#52652093f4f3d9f6369c455e496123ce46970c07"
 dependencies = [
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.2.0",
  "cfg-if",
  "derive_more 2.0.1",
  "impl-trait-for-tuples",
  "ink_prelude 6.0.0-alpha (git+https://github.com/use-ink/ink?branch=master)",
  "itertools 0.14.0",
  "num-traits",
- "pallet-revive",
+ "pallet-revive 0.5.0",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "paste",
@@ -3755,7 +3764,7 @@ dependencies = [
  "frame-system",
  "ink_primitives 6.0.0-alpha",
  "pallet-balances",
- "pallet-revive",
+ "pallet-revive 0.6.1",
  "pallet-timestamp",
  "parity-scale-codec",
  "paste",
@@ -4191,7 +4200,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -4710,6 +4719,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-revive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff67ac7b1053411a2bd2f5438cc0fa0c58757ec0c51efa551f1cfcd9ebc7ee3"
+dependencies = [
+ "alloy-core",
+ "derive_more 0.99.19",
+ "environmental",
+ "ethabi-decode",
+ "ethereum-types",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex-literal 0.4.1",
+ "humantime-serde",
+ "impl-trait-for-tuples",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "pallet-revive-fixtures",
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "paste",
+ "polkavm",
+ "polkavm-common 0.21.0",
+ "rand 0.8.5",
+ "ripemd",
+ "rlp 0.6.1",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "substrate-bn",
+ "subxt-signer 0.38.1",
+]
+
+[[package]]
 name = "pallet-revive-fixtures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,16 +4783,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive-mock-network"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dc337fa4265c93849f7a00d56ae19c6b5f4f78140b03ea752ef6f176507aaf"
+checksum = "ce198787c5c07bf424971953d431b68feec771196303315fefe3d00ac5b90656"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-assets",
  "pallet-balances",
  "pallet-message-queue",
- "pallet-revive",
+ "pallet-revive 0.6.1",
  "pallet-revive-uapi",
  "pallet-timestamp",
  "pallet-xcm",
@@ -4898,9 +4955,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -4915,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5562,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -6850,7 +6907,7 @@ dependencies = [
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "hex",
  "hmac 0.12.1",
  "itertools 0.13.0",
@@ -6900,7 +6957,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "hex",
  "itertools 0.13.0",
  "log",
@@ -7223,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
+checksum = "3e41d010bcc515d119901ff7ac83150c335d543c7f6c03be5c8fe08430b8a03b"
 dependencies = [
  "bytes",
  "docify",
@@ -7623,9 +7680,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-xcm"
-version = "16.1.0"
+version = "16.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead7481ba2dec11b0df89745cef3a76f3eef9c9df20155426cd7e9651b4c799"
+checksum = "d0126278d7fc6d7dec55e5a109f838bbf401dd084aecf2597e4e11ea07515a0a"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -7645,9 +7702,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.0.0"
+version = "20.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041eaa60fc0df3dbaa5779959f5eaac9c1b81d045a5a1792479e46dfd31f028"
+checksum = "6f031952c1496cf7f86d19ab38e3264be9a54b7d8eecb25ba69f977cc7549d08"
 dependencies = [
  "environmental",
  "frame-support",
@@ -7670,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.0"
+version = "19.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6d7cc19f02e4c088c2719fe11f22216041909d6a6ab130c71e8d25818d7768"
+checksum = "af9bc315e8c7018fcfe0371ce4b7e726fb699e37b2acc3e5effb87a7d131a3ff"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8061,9 +8118,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -8252,9 +8309,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8627,9 +8684,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -8638,14 +8695,12 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
- "thiserror 1.0.69",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,17 +86,17 @@ frame-system = { version = "40.1.0", default-features = false }
 frame-support = { version = "40.1.0", default-features = false }
 pallet-balances = { version = "41.1.0", default-features = false }
 pallet-timestamp = { version = "39.0.0", default-features = false }
-pallet-revive = { version = "0.5.0", default-features = false }
-pallet-revive-mock-network = { version = "0.4.0", default-features = false }
+pallet-revive = { version = "0.6.1", default-features = false }
+pallet-revive-mock-network = { version = "0.5.0", default-features = false }
 pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn"] }
 sp-externalities = { version = "0.30.0", default-features = false }
-sp-io = { version = "40.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-io = { version = "40.0.1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 sp-runtime-interface = { version = "29.0.1", default-features = false, features = ["disable_target_static_assertions"] }
 sp-core = { version = "36.1.0", default-features = false }
 sp-keyring = { version = "41.0.0", default-features = false }
 sp-runtime = "41.1.0"
 sp-weights = { version = "31.1.0", default-features = false }
-xcm = { package = "staging-xcm", version = "16.1.0", default-features = false }
+xcm = { version = "16.2.0", package = "staging-xcm", default-features = false }
 
 # PolkaVM dependencies
 polkavm-derive = { version = "0.22.0", default-features = false }

--- a/crates/e2e/sandbox/src/api/revive_api.rs
+++ b/crates/e2e/sandbox/src/api/revive_api.rs
@@ -20,6 +20,10 @@ use ink_primitives::{
     DepositLimit,
 };
 use pallet_revive::{
+    evm::{
+        Tracer,
+        TracerType,
+    },
     Code,
     CodeUploadResult,
 };
@@ -133,6 +137,8 @@ pub trait ContractAPI {
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<BalanceOf<Self::T>>,
     ) -> ContractExecResultFor<Self::T>;
+
+    fn evm_tracer(&mut self, tracer_type: TracerType) -> Tracer;
 }
 
 impl<T> ContractAPI for T
@@ -239,6 +245,10 @@ where
                 data,
             )
         })
+    }
+
+    fn evm_tracer(&mut self, tracer_type: TracerType) -> Tracer {
+        self.execute_with(|| pallet_revive::Pallet::<Self::T>::evm_tracer(tracer_type))
     }
 }
 

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -32,7 +32,9 @@ use ink_primitives::{
 use pallet_revive::{
     evm::{
         CallTrace,
-        TracerConfig,
+        CallTracerConfig,
+        Trace,
+        TracerType,
     },
     CodeUploadResult,
 };
@@ -457,11 +459,11 @@ where
             _ => panic!("pattern error"),
         };
 
-        let tracer_config = TracerConfig::CallTracer { with_logs: true };
+        let tracer_type = TracerType::CallTracer(Some(CallTracerConfig::default()));
         let func = "ReviveApi_trace_tx";
 
         let params =
-            scale::Encode::encode(&((header, exts), tx_index.as_u32(), tracer_config));
+            scale::Encode::encode(&((header, exts), tx_index.as_u32(), tracer_type));
 
         let bytes = self
             .rpc
@@ -473,8 +475,14 @@ where
                     format!("{}", err).trim_start_matches("RPC error: ")
                 );
             });
-        scale::Decode::decode(&mut bytes.as_ref())
-            .unwrap_or_else(|err| panic!("decoding `trace_tx` result failed: {err}"))
+
+        let trace: Option<Trace> = scale::Decode::decode(&mut bytes.as_ref())
+            .unwrap_or_else(|err| panic!("decoding `trace_tx` result failed: {err}"));
+        let call_trace = match trace {
+            Some(Trace::Call(trace)) => Some(trace),
+            _ => None,
+        };
+        call_trace
     }
 
     /// Return the hash of the *best* block

--- a/integration-tests/public/runtime-call-contract/Cargo.toml
+++ b/integration-tests/public/runtime-call-contract/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 frame-support = { version = "40.1.0", default-features = false }
 frame-system = { version = "40.1.0", default-features = false }
 pallet-balances = { version = "41.1.0", default-features = false }
-pallet-revive = { version = "0.5.0", default-features = false }
+pallet-revive = { version = "0.6.1", default-features = false }
 sp-runtime = { version = "41.1.0", default-features = false }
 # todo
 codec = { package = "parity-scale-codec", version =  "3.7.4", default-features = false }

--- a/integration-tests/solidity-abi/sol-cross-contract/Cargo.toml
+++ b/integration-tests/solidity-abi/sol-cross-contract/Cargo.toml
@@ -12,7 +12,7 @@ sha3 = { version = "0.10", default-features = false }
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
 ink_sandbox = { path = "../../../crates/e2e/sandbox" }
-pallet-revive = { version = "0.5.0", default-features = false }
+pallet-revive = { version = "0.6.1", default-features = false }
 sha3 = { version = "0.10" }
 other-contract-sol = { path = "other-contract-sol" }
 

--- a/integration-tests/solidity-abi/sol-encoding/Cargo.toml
+++ b/integration-tests/solidity-abi/sol-encoding/Cargo.toml
@@ -11,7 +11,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
 ink_sandbox = { path = "../../../crates/e2e/sandbox" }
-pallet-revive = { version = "0.5.0", default-features = false }
+pallet-revive = { version = "0.6.1", default-features = false }
 sha3 = { version = "0.10" }
 
 [lib]


### PR DESCRIPTION
Incomplete PR  intended to resolve https://github.com/use-ink/ink/issues/2528

With the update of `ink-node` to use the latest `pallet_revive` version: https://github.com/use-ink/ink-node/releases/tag/v0.43.3 e2e tests are now failing due to changes in the behavior of the `ReviveApi_trace_tx` RPC.

Error encountered:
```
error on ws request `trace_tx`: User(UserError { code: 4003, message: "Client error: Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed\nWASM backtrace:\nerror while executing at wasm backtrace:\n    0: 0x20b938 - ink_node_runtime.wasm!rust_begin_unwind\n    1: 0xed65 - ink_node_runtime.wasm!core::panicking::panic_fmt::hfdb65cc345fb23df\n    2: 0xd8f78 - ink_node_runtime.wasm!ReviveApi_trace_tx", data: None })

User error: Client error: Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed
WASM backtrace:
error while executing at wasm backtrace:
    0: 0x20b938 - ink_node_runtime.wasm!rust_begin_unwind
    1: 0xed65 - ink_node_runtime.wasm!core::panicking::panic_fmt::hfdb65cc345fb23df
    2: 0xd8f78 - ink_node_runtime.wasm!ReviveApi_trace_tx (4003)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
### How to Reproduce
To see the issue on `master` with `ink-node v0.43.3`:
```
export CONTRACTS_NODE="path-to-ink-node/ink-node-v0.43.3"
git checkout master
cargo contract test --all-features --manifest-path integration-tests/public/flipper/Cargo.toml --nocapture
```
Now with the changes of this PR :
```
git checkout chore/update-revive-e2e-crate 
cargo contract test --all-features --manifest-path integration-tests/public/flipper/Cargo.toml --nocapture
```