### PR TITLE
fix: Ensure immutable messages are not payable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Update metadata version to version 6 ‒ [#2507](https://github.com/use-ink/ink/pull/2507)
+- Ensure immutable messages are not payable - [#2535](https://github.com/use-ink/ink/pull/2535)
 
 ## Version 6.0.0-alpha
 

--- a/crates/ink/ir/src/ir/trait_def/item/mod.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/mod.rs
@@ -301,7 +301,8 @@ impl InkItemTrait {
     ///
     /// - If the message has no `&self` or `&mut self` receiver.
     fn analyse_trait_message(message: &syn::TraitItemFn) -> Result<()> {
-        InkTraitMessage::extract_attributes(message.span(), &message.attrs)?;
+        let (ink_attrs, _) =
+            InkTraitMessage::extract_attributes(message.span(), &message.attrs)?;
         match message.sig.receiver() {
             None => {
                 return Err(format_err_spanned!(
@@ -314,6 +315,13 @@ impl InkItemTrait {
                     return Err(format_err_spanned!(
                         receiver,
                         "self receiver of ink! message must be `&self` or `&mut self`"
+                    ))
+                }
+
+                if ink_attrs.is_payable() && receiver.mutability.is_none() {
+                    return Err(format_err_spanned!(
+                        receiver,
+                        "ink! messages with a `payable` attribute argument must have a `&mut self` receiver"
                     ))
                 }
             }

--- a/crates/ink/ir/src/ir/trait_def/tests.rs
+++ b/crates/ink/ir/src/ir/trait_def/tests.rs
@@ -374,8 +374,6 @@ fn trait_def_with_payable_ok() {
         <InkItemTrait as TryFrom<syn::ItemTrait>>::try_from(syn::parse_quote! {
             pub trait MyTrait {
                 #[ink(message, payable)]
-                fn my_message(&self);
-                #[ink(message, payable)]
                 fn my_message_mut(&mut self);
             }
         })
@@ -391,10 +389,8 @@ fn trait_def_with_everything_combined_ok() {
             pub trait MyTrait {
                 #[ink(message)]
                 fn my_message_1(&self);
-                #[ink(message, payable)]
+                #[ink(message, selector = 0xDEADBEEF)]
                 fn my_message_2(&self);
-                #[ink(message, payable, selector = 0xDEADBEEF)]
-                fn my_message_3(&self);
                 #[ink(message)]
                 fn my_message_mut_1(&mut self);
                 #[ink(message, payable)]

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -344,9 +344,15 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///           self.value = !self.value;
 ///       }
 ///
-///      /// Returns the current value.
-///      #[ink(message, payable)] // ...or specify payable inline.
-///      pub fn get(&self) -> bool {
+///       /// Flips the current value.
+///       #[ink(message, payable)] // ...or specify payable inline.
+///       pub fn flip_2(&mut self) {
+///           self.value = !self.value;
+///       }
+///
+///       /// Returns the current value.
+///       #[ink(message)]
+///       pub fn get(&self) -> bool {
 ///           self.value
 ///       }
 ///   }
@@ -423,7 +429,7 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///         }
 ///
 ///         #[ink(message, payable)]
-///         pub fn fund(&self) {
+///         pub fn fund(&mut self) {
 ///             let caller = self.env().caller();
 ///             let value = self.env().transferred_value();
 ///         }

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -142,7 +142,7 @@ where
     /// #
     /// /// Allows funding the contract. Prints a debug message with the transferred value.
     /// #[ink(message, payable)]
-    /// pub fn fund(&self) {
+    /// pub fn fund(&mut self) {
     ///     let caller = self.env().caller();
     ///     let value = self.env().transferred_value();
     /// }

--- a/crates/ink/tests/ui/contract/fail/message/message-immutable-payable.rs
+++ b/crates/ink/tests/ui/contract/fail/message/message-immutable-payable.rs
@@ -1,15 +1,7 @@
 #![allow(unexpected_cfgs)]
 
-#[ink::trait_definition]
-pub trait TraitDefinition {
-    #[ink(message)]
-    fn message(&mut self);
-}
-
 #[ink::contract]
 mod contract {
-    use super::TraitDefinition;
-
     #[ink(storage)]
     pub struct Contract {}
 
@@ -18,11 +10,9 @@ mod contract {
         pub fn constructor() -> Self {
             Self {}
         }
-    }
 
-    impl TraitDefinition for Contract {
         #[ink(message, payable)]
-        fn message(&mut self) {}
+        pub fn message(&self) {}
     }
 }
 

--- a/crates/ink/tests/ui/contract/fail/message/message-immutable-payable.stderr
+++ b/crates/ink/tests/ui/contract/fail/message/message-immutable-payable.stderr
@@ -1,0 +1,6 @@
+error: ink! messages with a `payable` attribute argument must have a `&mut self` receiver
+  --> tests/ui/contract/fail/message/message-immutable-payable.rs:14:9
+   |
+14 | /         #[ink(message, payable)]
+15 | |         pub fn message(&self) {}
+   | |________________________________^

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-payable-mismatch.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-payable-mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
   --> tests/ui/contract/fail/trait/trait-message-payable-mismatch.rs:25:9
    |
-25 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
+25 |         fn message(&mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
    |
    = note: expected struct `TraitMessagePayable<false>`
               found struct `TraitMessagePayable<true>`

--- a/crates/ink/tests/ui/contract/pass/message/message-payable.rs
+++ b/crates/ink/tests/ui/contract/pass/message/message-payable.rs
@@ -12,7 +12,7 @@ mod contract {
         }
 
         #[ink(message, selector = 1, payable)]
-        pub fn message_1(&self) {}
+        pub fn message_1(&mut self) {}
 
         #[ink(message, selector = 2)]
         pub fn message_2(&self) {}

--- a/crates/ink/tests/ui/contract/pass/trait-message-payable-guard.rs
+++ b/crates/ink/tests/ui/contract/pass/trait-message-payable-guard.rs
@@ -3,7 +3,7 @@
 #[ink::trait_definition]
 pub trait TraitDefinition {
     #[ink(message, payable)]
-    fn message(&self);
+    fn message(&mut self);
 }
 
 #[ink::contract]
@@ -22,7 +22,7 @@ mod contract {
 
     impl TraitDefinition for Contract {
         #[ink(message, payable)]
-        fn message(&self) {}
+        fn message(&mut self) {}
     }
 }
 

--- a/crates/ink/tests/ui/trait_def/fail/message_immutable_payable.rs
+++ b/crates/ink/tests/ui/trait_def/fail/message_immutable_payable.rs
@@ -1,0 +1,7 @@
+#[ink::trait_definition]
+pub trait TraitDefinition {
+    #[ink(message, payable)]
+    fn message(&self);
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/trait_def/fail/message_immutable_payable.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_immutable_payable.stderr
@@ -1,0 +1,5 @@
+error: ink! messages with a `payable` attribute argument must have a `&mut self` receiver
+ --> tests/ui/trait_def/fail/message_immutable_payable.rs:4:16
+  |
+4 |     fn message(&self);
+  |                ^^^^^

--- a/crates/ink/tests/ui/trait_def/pass/payable_message.rs
+++ b/crates/ink/tests/ui/trait_def/pass/payable_message.rs
@@ -1,9 +1,6 @@
 #[ink::trait_definition]
 pub trait PayableDefinition {
     #[ink(message, payable)]
-    fn payable(&self);
-
-    #[ink(message, payable)]
     fn payable_mut(&mut self);
 
     #[ink(message)]
@@ -15,7 +12,6 @@ pub trait PayableDefinition {
 
 use ink::selector_id;
 
-const PAYABLE_ID: u32 = selector_id!("payable");
 const PAYABLE_MUT_ID: u32 = selector_id!("payable_mut");
 const UNPAYABLE_ID: u32 = selector_id!("unpayable");
 const UNPAYABLE_MUT_ID: u32 = selector_id!("unpayable_mut");
@@ -26,11 +22,7 @@ fn main() {
         TraitMessageInfo,
     };
     use ink_env::DefaultEnvironment;
-    assert!(
-        <<TraitDefinitionRegistry<DefaultEnvironment>
-            as PayableDefinition>::__ink_TraitInfo
-            as TraitMessageInfo<PAYABLE_ID>>::PAYABLE,
-    );
+
     assert!(
         <<TraitDefinitionRegistry<DefaultEnvironment>
             as PayableDefinition>::__ink_TraitInfo

--- a/integration-tests/internal/storage-types/lib.rs
+++ b/integration-tests/internal/storage-types/lib.rs
@@ -251,7 +251,7 @@ mod storage_types {
         }
 
         #[ink(message, payable)]
-        pub fn payable(&self) -> Result<ink::U256, ()> {
+        pub fn payable(&mut self) -> Result<ink::U256, ()> {
             Ok(self.env().transferred_value())
         }
     }

--- a/integration-tests/public/contract-transfer/lib.rs
+++ b/integration-tests/public/contract-transfer/lib.rs
@@ -49,7 +49,7 @@ pub mod give_me {
         /// The method needs to be annotated with `payable`; only then it is
         /// allowed to receive value as part of the call.
         #[ink(message, payable, selector = 0xCAFEBABE)]
-        pub fn was_it_ten(&self) {
+        pub fn was_it_ten(&mut self) {
             /*
             ink::env::debug_println!(
                 "received payment: {}",
@@ -111,7 +111,7 @@ pub mod give_me {
             use ink::codegen::Env;
             // given
             let accounts = default_accounts();
-            let give_me = create_contract(100.into());
+            let mut give_me = create_contract(100.into());
             let contract_account = give_me.env().address();
 
             // when
@@ -140,7 +140,7 @@ pub mod give_me {
         fn test_transferred_value_must_fail() {
             // given
             let accounts = default_accounts();
-            let give_me = create_contract(100.into());
+            let mut give_me = create_contract(100.into());
 
             // when
             // Push the new execution context which sets Eve as caller and

--- a/integration-tests/public/debugging-strategies/lib.rs
+++ b/integration-tests/public/debugging-strategies/lib.rs
@@ -63,7 +63,7 @@ mod debugging_strategies {
         }
 
         #[ink(message, payable)]
-        pub fn instantiate_and_call(&self, code_hash: ink::H256) -> bool {
+        pub fn instantiate_and_call(&mut self, code_hash: ink::H256) -> bool {
             let create_params = build_create::<DebuggingStrategiesRef>()
                 .code_hash(code_hash)
                 .endowment(0.into())
@@ -240,7 +240,7 @@ mod debugging_strategies {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call_builder = contract.call_builder::<DebuggingStrategies>();
+            let mut call_builder = contract.call_builder::<DebuggingStrategies>();
 
             let call = call_builder.instantiate_and_call(contract.code_hash);
             let call_res = client


### PR DESCRIPTION
## Summary
Closes #_
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Immutable messages (i.e. messages with a `&self` receiver) shouldn't modify state, as such they shouldn't be payable because receiving value inherently modifies blockchain state

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
