### PR TITLE
Implement `SolEncode` and `SolDecode` for generated contract refs, call and message builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Solidity ABI support in `codegen`, `ink_env` and `ink_e2e` - [#2517](https://github.com/use-ink/ink/pull/2517)
 - Support Solidity ABI encoded constructor dispatch - [#2525](https://github.com/use-ink/ink/pull/2525)
 - Export `Weight` with Solidity encoding - [#2540](https://github.com/use-ink/ink/pull/2540)
+- Implement `SolEncode` and `SolDecode` for generated contract refs, call and message builders - [#2539](https://github.com/use-ink/ink/pull/2539)
 
 ### Changed
 - Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)

--- a/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
@@ -139,6 +139,28 @@ impl CallBuilder<'_> {
                         <::ink::Address as ::ink::scale_info::TypeInfo>::type_info()
                     }
                 }
+
+                // TODO: (@davidsemakula) Replace with derived implementations when available.
+                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+                impl<Abi> ::ink::SolDecode for #cb_ident<Abi> {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            addr: value,
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+                impl<'a, Abi> ::ink::SolEncode<'a> for #cb_ident<Abi> {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        &self.addr
+                    }
+                }
             };
         )
     }

--- a/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
@@ -79,6 +79,31 @@ impl CallBuilder<'_> {
         let span = self.contract.module().storage().span();
         let storage_ident = self.contract.module().storage().ident();
         let cb_ident = Self::call_builder_ident();
+        let sol_codec = if cfg!(any(ink_abi = "sol", ink_abi = "all")) {
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            quote_spanned!(span=>
+                impl<Abi> ::ink::SolDecode for #cb_ident<Abi> {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            addr: value,
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                impl<'a, Abi> ::ink::SolEncode<'a> for #cb_ident<Abi> {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        &self.addr
+                    }
+                }
+            )
+        } else {
+            quote!()
+        };
         quote_spanned!(span=>
             /// The ink! smart contract's call builder.
             ///
@@ -140,27 +165,7 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                // TODO: (@davidsemakula) Replace with derived implementations when available.
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                impl<Abi> ::ink::SolDecode for #cb_ident<Abi> {
-                    type SolType = ::ink::Address;
-
-                    fn from_sol_type(value: Self::SolType) -> Self {
-                        Self {
-                            addr: value,
-                            _marker: ::core::default::Default::default(),
-                        }
-                    }
-                }
-
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                impl<'a, Abi> ::ink::SolEncode<'a> for #cb_ident<Abi> {
-                    type SolType = &'a ::ink::Address;
-
-                    fn to_sol_type(&'a self) -> Self::SolType {
-                        &self.addr
-                    }
-                }
+                #sol_codec
             };
         )
     }

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -182,6 +182,30 @@ impl ContractRef<'_> {
                         >::type_info()
                     }
                 }
+
+                // TODO: (@davidsemakula) Replace with derived implementations when available.
+                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+                impl<Abi> ::ink::SolDecode for #ref_ident<Abi> {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            inner: <<#storage_ident
+                                as ::ink::codegen::ContractCallBuilder>::Type<Abi>
+                                as ::ink::env::call::FromAddr>::from_addr(value),
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+                impl<'a, Abi> ::ink::SolEncode<'a> for #ref_ident<Abi> {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        self.as_ref()
+                    }
+                }
             };
         )
     }

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -89,6 +89,33 @@ impl ContractRef<'_> {
         let storage_ident = self.contract.module().storage().ident();
         let ref_ident = self.generate_contract_ref_ident();
         let abi = default_abi!();
+        let sol_codec = if cfg!(any(ink_abi = "sol", ink_abi = "all")) {
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            quote_spanned!(span=>
+                impl<Abi> ::ink::SolDecode for #ref_ident<Abi> {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            inner: <<#storage_ident
+                                as ::ink::codegen::ContractCallBuilder>::Type<Abi>
+                                as ::ink::env::call::FromAddr>::from_addr(value),
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                impl<'a, Abi> ::ink::SolEncode<'a> for #ref_ident<Abi> {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        self.as_ref()
+                    }
+                }
+            )
+        } else {
+            quote!()
+        };
         quote_spanned!(span=>
             #[derive(
                 ::core::fmt::Debug,
@@ -183,29 +210,7 @@ impl ContractRef<'_> {
                     }
                 }
 
