### PR TITLE
docs: fix typos

### DIFF
--- a/integration-tests/public/debugging-strategies/lib.rs
+++ b/integration-tests/public/debugging-strategies/lib.rs
@@ -86,7 +86,7 @@ mod debugging_strategies {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instatiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {:?}", error)
                 });
 
             let call = build_call()

--- a/integration-tests/public/trait-erc20/lib.rs
+++ b/integration-tests/public/trait-erc20/lib.rs
@@ -288,7 +288,7 @@ mod erc20 {
             let Transfer { from, to, value } = decoded_event;
             assert_eq!(from, expected_from, "encountered invalid Transfer.from");
             assert_eq!(to, expected_to, "encountered invalid Transfer.to");
-            assert_eq!(value, expected_value, "encountered invalid Trasfer.value");
+            assert_eq!(value, expected_value, "encountered invalid Transfer.value");
 
             fn encoded_into_hash<T>(entity: T) -> Hash
             where
@@ -424,7 +424,7 @@ mod erc20 {
                 Some(accounts.alice),
                 100.into(),
             );
-            // Check the second transfer event relating to the actual trasfer.
+            // Check the second transfer event relating to the actual transfer.
             assert_transfer_event(
                 &emitted_events[1],
                 Some(accounts.alice),


### PR DESCRIPTION
## Description

This PR fixes several typos in comments and error messages:
In comments: Changed "trasfer" to "transfer"
In error message: Fixed "Trasfer" to "Transfer"
In error message: Fixed "instatiating" to "instantiating"
These changes improve readability and code quality without affecting any functionality.