### PR TITLE
Upgrade dylint to 4.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,6 @@ jobs:
         if: ${{ matrix.type == 'RISCV' }}
         with:
           command: |
-            # todo move to `use-ink/docker-images`
-            apt-get update && apt-get install gcc-riscv64-unknown-elf
             for crate in ${ALSO_RISCV_CRATES}; do
               echo $crate;
               cargo +nightly clippy --no-default-features --manifest-path ./crates/${crate}/Cargo.toml \
@@ -206,8 +204,6 @@ jobs:
           RUSTFLAGS: "--cfg substrate_runtime"
         with:
           command: |
-            # todo move to `use-ink/docker-images`
-            apt-get install gcc-riscv64-unknown-elf
             scripts/for_all_contracts_exec.sh --path integration-tests -- cargo clippy --no-default-features \
               --target ${CLIPPY_TARGET} \
               --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED $ALLOWED_LINTS

--- a/crates/ink/codegen/src/generator/sol/utils.rs
+++ b/crates/ink/codegen/src/generator/sol/utils.rs
@@ -91,7 +91,7 @@ pub fn call_signature(name: String, inputs: InputsIter) -> TokenStream2 {
         .map(|_| "{}")
         .collect::<Vec<_>>()
         .join(",");
-    let sig_fmt_lit = format!("{{}}({})", sig_arg_fmt_params);
+    let sig_fmt_lit = format!("{{}}({sig_arg_fmt_params})");
     quote! {
         ::ink::codegen::utils::const_format!(#sig_fmt_lit, #name #(,#sig_param_tys)*)
     }

--- a/crates/ink/ir/src/ir/attrs.rs
+++ b/crates/ink/ir/src/ir/attrs.rs
@@ -525,7 +525,7 @@ impl core::fmt::Display for AttributeArg {
             Self::Payable => write!(f, "payable"),
             Self::Selector(selector) => core::fmt::Display::fmt(&selector, f),
             Self::SignatureTopic(hash) => {
-                write!(f, "signature_topic = {:?}", hash)
+                write!(f, "signature_topic = {hash:?}")
             }
             Self::Function(function) => {
                 write!(f, "function = {:?}", function.into_u16())

--- a/crates/ink/macro/src/event/mod.rs
+++ b/crates/ink/macro/src/event/mod.rs
@@ -274,7 +274,7 @@ fn has_ink_attribute(ink_attrs: &[syn::Meta], path: &str) -> syn::Result<bool> {
         } else if a.path().is_ident(path) {
             return Err(syn::Error::new(
                 a.span(),
-                format!("Only a single `#[ink({})]` is allowed", path),
+                format!("Only a single `#[ink({path})]` is allowed"),
             ));
         } else {
             return Err(syn::Error::new(
@@ -342,6 +342,6 @@ fn signature_topic(fields: &syn::Fields, event_ident: &syn::Ident) -> TokenStrea
         })
         .collect::<Vec<_>>()
         .join(",");
-    let topic_str = format!("{}({fields})", event_ident);
+    let topic_str = format!("{event_ident}({fields})");
     quote!(::ink::blake2x256!(#topic_str))
 }

--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "4.0.1"
+dylint_linting = "4.1.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
@@ -29,10 +29,10 @@ ink_env = { version = "=6.0.0-alpha.1", path = "../../crates/env" }
 tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
-dylint_testing = "4.0.1"
+dylint_testing = "4.1.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
-# library with `--default-features=std` (see the `features` section bellow).
+# library with `--default-features=std` (see the `features` section below).
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.

--- a/linting/extra/src/non_fallible_api.rs
+++ b/linting/extra/src/non_fallible_api.rs
@@ -17,10 +17,10 @@ use ink_linting_utils::{
     clippy::{
         diagnostics::span_lint_and_then,
         is_lint_allowed,
-        match_def_path,
     },
     expand_unnamed_consts,
     find_contract_impl_id,
+    match_def_path,
 };
 use rustc_errors::Applicability;
 use rustc_hir::{
@@ -230,14 +230,12 @@ impl<'a, 'tcx> APIUsageChecker<'a, 'tcx> {
                     NON_FALLIBLE_API,
                     method_path.ident.span,
                     format!(
-                        "using a non-fallible `{:?}::{}` with an argument that may not fit into the static buffer",
-                        receiver_ty,
-                        method_name,
+                        "using a non-fallible `{receiver_ty:?}::{method_name}` with an argument that may not fit into the static buffer",
                     ).as_str().to_owned(),
                     |diag| {
                         diag.span_suggestion(
                             method_path.ident.span,
-                            format!("consider using `{}`", fallible_method),
+                            format!("consider using `{fallible_method}`"),
                             "",
                             Applicability::Unspecified,
                         );

--- a/linting/extra/src/primitive_topic.rs
+++ b/linting/extra/src/primitive_topic.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 use if_chain::if_chain;
-use ink_linting_utils::clippy::{
-    diagnostics::span_lint_and_then,
-    is_lint_allowed,
+use ink_linting_utils::{
+    clippy::{
+        diagnostics::span_lint_and_then,
+        is_lint_allowed,
+        source::snippet_opt,
+    },
     match_def_path,
-    source::snippet_opt,
 };
 use rustc_errors::Applicability;
 use rustc_hir::{
@@ -133,7 +135,7 @@ fn is_primitive_number_ty(ty: &Ty) -> bool {
 fn report_field(cx: &LateContext, event_def_id: DefId, field_name: &str) {
     if_chain! {
         if let Some(Node::Item(event_node)) = cx.tcx.hir_get_if_local(event_def_id);
-        if let ItemKind::Struct(ref struct_def, _) = event_node.kind;
+        if let ItemKind::Struct(_, ref struct_def, _) = event_node.kind;
         if let Some(field) = struct_def.fields().iter().find(|f|{ f.ident.as_str() == field_name });
         if !is_lint_allowed(cx, PRIMITIVE_TOPIC, field.hir_id);
         then {

--- a/linting/extra/src/storage_never_freed.rs
+++ b/linting/extra/src/storage_never_freed.rs
@@ -17,12 +17,12 @@ use ink_linting_utils::{
     clippy::{
         diagnostics::span_lint_and_help,
         is_lint_allowed,
-        match_def_path,
-        match_path,
     },
     expand_unnamed_consts,
     find_contract_impl_id,
     find_storage_struct,
+    match_def_path,
+    match_path,
 };
 use rustc_hir::{
     self as hir,
@@ -187,7 +187,7 @@ fn find_collection_def_id(
 fn find_collection_fields(cx: &LateContext, storage_struct_id: ItemId) -> FieldsMap {
     let mut result = FieldsMap::new();
     let item = cx.tcx.hir_item(storage_struct_id);
-    if let ItemKind::Struct(var_data, _) = item.kind {
+    if let ItemKind::Struct(_, var_data, _) = item.kind {
         var_data.fields().iter().for_each(|field_def| {
             if_chain! {
                 // Collection fields of the storage are expanded like this:

--- a/linting/extra/src/strict_balance_equality.rs
+++ b/linting/extra/src/strict_balance_equality.rs
@@ -14,13 +14,11 @@
 
 use if_chain::if_chain;
 use ink_linting_utils::{
-    clippy::{
-        diagnostics::span_lint_hir_and_then,
-        match_any_def_paths,
-        match_def_path,
-    },
+    clippy::diagnostics::span_lint_hir_and_then,
     expand_unnamed_consts,
     find_contract_impl_id,
+    match_any_def_paths,
+    match_def_path,
 };
 use rustc_errors::Applicability;
 use rustc_hir::{
@@ -581,7 +579,7 @@ impl StrictBalanceEquality {
                 let node = fn_mir.source_scopes[scope]
                     .local_data
                     .as_ref()
-                    .assert_crate_local()
+                    .unwrap_crate_local()
                     .lint_root;
                 then {
                     let sugg_span = Span::new(

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "4.0.1"
+dylint_linting = "4.1.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
@@ -28,7 +28,7 @@ ink_linting_utils = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 
 [dev-dependencies]
-dylint_testing = "4.0.1"
+dylint_testing = "4.1.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
 # library with `--default-features=std` (see the `features` section bellow).

--- a/linting/rust-toolchain.toml
+++ b/linting/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
 
 [toolchain]
-channel = "nightly-2025-02-20"
+channel = "nightly-2025-05-14"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -15,7 +15,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
 if_chain = "1.0.2"
-parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "238edf273d195c8e472851ebd60571f77f978ac8" }
+parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "0450db33a5d8587f7c1d4b6d233dac963605766b" }
 
 # todo Remove once the `polkadot-sdk` compilation error
 # for `tokio` is fixed (https://github.com/use-ink/ink/pull/2557).

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -15,6 +15,10 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
 if_chain = "1.0.2"
+
+# The following `rev` is taken from the examples of the
+# dylint version that we use:
+# https://github.com/trailofbits/dylint/blob/v4.1.0/examples/supplementary/Cargo.toml#L40
 parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "0450db33a5d8587f7c1d4b6d233dac963605766b" }
 
 # todo Remove once the `polkadot-sdk` compilation error


### PR DESCRIPTION
* Upgrades the `dylint` and `dylint_testing` deps to 4.1.0.
* Allows us to upgrade the Rust nightly to a later version.
* I've bumped the nightly in our Docker image (https://github.com/use-ink/docker-images/commit/979b0e5596f158f8ce4abc7107282cccc4911c1b).
* `cargo-contract` PR will follow.