### PR TITLE
Minor Typo Fixes in Integration Test Modules

### DIFF
--- a/integration-tests/public/erc1155/lib.rs
+++ b/integration-tests/public/erc1155/lib.rs
@@ -199,7 +199,7 @@ mod erc1155 {
     type Owner = Address;
     type Operator = Address;
 
-    /// Indicate that a token transfer has occured.
+    /// Indicate that a token transfer has occurred.
     ///
     /// This must be emitted even if a zero value transfer occurs.
     #[ink(event)]

--- a/integration-tests/public/own-code-hash/lib.rs
+++ b/integration-tests/public/own-code-hash/lib.rs
@@ -62,7 +62,7 @@ mod own_code_hash {
                         )
                     })
                     .unwrap_or_else(|error| {
-                        panic!("Received a `LangError` while instatiating: {:?}", error)
+                        panic!("Received a `LangError` while instantiating: {:?}", error)
                     });
                 ink::ToAddr::to_addr(&cr)
             };


### PR DESCRIPTION


---



## Description
This pull request corrects minor typos in the documentation and panic messages within the `erc1155` and `own-code-hash` integration test modules.  
- Fixed "occured" → "occurred" in a comment.


---