### PR TITLE
fix: Correct typo in panic message - "instatiating" → "instantiating"

### DIFF
--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -470,7 +470,7 @@ where
     ///             )
     ///         })
     ///         .unwrap_or_else(|error| {
-    ///             panic!("Received a `LangError` while instatiating: {:?}", error)
+    ///             panic!("Received a `LangError` while instantiating: {:?}", error)
     ///         })
     /// }
     /// #


### PR DESCRIPTION
## Summary
Fixes a typo in the panic message within `env_access.rs`.

## Changes
- **File:** `crates/ink/src/env_access.rs`
- **Line 473:** Corrected "instatiating" → "instantiating" in panic message

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


