### PR TITLE
fix typo in Error Messages

### DIFF
--- a/integration-tests/public/contract-invocation/lib.rs
+++ b/integration-tests/public/contract-invocation/lib.rs
@@ -47,7 +47,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instatiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {:?}", error)
                 })
         }
 
@@ -74,7 +74,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instatiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {:?}", error)
                 })
         }
 
@@ -282,7 +282,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instatiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {:?}", error)
                 });
 
             use ink::ToAddr;
@@ -305,7 +305,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instatiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {:?}", error)
                 });
             let addr3: Address = addr3.to_addr();
 
@@ -335,7 +335,7 @@ mod instantiate_contract {
                         )
                     })
                     .unwrap_or_else(|error| {
-                        panic!("Received a `LangError` while instatiating: {:?}", error)
+                        panic!("Received a `LangError` while instantiating: {:?}", error)
                     })
             };
 


### PR DESCRIPTION

Description:  
This pull request corrects a minor typo in panic messages within the contract instantiation logic. The word "instatiating" has been updated to the correct spelling "instantiating" for improved clarity and professionalism in error reporting. 