### PR TITLE
Implement stable host functions `account_id` + `to_account_id`

### DIFF
--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -274,6 +274,24 @@ impl Engine {
         set_output(output, callee)
     }
 
+    pub fn account_id(&self, output: &mut &mut [u8]) {
+        let callee = self
+            .exec_context
+            .callee
+            .as_ref()
+            .expect("no callee has been set");
+        let account_id = self.database.to_account_id(callee);
+        set_output(output, account_id.as_slice())
+    }
+
+    /// Retrieves the account id for a specified contract address.
+    pub fn to_account_id(&self, input: &[u8], output: &mut &mut [u8]) {
+        let addr =
+            scale::Decode::decode(&mut &input[..]).expect("unable to decode Address");
+        let account_id = self.database.to_account_id(&addr);
+        set_output(output, account_id.as_slice())
+    }
+
     /// Conduct the BLAKE-2 256-bit hash and place the result into `output`.
     pub fn hash_blake2_256(input: &[u8], output: &mut [u8; 32]) {
         super::hashing::blake2b_256(input, output);

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -117,7 +117,6 @@ where
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
 pub fn account_id<E>() -> E::AccountId
 where
     E: Environment,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -108,6 +108,20 @@ where
     })
 }
 
+/// Retrieves the account id for a specified contract address.
+///
+/// # Errors
+///
+/// If the returned value cannot be properly decoded.
+pub fn to_account_id<E>(addr: Address) -> E::AccountId
+where
+    E: Environment,
+{
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        TypedEnvBackend::to_account_id::<E>(instance, addr)
+    })
+}
+
 /// Returns the account ID of the executed contract.
 ///
 /// # Note

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -276,12 +276,18 @@ pub trait TypedEnvBackend: EnvBackend {
     /// For more details visit: [`block_timestamp`][`crate::block_timestamp`]
     fn block_timestamp<E: Environment>(&mut self) -> E::Timestamp;
 
+    /// Retrieves the account id for a specified contract address.
+    ///
+    /// # Note
+    ///
+    /// For more details visit: [`to_account_id`][`crate::to_account_id`]
+    fn to_account_id<E: Environment>(&mut self, addr: Address) -> E::AccountId;
+
     /// Returns the address of the executed contract.
     ///
     /// # Note
     ///
     /// For more details visit: [`account_id`][`crate::account_id`]
-    #[cfg(feature = "unstable-hostfn")]
     fn account_id<E: Environment>(&mut self) -> E::AccountId;
 
     /// Returns the address of the executed contract.

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -537,7 +537,6 @@ impl TypedEnvBackend for EnvInstance {
             })
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn account_id<E: Environment>(&mut self) -> E::AccountId {
         // todo should not use `Engine::account_id`
         self.get_property::<E::AccountId>(Engine::address)

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -537,9 +537,15 @@ impl TypedEnvBackend for EnvInstance {
             })
     }
 
