### PR TITLE
Hotfix missing `tokio/net` feature in `substrate-prometheus-endpoint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1080,6 +1080,11 @@ jobs:
               # Build the comparison table
               echo "---master:"
               cat measurements-master
+              if [[ ! -s "measurements-master" ]]; then
+                echo "measurements-master is empty! It seems the CI job"
+                echo "to collect contract sizes was not run on master."
+                exit 1
+              fi
               echo "---branch:"
               cat measurements-${{ env.MEASUREMENTS_ID }}
               echo "---"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
  "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
  "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
  "staging-xcm",
+ "tokio",
  "trybuild",
 ]
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -59,6 +59,9 @@ deranged = { version = "=0.4.0", default-features = false }
 # Required for the doctest of `MessageBuilder::call`
 scale-info = { workspace = true, features = ["derive"] }
 
+[build-dependencies]
+tokio = { workspace = true, features = ["net"] }
+
 [features]
 default = [ "std" ]
 std = [

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -59,6 +59,8 @@ deranged = { version = "=0.4.0", default-features = false }
 # Required for the doctest of `MessageBuilder::call`
 scale-info = { workspace = true, features = ["derive"] }
 
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 [build-dependencies]
 tokio = { workspace = true, features = ["net"] }
 

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -44,6 +44,9 @@ ink_ir = { workspace = true, default-features = true }
 ink_metadata = { workspace = true } # todo why here too?
 trybuild = { workspace = true, features = ["diff"] }
 
+[build-dependencies]
+tokio = { workspace = true, features = ["net"] }
+
 [features]
 default = ["std"]
 std = [

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -44,6 +44,8 @@ ink_ir = { workspace = true, default-features = true }
 ink_metadata = { workspace = true } # todo why here too?
 trybuild = { workspace = true, features = ["diff"] }
 
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 [build-dependencies]
 tokio = { workspace = true, features = ["net"] }
 

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["ink", "blockchain", "edsl", "dylint", "linting"]
 
 [workspace.dependencies]
 ink_linting_utils = { version = "=6.0.0-alpha.1", path = "utils" }
+tokio = { version = "1.44.2" }
 
 [workspace.metadata.dylint]
 libraries = [

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -17,6 +17,9 @@ keywords = ["ink", "blockchain", "edsl", "dylint", "linting"]
 
 [workspace.dependencies]
 ink_linting_utils = { version = "=6.0.0-alpha.1", path = "utils" }
+
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 tokio = { version = "1.44.2" }
 
 [workspace.metadata.dylint]

--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
 ink_env = { version = "=6.0.0-alpha.1", path = "../../crates/env" }
+tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
 dylint_testing = "4.0.1"
@@ -34,6 +35,9 @@ dylint_testing = "4.0.1"
 # the `[[workspace.dev-dependencies]]` directive.
 ink = { version = "=6.0.0-alpha.1", path = "../../crates/ink" }
 ink_primitives = { version = "=6.0.0-alpha.1", path = "../../crates/primitives" }
+
+[build-dependencies]
+tokio = { workspace = true, features = ["net"] }
 
 # For the moment we have to include the tests as examples and
 # then use `dylint_testing::ui_test_examples`.

--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -23,6 +23,9 @@ log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
 ink_env = { version = "=6.0.0-alpha.1", path = "../../crates/env" }
+
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
@@ -36,6 +39,8 @@ dylint_testing = "4.0.1"
 ink = { version = "=6.0.0-alpha.1", path = "../../crates/ink" }
 ink_primitives = { version = "=6.0.0-alpha.1", path = "../../crates/primitives" }
 
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 [build-dependencies]
 tokio = { workspace = true, features = ["net"] }
 

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -22,6 +22,9 @@ if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
+
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
@@ -34,6 +37,8 @@ dylint_testing = "4.0.1"
 # the `[[workspace.dev-dependencies]]` directive.
 ink = { version = "=6.0.0-alpha.1", path = "../../crates/ink" }
 
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 [build-dependencies]
 tokio = { workspace = true, features = ["net"] }
 

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -22,6 +22,7 @@ if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
 dylint_testing = "4.0.1"
@@ -32,6 +33,9 @@ dylint_testing = "4.0.1"
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.
 ink = { version = "=6.0.0-alpha.1", path = "../../crates/ink" }
+
+[build-dependencies]
+tokio = { workspace = true, features = ["net"] }
 
 # For the moment we have to include the tests as examples and
 # then use `dylint_testing::ui_test_examples`.

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -17,5 +17,8 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 if_chain = "1.0.2"
 parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "238edf273d195c8e472851ebd60571f77f978ac8" }
 
+[build-dependencies]
+tokio = { workspace = true, features = ["net"] }
+
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -17,6 +17,8 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 if_chain = "1.0.2"
 parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "238edf273d195c8e472851ebd60571f77f978ac8" }
 
+# todo Remove once the `polkadot-sdk` compilation error
+# for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).
 [build-dependencies]
 tokio = { workspace = true, features = ["net"] }
 


### PR DESCRIPTION
Hotfixes a compilation error occuring in `polkadot-sdk`:

```
   Compiling substrate-prometheus-endpoint v0.17.0 (https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46)
error[E0433]: failed to resolve: could not find `TcpListener` in `net`
  --> /Users/michi/.cargo/git/checkouts/polkadot-sdk-dee0edd6eefa0594/cb629d4/substrate/utils/prometheus/src/lib.rs:89:29
   |
89 |     let listener = tokio::net::TcpListener::bind(&prometheus_addr).await.map_err(|e| {
   |                                ^^^^^^^^^^^ could not find `TcpListener` in `net`
   |
note: found an item that was configured out
  --> /Users/michi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.46.1/src/net/mod.rs:43:28
   |
43 |     pub use tcp::listener::TcpListener;
   |                            ^^^^^^^^^^^
note: the item is gated behind the `net` feature
  --> /Users/michi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.46.1/src/net/mod.rs:38:1
   |
38 | / cfg_net! {
39 | |     mod lookup_host;
40 | |     pub use lookup_host::lookup_host;
...  |
52 | | }
   | |_^
   = note: this error originates in the macro `cfg_net` (in Nightly builds, run with -Z macro-backtrace for more info)
```