### PR TITLE
Improve handling of Solidity constructor return and revert data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `SolEncode` and `SolDecode` for generated contract refs, call and message builders - [#2539](https://github.com/use-ink/ink/pull/2539)
 - Abstractions for mapping Rust/ink! `Result` and error types to/from Solidity ABI error and result representations - [#2543](https://github.com/use-ink/ink/pull/2543)
 - `Derive` macros for implementing `SolEncode` and `SolDecode` for arbitrary types - [#2549](https://github.com/use-ink/ink/pull/2549)
+- Improve handling of Solidity constructor return and revert data - [#2552](https://github.com/use-ink/ink/pull/2552)
 
 ### Changed
 - Use marker trait for finding ink! storage `struct` during code analysis - [2499](https://github.com/use-ink/ink/pull/2499)

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -336,7 +336,7 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<InstantiateDryRunResult<E>, Self::Error>;
+    ) -> Result<InstantiateDryRunResult<E, Abi>, Self::Error>;
 
     /// todo
     async fn map_account(&mut self, caller: &Keypair) -> Result<(), Self::Error>;

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -300,7 +300,7 @@ where
     /// to add a margin to the gas limit.
     pub async fn submit(
         &mut self,
-    ) -> Result<InstantiationResult<E, B::EventLog>, B::Error> {
+    ) -> Result<InstantiationResult<E, B::EventLog, Abi>, B::Error> {
         // we have to make sure the account was mapped
         let _map = B::map_account(self.client, self.caller).await; // todo will fail if instantiation happened before
 
@@ -346,7 +346,7 @@ where
     }
 
     /// Dry run the instantiate call.
-    pub async fn dry_run(&mut self) -> Result<InstantiateDryRunResult<E>, B::Error> {
+    pub async fn dry_run(&mut self) -> Result<InstantiateDryRunResult<E, Abi>, B::Error> {
         B::bare_instantiate_dry_run(
             self.client,
             self.contract_name,

--- a/crates/e2e/src/builders.rs
+++ b/crates/e2e/src/builders.rs
@@ -36,6 +36,7 @@ pub type CreateBuilderPartial<E, ContractRef, Args, R, Abi> = CreateBuilder<
     Set<LimitParamsV2>,
     Set<ExecutionInput<Args, Abi>>,
     Set<ReturnType<R>>,
+    Abi,
 >;
 
 /// Get the encoded constructor arguments from the partially initialized `CreateBuilder`

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -323,7 +323,7 @@ where
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<InstantiateDryRunResult<E>, Self::Error> {
+    ) -> Result<InstantiateDryRunResult<E, Abi>, Self::Error> {
         // todo has to be: let _ = <Client<AccountId, S> as
         // BuilderClient<E>>::map_account_dry_run(self, &caller).await;
         let _ =

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -567,7 +567,7 @@ where
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
         value: E::Balance,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<InstantiateDryRunResult<E>, Self::Error> {
+    ) -> Result<InstantiateDryRunResult<E, Abi>, Self::Error> {
         // todo beware side effect! this is wrong, we have to batch up the `map_account`
         // into the RPC dry run instead
         let _ = self.map_account(caller).await;

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -346,16 +346,17 @@ where
 pub fn instantiate_contract<E, ContractRef, Args, R, Abi>(
     params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
 ) -> Result<
-    ink_primitives::ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>,
+    ink_primitives::ConstructorResult<
+        <R as ConstructorReturnType<ContractRef, Abi>>::Output,
+    >,
 >
 where
     E: Environment,
     ContractRef: FromAddr + crate::ContractReverseReference,
     <ContractRef as crate::ContractReverseReference>::Type:
         crate::reflect::ContractConstructorDecoder,
-
     Args: AbiEncodeWith<Abi>,
-    R: ConstructorReturnType<ContractRef>,
+    R: ConstructorReturnType<ContractRef, Abi>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         TypedEnvBackend::instantiate_contract::<E, ContractRef, Args, R, Abi>(

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -366,7 +366,7 @@ pub trait TypedEnvBackend: EnvBackend {
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
     ) -> Result<
         ink_primitives::ConstructorResult<
-            <R as ConstructorReturnType<ContractRef>>::Output,
+            <R as ConstructorReturnType<ContractRef, Abi>>::Output,
         >,
     >
     where
@@ -375,7 +375,7 @@ pub trait TypedEnvBackend: EnvBackend {
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
         Args: AbiEncodeWith<Abi>,
-        R: ConstructorReturnType<ContractRef>;
+        R: ConstructorReturnType<ContractRef, Abi>;
 
     /// Terminates a smart contract.
     ///

--- a/crates/env/src/call/common.rs
+++ b/crates/env/src/call/common.rs
@@ -22,9 +22,11 @@ use ink_primitives::{
         Sol,
     },
     sol::{
+        SolErrorDecode,
         SolResultDecode,
         SolResultDecodeError,
     },
+    LangError,
     MessageResult,
 };
 use pallet_revive_uapi::ReturnErrorCode;
@@ -174,6 +176,113 @@ impl From<SolResultDecodeError> for crate::Error {
                 Self::ReturnError(ReturnErrorCode::CalleeReverted)
             }
             SolResultDecodeError::Decode => Self::DecodeSol(ink_primitives::sol::Error),
+        }
+    }
+}
+
+/// A trait for decoding constructor error data based on ABI.
+///
+/// # Note
+///
+/// This is necessary because constructors supporting different ABIs encode return data
+/// differently.
+///
+/// For example, ink! ABI encoded constructors return data encoded as
+/// `ConstructorResult<Result<_, Error>, LangErr>` where `Error` is either the user
+/// defined error for fallible constructors, or unit (i.e. `()`) for infallible
+/// constructors. On the other hand, Solidity ABI encoded constructors always return the
+/// output data directly and the state of the revert flag determines whether its "normal"
+/// return data or error data.
+///
+/// This trait assumes the caller has already checked that the revert flag is set.
+pub trait DecodeConstructorError<Abi>: Sized {
+    /// Decodes constructor error data.
+    fn decode_error_output(buffer: &[u8]) -> ConstructorError<Self>;
+}
+
+/// A decoded constructor error.
+pub enum ConstructorError<E> {
+    /// A user defined error.
+    Contract(E),
+    /// A `LangError`.
+    Lang(LangError),
+    /// An environmental error.
+    Env(crate::Error),
+}
+
+impl<E> DecodeConstructorError<Ink> for E
+where
+    E: Decode,
+{
+    fn decode_error_output(mut buffer: &[u8]) -> ConstructorError<Self> {
+        // ink! ABI encoded constructors return data encoded as
+        // `ConstructorResult<Result<_, Error>, LangErr>` where `Error` is either the user
+        // defined error for fallible entry points or unit (i.e. `()`) for
+        // infallible entry points.
+        let out_return_value = &mut buffer;
+
+        // Debug friendly SCALE decode errors.
+        const INVALID_OUTER_RESULT: &str = "Invalid outer constructor Result encoding, \
+        expected 0 or 1 as the first byte";
+        const INVALID_INNER_RESULT: &str = "Invalid inner constructor Result encoding, \
+        expected 0 or 1 as the first byte";
+        const REVERT_BUT_NOT_ERROR_DATA: &str =
+            "The callee reverted, but did not encode an error in the output buffer.";
+        fn scale_decode_err<T>(desc: &'static str) -> ConstructorError<T> {
+            ConstructorError::Env(crate::Error::Decode(desc.into()))
+        }
+
+        let Ok(lang_result_variant) = <_ as scale::Input>::read_byte(out_return_value)
+        else {
+            return scale_decode_err(INVALID_OUTER_RESULT);
+        };
+        match lang_result_variant {
+            // 0 == `ConstructorResult::Ok` variant
+            0 => {
+                let Ok(inner_result_variant) =
+                    <_ as scale::Input>::read_byte(out_return_value)
+                else {
+                    return scale_decode_err(INVALID_INNER_RESULT);
+                };
+                match inner_result_variant {
+                    // 0 == `Ok` variant
+                    0 => scale_decode_err(REVERT_BUT_NOT_ERROR_DATA),
+                    // 1 == `Err` variant
+                    1 => {
+                        let decoded = <E as scale::Decode>::decode(out_return_value);
+                        match decoded {
+                            Ok(contract_err) => ConstructorError::Contract(contract_err),
+                            Err(error) => {
+                                ConstructorError::Env(crate::Error::Decode(error))
+                            }
+                        }
+                    }
+                    _ => scale_decode_err(INVALID_INNER_RESULT),
+                }
+            }
+            // 1 == `ConstructorResult::Err` variant
+            1 => {
+                let decoded = <LangError as scale::Decode>::decode(out_return_value);
+                match decoded {
+                    Ok(lang_err) => ConstructorError::Lang(lang_err),
+                    Err(error) => ConstructorError::Env(crate::Error::Decode(error)),
+                }
+            }
+            _ => scale_decode_err(INVALID_OUTER_RESULT),
+        }
+    }
+}
+
+impl<E> DecodeConstructorError<Sol> for E
+where
+    E: SolErrorDecode,
+{
+    fn decode_error_output(buffer: &[u8]) -> ConstructorError<Self> {
+        // Solidity ABI encoded entry points return error data directly.
+        let decoded = SolErrorDecode::decode(buffer);
+        match decoded {
+            Ok(contract_err) => ConstructorError::Contract(contract_err),
+            Err(error) => ConstructorError::Env(crate::Error::DecodeSol(error)),
         }
     }
 }

--- a/crates/env/src/call/common.rs
+++ b/crates/env/src/call/common.rs
@@ -125,9 +125,13 @@ impl<T> Unwrap for Set<T> {
     }
 }
 
-/// A trait for decoding the output of a message based on different ABIs.
-/// This is necessary as contracts with different ABIs have different return types.
-/// For example, Solidity contracts return the output directly without `MessageResult`.
+/// A trait for decoding the output of a message based on the ABI.
+///
+/// # Note
+///
+/// This is necessary because messages supporting different ABI have different return
+/// types. For example, Solidity ABI encoded messages return the output directly without
+/// `MessageResult`.
 pub trait DecodeMessageResult<Abi>: Sized {
     /// Decodes the output of a message call, requiring the output
     /// to be wrapped with `MessageResult` (if not included in the output).

--- a/crates/env/src/call/mod.rs
+++ b/crates/env/src/call/mod.rs
@@ -24,6 +24,8 @@ mod selector;
 pub mod utils {
     pub use super::{
         common::{
+            ConstructorError,
+            DecodeConstructorError,
             DecodeMessageResult,
             ReturnType,
             Set,

--- a/crates/env/src/engine/mod.rs
+++ b/crates/env/src/engine/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cfg_if::cfg_if;
+#[cfg(feature = "unstable-hostfn")]
+use ink_primitives::ConstructorResult;
+#[cfg(feature = "unstable-hostfn")]
+use pallet_revive_uapi::ReturnErrorCode;
+
 use crate::backend::{
     EnvBackend,
     TypedEnvBackend,
@@ -19,20 +25,16 @@ use crate::backend::{
 #[cfg(feature = "unstable-hostfn")]
 use crate::{
     call::{
+        utils::{
+            ConstructorError,
+            DecodeConstructorError,
+        },
         ConstructorReturnType,
         FromAddr,
     },
     Error,
     Result as EnvResult,
 };
-use cfg_if::cfg_if;
-#[cfg(feature = "unstable-hostfn")]
-use ink_primitives::{
-    ConstructorResult,
-    LangError,
-};
-#[cfg(feature = "unstable-hostfn")]
-use pallet_revive_uapi::ReturnErrorCode;
 
 /// Convert a slice into an array reference.
 ///
@@ -74,25 +76,25 @@ cfg_if! {
 // We only use this function when 1) compiling for PolkaVM 2) compiling for tests.
 #[cfg_attr(all(feature = "std", not(test)), allow(dead_code))]
 #[cfg(feature = "unstable-hostfn")] // only usages are when unstable-hostfn is enabled
-pub(crate) fn decode_instantiate_result<I, ContractRef, R>(
+pub(crate) fn decode_instantiate_result<I, ContractRef, R, Abi>(
     instantiate_result: EnvResult<()>,
     out_address: &mut I,
-    out_return_value: &mut I,
-) -> EnvResult<ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>>
+    out_return_value: &[u8],
+) -> EnvResult<ConstructorResult<<R as ConstructorReturnType<ContractRef, Abi>>::Output>>
 where
     I: scale::Input,
     ContractRef: FromAddr,
-    R: ConstructorReturnType<ContractRef>,
+    R: ConstructorReturnType<ContractRef, Abi>,
 {
     match instantiate_result {
         Ok(()) => {
             let addr = scale::Decode::decode(out_address)?;
             let contract_ref = <ContractRef as FromAddr>::from_addr(addr);
-            let output = <R as ConstructorReturnType<ContractRef>>::ok(contract_ref);
+            let output = <R as ConstructorReturnType<ContractRef, Abi>>::ok(contract_ref);
             Ok(Ok(output))
         }
         Err(Error::ReturnError(ReturnErrorCode::CalleeReverted)) => {
-            decode_instantiate_err::<I, ContractRef, R>(out_return_value)
+            decode_instantiate_err::<ContractRef, R, Abi>(out_return_value)
         }
         Err(actual_error) => Err(actual_error),
     }
@@ -100,49 +102,33 @@ where
 
 #[cfg_attr(all(feature = "std", not(test)), allow(dead_code))]
 #[cfg(feature = "unstable-hostfn")] // only usages are when unstable-hostfn is enabled
-fn decode_instantiate_err<I, ContractRef, R>(
-    out_return_value: &mut I,
-) -> EnvResult<ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>>
+fn decode_instantiate_err<ContractRef, R, Abi>(
+    out_return_value: &[u8],
+) -> EnvResult<ConstructorResult<<R as ConstructorReturnType<ContractRef, Abi>>::Output>>
 where
-    I: scale::Input,
     ContractRef: FromAddr,
-    R: ConstructorReturnType<ContractRef>,
+    R: ConstructorReturnType<ContractRef, Abi>,
 {
-    let constructor_result_variant = out_return_value.read_byte()?;
-    match constructor_result_variant {
-        // 0 == `ConstructorResult::Ok` variant
-        0 => {
-            if <R as ConstructorReturnType<ContractRef>>::IS_RESULT {
-                let result_variant = out_return_value.read_byte()?;
-                match result_variant {
-                    // 0 == `Ok` variant
-                    0 => panic!("The callee reverted, but did not encode an error in the output buffer."),
-                    // 1 == `Err` variant
-                    1 => {
-                        let contract_err = <<R as ConstructorReturnType<ContractRef>>::Error
-                        as scale::Decode>::decode(out_return_value)?;
-                        let err = <R as ConstructorReturnType<ContractRef>>::err(contract_err)
-                            .unwrap_or_else(|| {
-                                panic!("Expected an error instance for return type where IS_RESULT == true")
-                            });
-                        Ok(Ok(err))
-                    }
-                    _ => Err(Error::Decode(
-                        "Invalid inner constructor Result encoding, expected 0 or 1 as the first byte".into())
-                    )
+    let decoded_error =
+        <<R as ConstructorReturnType<ContractRef, Abi>>::Error as DecodeConstructorError<
+            Abi,
+        >>::decode_error_output(out_return_value);
+    match decoded_error {
+        ConstructorError::Contract(contract_err) => {
+            let error_output =
+                <R as ConstructorReturnType<ContractRef, Abi>>::err(contract_err);
+            match error_output {
+                Some(output) => Ok(Ok(output)),
+                None => {
+                    // No user defined error variant, and successful error decoding
+                    // (i.e. to unit), so we maintain the `CalleeReverted`
+                    // environmental error.
+                    Err(Error::ReturnError(ReturnErrorCode::CalleeReverted))
                 }
-            } else {
-                panic!("The callee reverted, but did not encode an error in the output buffer.")
             }
         }
-        // 1 == `ConstructorResult::Err` variant
-        1 => {
-            let lang_err = <LangError as scale::Decode>::decode(out_return_value)?;
-            Ok(Err(lang_err))
-        }
-        _ => Err(Error::Decode(
-            "Invalid outer constructor Result encoding, expected 0 or 1 as the first byte".into())
-        )
+        ConstructorError::Lang(lang_err) => Ok(Err(lang_err)),
+        ConstructorError::Env(env_err) => Err(env_err),
     }
 }
 
@@ -156,11 +142,12 @@ mod decode_instantiate_result_tests {
     // The `Result` type used to represent the programmer defined contract output.
     type ContractResult<T, E> = Result<T, E>;
 
-    #[derive(scale::Encode, scale::Decode)]
+    #[derive(Debug, PartialEq, scale::Encode, scale::Decode)]
     struct ContractError(String);
 
     // The `allow(dead_code)` is for the `AccountId` in the struct.
     #[allow(dead_code)]
+    #[derive(Debug, PartialEq)]
     struct TestContractRef(Address);
 
     impl crate::ContractEnv for TestContractRef {
@@ -178,20 +165,18 @@ mod decode_instantiate_result_tests {
     ) -> EnvResult<ConstructorResult<Result<TestContractRef, ContractError>>> {
         let out_address = Vec::new();
         let encoded_return_value = return_value.encode();
-        decode_return_value_fallible(
-            &mut &out_address[..],
-            &mut &encoded_return_value[..],
-        )
+        decode_return_value_fallible(&mut &out_address[..], &encoded_return_value[..])
     }
 
     fn decode_return_value_fallible<I: scale::Input>(
         out_address: &mut I,
-        out_return_value: &mut I,
+        out_return_value: &[u8],
     ) -> EnvResult<ConstructorResult<Result<TestContractRef, ContractError>>> {
         decode_instantiate_result::<
             I,
             TestContractRef,
             Result<TestContractRef, ContractError>,
+            ink_primitives::abi::Ink,
         >(
             Err(ReturnErrorCode::CalleeReverted.into()),
             out_address,
@@ -200,13 +185,18 @@ mod decode_instantiate_result_tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "The callee reverted, but did not encode an error in the output buffer."
-    )]
     fn revert_branch_rejects_valid_output_buffer_with_success_case() {
         let return_value = ConstructorResult::Ok(ContractResult::Ok(()));
 
-        let _decoded_result = encode_and_decode_return_value(return_value);
+        let decoded_result = encode_and_decode_return_value(return_value);
+
+        let expected_error: EnvResult<
+            ConstructorResult<Result<TestContractRef, ContractError>>,
+        > = EnvResult::Err(crate::Error::Decode(
+            "The callee reverted, but did not encode an error in the output buffer."
+                .into(),
+        ));
+        assert_eq!(decoded_result, expected_error);
     }
 
     #[test]
@@ -245,7 +235,7 @@ mod decode_instantiate_result_tests {
 
         let decoded_result = decode_return_value_fallible(
             &mut &out_address[..],
-            &mut &invalid_encoded_return_value[..],
+            &invalid_encoded_return_value[..],
         );
 
         assert!(matches!(decoded_result, Err(crate::Error::Decode(_))))

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -645,7 +645,7 @@ impl TypedEnvBackend for EnvInstance {
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
     ) -> Result<
         ink_primitives::ConstructorResult<
-            <R as ConstructorReturnType<ContractRef>>::Output,
+            <R as ConstructorReturnType<ContractRef, Abi>>::Output,
         >,
     >
     where
@@ -654,7 +654,7 @@ impl TypedEnvBackend for EnvInstance {
         <ContractRef as crate::ContractReverseReference>::Type:
             crate::reflect::ContractConstructorDecoder,
         Args: AbiEncodeWith<Abi>,
-        R: ConstructorReturnType<ContractRef>,
+        R: ConstructorReturnType<ContractRef, Abi>,
     {
         let endowment = params.endowment();
         let salt_bytes = params.salt_bytes();

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -603,14 +603,14 @@ impl TypedEnvBackend for EnvInstance {
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, RetType, Abi>,
     ) -> Result<
         ink_primitives::ConstructorResult<
-            <RetType as ConstructorReturnType<ContractRef>>::Output,
+            <RetType as ConstructorReturnType<ContractRef, Abi>>::Output,
         >,
     >
     where
         E: Environment,
         ContractRef: FromAddr,
         Args: AbiEncodeWith<Abi>,
-        RetType: ConstructorReturnType<ContractRef>,
+        RetType: ConstructorReturnType<ContractRef, Abi>,
     {
         let mut scoped = self.scoped_buffer();
         /*
@@ -671,10 +671,10 @@ impl TypedEnvBackend for EnvInstance {
             salt,
         );
 
-        crate::engine::decode_instantiate_result::<_, ContractRef, RetType>(
+        crate::engine::decode_instantiate_result::<_, ContractRef, RetType, Abi>(
             instantiate_result.map_err(Into::into),
             &mut &out_address[..],
-            &mut &output_data[..],
+            &output_data[..],
         )
     }
 

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -141,7 +141,10 @@ impl ContractRef<'_> {
                     type Type = #storage_ident;
                 }
 
-                impl ::ink::env::call::ConstructorReturnType<#ref_ident> for #storage_ident {
+                impl<Abi> ::ink::env::call::ConstructorReturnType<#ref_ident, Abi> for #storage_ident
+                where
+                    (): ink::env::call::utils::DecodeConstructorError<Abi>
+                {
                     type Output = #ref_ident;
                     type Error = ();
 
@@ -150,10 +153,10 @@ impl ContractRef<'_> {
                     }
                 }
 
-                impl<E> ::ink::env::call::ConstructorReturnType<#ref_ident>
+                impl<E, Abi> ::ink::env::call::ConstructorReturnType<#ref_ident, Abi>
                     for ::core::result::Result<#storage_ident, E>
                 where
-                    E: ::ink::scale::Decode
+                    E: ink::env::call::utils::DecodeConstructorError<Abi>
                 {
                     const IS_RESULT: bool = true;
 
@@ -620,6 +623,7 @@ impl ContractRef<'_> {
                 ::ink::env::call::utils::Set<::ink::env::call::LimitParamsV2 >,
                 ::ink::env::call::utils::Set<::ink::env::call::ExecutionInput<#arg_list, #abi_ty>>,
                 ::ink::env::call::utils::Set<::ink::env::call::utils::ReturnType<#ret_type>>,
+                #abi_ty
             > {
                 ::ink::env::call::build_create_abi::<Self, #abi_ty>()
                     .exec_input(

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -490,7 +490,7 @@ where
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
     ) -> Result<
         ink_primitives::ConstructorResult<
-            <R as ConstructorReturnType<ContractRef>>::Output,
+            <R as ConstructorReturnType<ContractRef, Abi>>::Output,
         >,
     >
     where
@@ -499,7 +499,7 @@ where
             ink_env::reflect::ContractConstructorDecoder,
 
         Args: AbiEncodeWith<Abi>,
-        R: ConstructorReturnType<ContractRef>,
+        R: ConstructorReturnType<ContractRef, Abi>,
     {
         ink_env::instantiate_contract::<E, ContractRef, Args, R, Abi>(params)
     }

--- a/crates/ink/tests/ui/abi/all/fail/message-selector-overlap.stderr
+++ b/crates/ink/tests/ui/abi/all/fail/message-selector-overlap.stderr
@@ -1,8 +1,8 @@
-error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `Contract`
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `contract::Contract`
   --> tests/ui/abi/all/fail/message-selector-overlap.rs:16:9
    |
 16 |         pub fn message(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         first implementation here
-   |         conflicting implementation for `Contract`
+   |         conflicting implementation for `contract::Contract`

--- a/crates/ink/tests/ui/abi/sol/fail/trait-message-selector-overlap.stderr
+++ b/crates/ink/tests/ui/abi/sol/fail/trait-message-selector-overlap.stderr
@@ -1,8 +1,8 @@
-error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `Contract`
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<3793696718>` for type `contract::Contract`
   --> tests/ui/abi/sol/fail/trait-message-selector-overlap.rs:28:9
    |
 23 |         pub fn message(&self) {}
    |         ------------------------ first implementation here
 ...
 28 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
+   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`

--- a/crates/ink/tests/ui/contract/fail/constructor/constructor-return-result-invalid.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor/constructor-return-result-invalid.stderr
@@ -1,43 +1,51 @@
-error[E0277]: the trait bound `ConstructorOutputValue<Result<u8, contract::Error>>: ConstructorOutput<Contract>` is not satisfied
+error[E0277]: the trait bound `ConstructorOutputValue<Result<u8, contract::Error>>: ConstructorOutput<contract::Contract>` is not satisfied
   --> tests/ui/contract/fail/constructor/constructor-return-result-invalid.rs:16:9
    |
 16 | /         pub fn constructor() -> Result<u8, Error> {
 17 | |             Ok(5_u8)
 18 | |         }
-   | |_________^ the trait `ConstructorOutput<Contract>` is not implemented for `ConstructorOutputValue<Result<u8, contract::Error>>`
+   | |_________^ the trait `ConstructorOutput<contract::Contract>` is not implemented for `ConstructorOutputValue<Result<u8, contract::Error>>`
    |
    = help: the following other types implement trait `ConstructorOutput<C>`:
              ConstructorOutputValue<C>
              ConstructorOutputValue<Result<C, E>>
 
-error[E0277]: the trait bound `Result<u8, contract::Error>: ConstructorReturnType<ContractRef>` is not satisfied
+error[E0276]: impl has stricter requirements than trait
+  --> tests/ui/contract/fail/constructor/constructor-return-result-invalid.rs:16:9
+   |
+16 | /         pub fn constructor() -> Result<u8, Error> {
+17 | |             Ok(5_u8)
+18 | |         }
+   | |_________^ impl has extra requirement `ConstructorOutputValue<Result<u8, contract::Error>>: ConstructorOutput<contract::Contract>`
+
+error[E0277]: the trait bound `Result<u8, contract::Error>: ConstructorReturnType<ContractRef, ink::abi::Ink>` is not satisfied
   --> tests/ui/contract/fail/constructor/constructor-return-result-invalid.rs:16:33
    |
 16 |           pub fn constructor() -> Result<u8, Error> {
-   |           -                       ^^^^^^^^^^^^^^^^^ the trait `ConstructorReturnType<ContractRef>` is not implemented for `Result<u8, contract::Error>`
+   |           -                       ^^^^^^^^^^^^^^^^^ the trait `ConstructorReturnType<ContractRef, ink::abi::Ink>` is not implemented for `Result<u8, contract::Error>`
    |  _________|
    | |
 17 | |             Ok(5_u8)
 18 | |         }
    | |_________- required by a bound introduced by this call
    |
-   = help: the following other types implement trait `ConstructorReturnType<C>`:
-             `Result<C, E>` implements `ConstructorReturnType<C>`
-             `Result<Contract, E>` implements `ConstructorReturnType<ContractRef>`
-note: required by a bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>>::returns`
+   = help: the following other types implement trait `ConstructorReturnType<C, Abi>`:
+             `Result<C, E>` implements `ConstructorReturnType<C, Abi>`
+             `Result<contract::Contract, E>` implements `ConstructorReturnType<ContractRef, Abi>`
+note: required by a bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>, Abi>::returns`
   --> $WORKSPACE/crates/env/src/call/create_builder.rs
    |
    |     pub fn returns<R>(
    |            ------- required by a bound in this associated function
 ...
-   |         R: ConstructorReturnType<ContractRef>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>>::returns`
+   |         R: ConstructorReturnType<ContractRef, Abi>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>, Abi>::returns`
 
-error[E0277]: the trait bound `ConstructorOutputValue<Result<u8, contract::Error>>: ConstructorOutput<Contract>` is not satisfied
+error[E0277]: the trait bound `ConstructorOutputValue<Result<u8, contract::Error>>: ConstructorOutput<contract::Contract>` is not satisfied
  --> tests/ui/contract/fail/constructor/constructor-return-result-invalid.rs:6:16
   |
 6 |     pub struct Contract {}
-  |                ^^^^^^^^ the trait `ConstructorOutput<Contract>` is not implemented for `ConstructorOutputValue<Result<u8, contract::Error>>`
+  |                ^^^^^^^^ the trait `ConstructorOutput<contract::Contract>` is not implemented for `ConstructorOutputValue<Result<u8, contract::Error>>`
   |
   = help: the following other types implement trait `ConstructorOutput<C>`:
             ConstructorOutputValue<C>

--- a/crates/ink/tests/ui/contract/fail/constructor/constructor-return-result-non-codec-error.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor/constructor-return-result-non-codec-error.stderr
@@ -33,15 +33,16 @@ error[E0277]: the trait bound `contract::Error: WrapperTypeDecode` is not satisf
              Rc<T>
              sp_core::Bytes
    = note: required for `contract::Error` to implement `ink::parity_scale_codec::Decode`
-   = note: required for `Result<ContractRef, contract::Error>` to implement `ConstructorReturnType<ContractRef>`
-note: required by a bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>>::returns`
+   = note: required for `contract::Error` to implement `DecodeConstructorError<ink::abi::Ink>`
+   = note: required for `Result<ContractRef, contract::Error>` to implement `ConstructorReturnType<ContractRef, ink::abi::Ink>`
+note: required by a bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>, Abi>::returns`
   --> $WORKSPACE/crates/env/src/call/create_builder.rs
    |
    |     pub fn returns<R>(
    |            ------- required by a bound in this associated function
 ...
-   |         R: ConstructorReturnType<ContractRef>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>>::returns`
+   |         R: ConstructorReturnType<ContractRef, Abi>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, Limits, Args, Unset<ReturnType<()>>, Abi>::returns`
 
 error[E0277]: the trait bound `contract::Error: TypeInfo` is not satisfied
  --> tests/ui/contract/fail/constructor/constructor-return-result-non-codec-error.rs:6:16

--- a/crates/ink/tests/ui/contract/fail/impl/impl-block-for-non-storage-01.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl/impl-block-for-non-storage-01.stderr
@@ -4,10 +4,10 @@ error[E0308]: mismatched types
 20 |     impl NonContract {
    |          ^^^^^^^^^^^ expected `IsSameType<Contract>`, found `IsSameType<NonContract>`
    |
-   = note: expected struct `IsSameType<Contract>`
+   = note: expected struct `IsSameType<contract::Contract>`
               found struct `IsSameType<NonContract>`
 
-error[E0599]: no function or associated item named `constructor_2` found for struct `Contract` in the current scope
+error[E0599]: no function or associated item named `constructor_2` found for struct `contract::Contract` in the current scope
   --> tests/ui/contract/fail/impl/impl-block-for-non-storage-01.rs:22:16
    |
 6  |       pub struct Contract {}
@@ -24,7 +24,7 @@ error[E0599]: no function or associated item named `constructor_2` found for str
    | |_______________|
    |
    |
-note: if you're trying to build a new `Contract`, consider using `contract::_::<impl Contract>::constructor_1` which returns `Contract`
+note: if you're trying to build a new `contract::Contract`, consider using `contract::_::<impl contract::Contract>::constructor_1` which returns `contract::Contract`
   --> tests/ui/contract/fail/impl/impl-block-for-non-storage-01.rs:10:9
    |
 10 |         pub fn constructor_1() -> Self {
@@ -35,7 +35,7 @@ help: there is an associated function `constructor_1` with a similar name
 22 +         pub fn constructor_1() -> Self {
    |
 
-error[E0599]: no function or associated item named `message_2` found for struct `Contract` in the current scope
+error[E0599]: no function or associated item named `message_2` found for struct `contract::Contract` in the current scope
   --> tests/ui/contract/fail/impl/impl-block-for-non-storage-01.rs:27:16
    |
 6  |       pub struct Contract {}
@@ -52,7 +52,7 @@ error[E0599]: no function or associated item named `message_2` found for struct 
    | |_______________|
    |
    |
-note: if you're trying to build a new `Contract`, consider using `contract::_::<impl Contract>::constructor_1` which returns `Contract`
+note: if you're trying to build a new `contract::Contract`, consider using `contract::_::<impl contract::Contract>::constructor_1` which returns `contract::Contract`
   --> tests/ui/contract/fail/impl/impl-block-for-non-storage-01.rs:10:9
    |
 10 |         pub fn constructor_1() -> Self {

--- a/crates/ink/tests/ui/contract/fail/impl/impl-block-for-non-storage-02.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl/impl-block-for-non-storage-02.stderr
@@ -4,5 +4,5 @@ error[E0308]: mismatched types
 21 |     impl NonContract {}
    |          ^^^^^^^^^^^ expected `IsSameType<Contract>`, found `IsSameType<NonContract>`
    |
-   = note: expected struct `IsSameType<Contract>`
+   = note: expected struct `IsSameType<contract::Contract>`
               found struct `IsSameType<NonContract>`

--- a/crates/ink/tests/ui/contract/fail/impl/impl-block-using-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl/impl-block-using-env-no-marker.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `env` found for reference `&Contract` in the current scope
+error[E0599]: no method named `env` found for reference `&contract::Contract` in the current scope
   --> tests/ui/contract/fail/impl/impl-block-using-env-no-marker.rs:24:26
    |
 24 |             let _ = self.env().caller();

--- a/crates/ink/tests/ui/contract/fail/impl/impl-block-using-static-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl/impl-block-using-static-env-no-marker.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no function or associated item named `env` found for struct `Contract` in the current scope
+error[E0599]: no function or associated item named `env` found for struct `contract::Contract` in the current scope
   --> tests/ui/contract/fail/impl/impl-block-using-static-env-no-marker.rs:22:27
    |
 6  |     pub struct Contract {}
@@ -7,9 +7,9 @@ error[E0599]: no function or associated item named `env` found for struct `Contr
 22 |             let _ = Self::env().caller();
    |                           ^^^ function or associated item not found in `Contract`
    |
-note: if you're trying to build a new `Contract` consider using one of the following associated functions:
-      contract::_::<impl Contract>::constructor
-      Contract::constructor_impl
+note: if you're trying to build a new `contract::Contract` consider using one of the following associated functions:
+      contract::_::<impl contract::Contract>::constructor
+      contract::Contract::constructor_impl
   --> tests/ui/contract/fail/impl/impl-block-using-static-env-no-marker.rs:10:9
    |
 10 |         pub fn constructor() -> Self {

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-1.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-1.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1083895717>` for type `Contract`
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1083895717>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-1.rs:43:9
    |
 38 |         fn message(&self) {}
    |         -------------------- first implementation here
 ...
 43 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
+   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
 
 error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1083895717>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-1.rs:41:5

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-2.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-2.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1518209067>` for type `Contract`
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<1518209067>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-2.rs:43:9
    |
 38 |         fn message(&self) {}
    |         -------------------- first implementation here
 ...
 43 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
+   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
 
 error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<1518209067>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-2.rs:41:5

--- a/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-3.stderr
+++ b/crates/ink/tests/ui/contract/fail/trait/trait-message-selector-overlap-3.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<42>` for type `Contract`
+error[E0119]: conflicting implementations of trait `DispatchableMessageInfo<42>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-3.rs:43:9
    |
 38 |         fn message1(&self) {}
    |         --------------------- first implementation here
 ...
 43 |         fn message2(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Contract`
+   |         ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
 
 error[E0119]: conflicting implementations of trait `TraitCallForwarderFor<42>` for type `contract::_::CallBuilder<ink::abi::Ink>`
   --> tests/ui/contract/fail/trait/trait-message-selector-overlap-3.rs:41:5

--- a/crates/primitives/src/reflect/dispatch.rs
+++ b/crates/primitives/src/reflect/dispatch.rs
@@ -227,6 +227,14 @@ pub trait DispatchableConstructorInfo<const ID: u32> {
         &mut &[::core::primitive::u8],
     ) -> Result<Self::Input, DispatchError>;
 
+    /// The closure for returning return data.
+    #[cfg(not(feature = "std"))]
+    const RETURN: fn(ReturnFlags, Result<(), &Self::Error>) -> !;
+
+    /// The closure for returning return data.
+    #[cfg(feature = "std")]
+    const RETURN: fn(ReturnFlags, Result<(), &Self::Error>) -> ();
+
     /// Yields `true` if the dispatchable ink! constructor is payable.
     const PAYABLE: bool;
 


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/ink/pull/2525 and https://github.com/use-ink/ink/pull/2543
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

- Represent Solidity constructor return data as `Result<(), Error>` i.e.
  - Constructors don't return arbitrary data for "normal" returns
  -  `Error` is either the user defined error for fallible constructors, or unit (i.e. `()`) for infallible constructors
  - `Error` is encoded as revert error data based on the  `SolErrorEncode` implementation for the `Error` type
- Provide `SolErrorEncode` and `SolErrorDecode` implementations for unit (i.e. `()`)
- Provide `SolErrorEncode` implementations for reference types (i.e. `&T` and `&mut T`) where `T: SolErrorEncode`
- Update related `ink_env` and `ink_e2e` abstractions to properly handle Solidity ABI encoded return and revert data for constructors

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