-                // TODO: (@davidsemakula) Replace with derived implementations when available.
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                impl<Abi> ::ink::SolDecode for #ref_ident<Abi> {
-                    type SolType = ::ink::Address;
-
-                    fn from_sol_type(value: Self::SolType) -> Self {
-                        Self {
-                            inner: <<#storage_ident
-                                as ::ink::codegen::ContractCallBuilder>::Type<Abi>
-                                as ::ink::env::call::FromAddr>::from_addr(value),
-                            _marker: ::core::default::Default::default(),
-                        }
-                    }
-                }
-
-                #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-                impl<'a, Abi> ::ink::SolEncode<'a> for #ref_ident<Abi> {
-                    type SolType = &'a ::ink::Address;
-
-                    fn to_sol_type(&'a self) -> Self::SolType {
-                        self.as_ref()
-                    }
-                }
+                #sol_codec
             };
         )
     }

--- a/crates/ink/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_builder.rs
@@ -211,6 +211,34 @@ impl CallBuilder<'_> {
                     <::ink::Address as ::ink::scale_info::TypeInfo>::type_info()
                 }
             }
+
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<E, Abi> ::ink::SolDecode for #call_builder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = ::ink::Address;
+
+                fn from_sol_type(value: Self::SolType) -> Self {
+                    Self {
+                        addr: value,
+                        _marker: ::core::default::Default::default(),
+                    }
+                }
+            }
+
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_builder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = &'a ::ink::Address;
+
+                fn to_sol_type(&'a self) -> Self::SolType {
+                    &self.addr
+                }
+            }
         )
     }
 

--- a/crates/ink/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_builder.rs
@@ -168,6 +168,37 @@ impl CallBuilder<'_> {
     fn generate_auxiliary_trait_impls(&self) -> TokenStream2 {
         let span = self.span();
         let call_builder_ident = self.ident();
+        let sol_codec = if cfg!(any(ink_abi = "sol", ink_abi = "all")) {
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            quote_spanned!(span=>
+                impl<E, Abi> ::ink::SolDecode for #call_builder_ident<E, Abi>
+                where
+                    E: ::ink::env::Environment,
+                {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            addr: value,
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_builder_ident<E, Abi>
+                where
+                    E: ::ink::env::Environment,
+                {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        &self.addr
+                    }
+                }
+            )
+        } else {
+            quote!()
+        };
         quote_spanned!(span=>
             /// We require this manual implementation since the derive produces incorrect trait bounds.
             impl<E, Abi> ::core::clone::Clone for #call_builder_ident<E, Abi>
@@ -212,33 +243,7 @@ impl CallBuilder<'_> {
                 }
             }
 
-            // TODO: (@davidsemakula) Replace with derived implementations when available.
-            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-            impl<E, Abi> ::ink::SolDecode for #call_builder_ident<E, Abi>
-            where
-                E: ::ink::env::Environment,
-            {
-                type SolType = ::ink::Address;
-
-                fn from_sol_type(value: Self::SolType) -> Self {
-                    Self {
-                        addr: value,
-                        _marker: ::core::default::Default::default(),
-                    }
-                }
-            }
-
-            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-            impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_builder_ident<E, Abi>
-            where
-                E: ::ink::env::Environment,
-            {
-                type SolType = &'a ::ink::Address;
-
-                fn to_sol_type(&'a self) -> Self::SolType {
-                    &self.addr
-                }
-            }
+            #sol_codec
         )
     }
 

--- a/crates/ink/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_forwarder.rs
@@ -207,6 +207,35 @@ impl CallForwarder<'_> {
                     >::type_info()
                 }
             }
+
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<E, Abi> ::ink::SolDecode for #call_forwarder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = ::ink::Address;
+
+                fn from_sol_type(value: Self::SolType) -> Self {
+                    Self {
+                        builder: <<Self as ::ink::codegen::TraitCallBuilder>::Builder
+                            as ::ink::env::call::FromAddr>::from_addr(value),
+                        _marker: ::core::default::Default::default(),
+                    }
+                }
+            }
+
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_forwarder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = &'a ::ink::Address;
+
+                fn to_sol_type(&'a self) -> Self::SolType {
+                    self.as_ref()
+                }
+            }
         )
     }
 