+    fn to_account_id<E: Environment>(&mut self, addr: Address) -> E::AccountId {
+        let mut full_scope: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+        let full_scope = &mut &mut full_scope[..];
+        Engine::to_account_id(&self.engine, addr.as_bytes(), full_scope);
+        scale::Decode::decode(&mut &full_scope[..]).unwrap()
+    }
+
     fn account_id<E: Environment>(&mut self) -> E::AccountId {
-        // todo should not use `Engine::account_id`
-        self.get_property::<E::AccountId>(Engine::address)
+        self.get_property::<E::AccountId>(Engine::account_id)
             .unwrap_or_else(|error| {
                 panic!("could not read `account_id` property: {error:?}")
             })

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -443,7 +443,6 @@ impl TypedEnvBackend for EnvInstance {
         self.get_property_little_endian::<E::Timestamp>(ext::now)
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn account_id<E: Environment>(&mut self) -> E::AccountId {
         let mut scope = self.scoped_buffer();
 

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -455,6 +455,14 @@ impl TypedEnvBackend for EnvInstance {
             .expect("A contract being executed must have a valid account id.")
     }
 
+    fn to_account_id<E: Environment>(&mut self, addr: Address) -> E::AccountId {
+        let mut scope = self.scoped_buffer();
+        let account_id: &mut [u8; 32] = scope.take(32).try_into().unwrap();
+        ext::to_account_id(addr.as_fixed_bytes(), account_id);
+        scale::Decode::decode(&mut &account_id[..])
+            .expect("A contract being executed must have a valid account id.")
+    }
+
     fn address(&mut self) -> Address {
         let mut scope = self.scoped_buffer();
 

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -238,6 +238,48 @@ where
         ink_env::block_timestamp::<E>()
     }
 
+    /// Retrieves the account id for a specified contract address.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[ink::contract]
+    /// pub mod only_owner {
+    ///     #[ink(storage)]
+    ///     pub struct OnlyOwner {
+    ///         owner: AccountId,
+    ///         value: u32,
+    ///     }
+    ///
+    ///     impl OnlyOwner {
+    ///         #[ink(constructor)]
+    ///         pub fn new(owner: AccountId) -> Self {
+    ///             Self { owner, value: 0 }
+    ///         }
+    ///
+    ///         /// Allows incrementing the contract's `value` only
+    ///         /// for the owner (i.e. the account which instantiated
+    ///         /// this contract.
+    ///         ///
+    ///         /// The contract panics if the caller is not the owner.
+    ///         #[ink(message)]
+    ///         pub fn increment(&mut self) {
+    ///             let caller = self.env().address();
+    ///             let caller_acc = self.env().to_account_id(&caller);
+    ///             assert!(self.owner == caller_acc);
+    ///             self.value = self.value + 1;
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// For more details visit: [`ink_env::account_id`]
+    pub fn to_account_id(self, addr: Address) -> E::AccountId {
+        ink_env::to_account_id::<E>(addr)
+    }
+
     /// Returns the account ID of the executed contract.
     ///
     /// # Example

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -279,7 +279,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::account_id`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn account_id(self) -> E::AccountId {
         ink_env::account_id::<E>()
     }

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -469,7 +469,6 @@ pub enum Origin<E: Environment> {
 
 pub struct AccountIdMapper {}
 impl AccountIdMapper {
-    //pub fn to_address(account_id: &E::AccountId) -> Address {
     pub fn to_address(account_id: &[u8]) -> Address {
         let mut account_bytes: [u8; 32] = [0u8; 32];
         account_bytes.copy_from_slice(&account_id[..32]);

--- a/integration-tests/internal/lang-err/constructors-return-value/lib.rs
+++ b/integration-tests/internal/lang-err/constructors-return-value/lib.rs
@@ -134,7 +134,8 @@ pub mod constructors_return_value {
                 .await?;
 
             // Infallible constructors return `Result<(), ()>`.
-            let decoded_result = infallible_constructor_result.constructor_result::<Result<(), ()>>();
+            let decoded_result =
+                infallible_constructor_result.constructor_result::<Result<(), ()>>();
             assert!(
                 decoded_result.is_ok(),
                 "Constructor dispatch should have succeeded"

--- a/integration-tests/internal/misc-hostfns/Cargo.toml
+++ b/integration-tests/internal/misc-hostfns/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "misc_hostfns"
+description = "E2E tests for various host functions"
+version = "6.0.0-alpha.1"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+
+[dev-dependencies]
+ink_e2e = { path = "../../../crates/e2e" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+e2e-tests = []
+
+[package.metadata.ink-lang]
+abi = "ink"

--- a/integration-tests/internal/misc-hostfns/lib.rs
+++ b/integration-tests/internal/misc-hostfns/lib.rs
@@ -1,0 +1,64 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod misc_hostfns {
+    #[ink(storage)]
+    pub struct MiscHostfns {}
+
+    impl MiscHostfns {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        /// Takes an auction data struct as input and returns it back.
+        #[ink(message)]
+        pub fn addr_account_id(&self) {
+            let addr = self.env().address();
+            let to_account_id = self.env().to_account_id(addr);
+            let account_id = self.env().account_id();
+            assert_eq!(to_account_id, account_id);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn works() {
+            let contract = MiscHostfns::new();
+            contract.addr_account_id();
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::ContractsBackend;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn e2e_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+            // given
+            let mut constructor = MiscHostfnsRef::new();
+            let contract = client
+                .instantiate("misc_hostfns", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let call_builder = contract.call_builder::<MiscHostfns>();
+
+            // then
+            let acc = call_builder.addr_account_id();
+            let _call_res = client
+                .call(&ink_e2e::alice(), &acc)
+                .submit()
+                .await
+                .expect("call failed");
+
+            Ok(())
+        }
+    }
+}

--- a/integration-tests/public/runtime-call-contract/sandbox-runtime/pallet-revive-caller/src/executor.rs
+++ b/integration-tests/public/runtime-call-contract/sandbox-runtime/pallet-revive-caller/src/executor.rs
@@ -25,8 +25,6 @@ use pallet_revive::{
 use sp_runtime::traits::Bounded;
 
 pub struct PalletReviveExecutor<E: Environment, Runtime: pallet_revive::Config> {
-    // todo
-    //pub origin: AccountIdOf<Runtime>,
     pub origin: OriginFor<Runtime>,
     pub contract: Address,
     pub value: BalanceOf<Runtime>,
@@ -59,8 +57,6 @@ where
         let data = input.encode();
         let result = pallet_revive::Pallet::<R>::bare_call(
             self.origin.clone(),
-            // <R as pallet_revive::Config>::AddressMapper::to_account_id(&self.
-            // contract),
             self.contract,
             self.value,
             self.gas_limit,

--- a/integration-tests/public/upgradeable-contracts/delegator/lib.rs
+++ b/integration-tests/public/upgradeable-contracts/delegator/lib.rs
@@ -141,6 +141,7 @@ pub mod delegator {
                 .await;
 
             /*
+            // todo
             let code_hash = client
                 .upload("delegatee", &origin)
                 .submit()
@@ -284,6 +285,7 @@ pub mod delegator {
                 .await;
 
             /*
+            // todo
             let code_hash = client
                 .upload("delegatee", &origin)
                 .submit()
@@ -308,6 +310,7 @@ pub mod delegator {
             let delegatee_addr = contract.addr;
 
             /*
+            // todo
             let code_hash2 = client
                 .upload("delegatee2", &origin)
                 .submit()


### PR DESCRIPTION
* Marks the `pallet-revive` host function `account_id` stable
* Implements the API for the `pallet-revive` host function `to_account_id`