### PR TITLE
Share intermediate build artifacts across all contract builds in e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,9 +726,12 @@ jobs:
       - name: Initialize runner
         uses: ./.github/init
         with:
-          cache: true
-          cache-directories: ${{ github.workspace }}/${{ env.CARGO_TARGET_DIR }}
-          cache-on-failure: true
+          # FIXME: (@davidsemakula) This job runs into "No space left" issue while saving cache,
+          # So cache is disable for now.
+          # See https://github.com/use-ink/ink/actions/runs/15879206960/job/44775329120?pr=2531#step:11:54
+          cache: false
+          #cache-directories: ${{ github.workspace }}/${{ env.CARGO_TARGET_DIR }}
+          #cache-on-failure: true
 
       - name: Extract branch name
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)
 - Solidity ABI compatibility metadata improvements - [#2511](https://github.com/use-ink/ink/pull/2511)
+- Share intermediate build artifacts across all contract builds in e2e tests - [#2531](https://github.com/use-ink/ink/pull/2531)
 
 ### Fixed
 - Update metadata version to version 6 ‒ [#2507](https://github.com/use-ink/ink/pull/2507)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 [[package]]
 name = "contract-build"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#f742baba08ee746ae137bc4f2fbf37befac7e560"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#c98ce288660ac1ca1a0058b2be83a7bec4612a6a"
 dependencies = [
  "alloy-json-abi 0.8.25",
  "anyhow",
@@ -1616,7 +1616,6 @@ dependencies = [
  "polkavm-linker 0.22.0",
  "regex",
  "rustc_version 0.4.1",
- "scale-info",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -1637,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "contract-metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#f742baba08ee746ae137bc4f2fbf37befac7e560"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#c98ce288660ac1ca1a0058b2be83a7bec4612a6a"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -3664,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#52652093f4f3d9f6369c455e496123ce46970c07"
+source = "git+https://github.com/use-ink/ink?branch=master#641f05706e4f7ff1fb7c60e261ed0f4bc833f2f0"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde",
@@ -3686,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#52652093f4f3d9f6369c455e496123ce46970c07"
+source = "git+https://github.com/use-ink/ink?branch=master#641f05706e4f7ff1fb7c60e261ed0f4bc833f2f0"
 dependencies = [
  "cfg-if",
 ]
@@ -3722,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#52652093f4f3d9f6369c455e496123ce46970c07"
+source = "git+https://github.com/use-ink/ink?branch=master#641f05706e4f7ff1fb7c60e261ed0f4bc833f2f0"
 dependencies = [
  "alloy-sol-types 1.0.0",
  "cfg-if",

--- a/crates/e2e/src/contract_build.rs
+++ b/crates/e2e/src/contract_build.rs
@@ -64,7 +64,7 @@ pub fn build_root_and_contract_dependencies(features: Vec<String>) -> Vec<PathBu
             env::set_var("INK_RUSTC_WRAPPER", rustc_wrapper);
         }
     }
-    build_contracts(&contract_manifests, features)
+    build_contracts(&contract_manifests, features, contract_project.target_dir)
 }
 
 /// Access manifest paths of contracts which are part of the project in which the E2E
@@ -80,7 +80,7 @@ impl ContractProject {
     fn new() -> Self {
         let mut cmd = cargo_metadata::MetadataCommand::new();
         let env_target_dir = env::var_os("CARGO_TARGET_DIR")
-            .map(|target_dir| PathBuf::from(target_dir))
+            .map(PathBuf::from)
             .filter(|target_dir| target_dir.is_absolute());
         if let Some(target_dir) = env_target_dir.as_ref() {
             cmd.env("CARGO_TARGET_DIR", target_dir);
@@ -126,7 +126,7 @@ impl ContractProject {
 
         let package_abi = metadata
             .root_package()
-            .and_then(|package| package_abi(package))
+            .and_then(package_abi)
             .and_then(Result::ok);
         log_info(&format!("found root package abi: {:?}", package_abi));
 
@@ -170,6 +170,7 @@ impl ContractProject {
 fn build_contracts(
     contract_manifests: &[PathBuf],
     features: Vec<String>,
+    target_dir: PathBuf,
 ) -> Vec<PathBuf> {
     static CONTRACT_BUILD_JOBS: OnceLock<Mutex<HashMap<PathBuf, PathBuf>>> =
         OnceLock::new();
@@ -183,7 +184,8 @@ fn build_contracts(
         let contract_binary_path = match contract_build_jobs.entry(manifest.clone()) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
-                let contract_binary_path = build_contract(manifest, features.clone());
+                let contract_binary_path =
+                    build_contract(manifest, features.clone(), target_dir.clone());
                 entry.insert(contract_binary_path.clone());
                 contract_binary_path
             }
@@ -196,23 +198,18 @@ fn build_contracts(
 /// Builds the contract at `manifest_path`, returns the path to the contract
 /// PolkaVM build artifact.
 fn build_contract(
-    path_to_cargo_toml: &Path,
-    additional_features: Vec<String>,
+    cargo_toml: &Path,
+    features: Vec<String>,
+    target_dir: PathBuf,
 ) -> PathBuf {
-    let manifest_path = ManifestPath::new(path_to_cargo_toml).unwrap_or_else(|err| {
-        panic!(
-            "Invalid manifest path {}: {err}",
-            path_to_cargo_toml.display()
-        )
+    let manifest_path = ManifestPath::new(cargo_toml).unwrap_or_else(|err| {
+        panic!("Invalid manifest path {}: {err}", cargo_toml.display())
     });
-    // todo add method in Features to just construct with new(features)
-    let mut features = Features::default();
-    additional_features.iter().for_each(|f| features.push(f));
     let args = ExecuteArgs {
         manifest_path,
         verbosity: Verbosity::Default,
         build_mode: BuildMode::Debug,
-        features,
+        features: Features::from(features),
         network: Network::Online,
         build_artifact: BuildArtifacts::CodeOnly,
         unstable_flags: UnstableFlags::default(),
@@ -221,6 +218,7 @@ fn build_contract(
         output_type: OutputType::HumanReadable,
         image: ImageVariant::Default,
         metadata_spec: None,
+        target_dir: Some(target_dir),
     };
 
     match contract_build::execute(args) {
@@ -232,10 +230,7 @@ fn build_contract(
                 .expect("Invalid dest bundle path")
         }
         Err(err) => {
-            panic!(
-                "contract build for {} failed: {err}",
-                path_to_cargo_toml.display()
-            )
+            panic!("contract build for {} failed: {err}", cargo_toml.display())
         }
     }
 }

--- a/crates/e2e/src/contract_build.rs
+++ b/crates/e2e/src/contract_build.rs
@@ -214,7 +214,7 @@ fn build_contract(
         build_mode: BuildMode::Debug,
         features,
         network: Network::Online,
-        build_artifact: BuildArtifacts::All,
+        build_artifact: BuildArtifacts::CodeOnly,
         unstable_flags: UnstableFlags::default(),
         keep_debug_symbols: false,
         extra_lints: false,


### PR DESCRIPTION
## Summary
Closes #2520
- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

- Set the same target directory for all contract builds for e2e tests (Depends on https://github.com/use-ink/cargo-contract/pull/2063)
  - This (combined with https://github.com/use-ink/cargo-contract/pull/2063) generally reduces build time and disk space usage efficiency for e2e tests from `O(n)` (where `n` is the number of contracts involved in the e2e test i.e. the root contract plus it's contract dependencies) to `O(1)` (for "fresh" builds)
- Disable metadata generation for e2e test contract builds
  - Additionally reduces build times for e2e tests for the general case by a further ~50%  (for "fresh" builds)

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