--- a/crates/ink/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_forwarder.rs
@@ -160,6 +160,38 @@ impl CallForwarder<'_> {
     fn generate_auxiliary_trait_impls(&self) -> TokenStream2 {
         let span = self.span();
         let call_forwarder_ident = self.ident();
+        let sol_codec = if cfg!(any(ink_abi = "sol", ink_abi = "all")) {
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            quote_spanned!(span=>
+                impl<E, Abi> ::ink::SolDecode for #call_forwarder_ident<E, Abi>
+                where
+                    E: ::ink::env::Environment,
+                {
+                    type SolType = ::ink::Address;
+
+                    fn from_sol_type(value: Self::SolType) -> Self {
+                        Self {
+                            builder: <<Self as ::ink::codegen::TraitCallBuilder>::Builder
+                                as ::ink::env::call::FromAddr>::from_addr(value),
+                            _marker: ::core::default::Default::default(),
+                        }
+                    }
+                }
+
+                impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_forwarder_ident<E, Abi>
+                where
+                    E: ::ink::env::Environment,
+                {
+                    type SolType = &'a ::ink::Address;
+
+                    fn to_sol_type(&'a self) -> Self::SolType {
+                        self.as_ref()
+                    }
+                }
+            )
+        } else {
+            quote!()
+        };
         quote_spanned!(span=>
             /// We require this manual implementation since the derive produces incorrect trait bounds.
             impl<E, Abi> ::core::clone::Clone for #call_forwarder_ident<E, Abi>
@@ -208,34 +240,7 @@ impl CallForwarder<'_> {
                 }
             }
 
-            // TODO: (@davidsemakula) Replace with derived implementations when available.
-            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-            impl<E, Abi> ::ink::SolDecode for #call_forwarder_ident<E, Abi>
-            where
-                E: ::ink::env::Environment,
-            {
-                type SolType = ::ink::Address;
-
-                fn from_sol_type(value: Self::SolType) -> Self {
-                    Self {
-                        builder: <<Self as ::ink::codegen::TraitCallBuilder>::Builder
-                            as ::ink::env::call::FromAddr>::from_addr(value),
-                        _marker: ::core::default::Default::default(),
-                    }
-                }
-            }
-
-            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
-            impl<'a, E, Abi> ::ink::SolEncode<'a> for #call_forwarder_ident<E, Abi>
-            where
-                E: ::ink::env::Environment,
-            {
-                type SolType = &'a ::ink::Address;
-
-                fn to_sol_type(&'a self) -> Self::SolType {
-                    self.as_ref()
-                }
-            }
+            #sol_codec
         )
     }
 

--- a/crates/ink/codegen/src/generator/trait_def/message_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/message_builder.rs
@@ -127,6 +127,31 @@ impl MessageBuilder<'_> {
             {
                 type Env = E;
             }
+
+            // TODO: (@davidsemakula) Replace with derived implementations when available.
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<E, Abi> ::ink::SolDecode for #message_builder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = ();
+
+                fn from_sol_type(_: Self::SolType) -> Self {
+                    Self {
+                        _marker: ::core::default::Default::default(),
+                    }
+                }
+            }
+
+            #[cfg(any(ink_abi = "sol", ink_abi = "all"))]
+            impl<'a, E, Abi> ::ink::SolEncode<'a> for #message_builder_ident<E, Abi>
+            where
+                E: ::ink::env::Environment,
+            {
+                type SolType = ();
+
+                fn to_sol_type(&'a self) {}
+            }
         )
     }
 

--- a/crates/ink/tests/ui/abi/sol/pass/constructor-contract-ref.rs
+++ b/crates/ink/tests/ui/abi/sol/pass/constructor-contract-ref.rs
@@ -1,0 +1,25 @@
+#![allow(unexpected_cfgs)]
+
+#[ink::contract]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {
+        contract: Option<ContractRef>
+    }
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {
+                contract: None
+            }
+        }
+
+        #[ink(message)]
+        pub fn message(&mut self, contract: ContractRef) {
+            self.contract = Some(contract);
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Allows contract refs to be used as constructor and message arguments when ABI is "sol"

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
