### PR TITLE
fix: correct typos in layout doc, arithmetic test, and macro comment

### DIFF
--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -79,7 +79,7 @@ pub enum Layout<F: Form = MetaForm> {
     Array(ArrayLayout<F>),
     /// A struct layout with fields of different types.
     Struct(StructLayout<F>),
-    /// An enum layout with a discriminant telling which variant is layed out.
+    /// An enum layout with a discriminant telling which variant is laid out.
     Enum(EnumLayout<F>),
 }
 

--- a/crates/primitives/src/arithmetic.rs
+++ b/crates/primitives/src/arithmetic.rs
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn saturatiung_sub() {
+    fn saturating_sub() {
         assert_eq!(u64::MIN, Saturating::saturating_sub(u64::MIN, 1))
     }
 

--- a/crates/primitives/src/sol/macros.rs
+++ b/crates/primitives/src/sol/macros.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Calls a macro upto 12 times with an increasing number of identifiers for each call.
+/// Calls a macro up to 12 times with an increasing number of identifiers for each call.
 ///
 /// # Note
 ///


### PR DESCRIPTION
Fixed typo in Layout enum comment: “layed out” → “laid out”.

Corrected function name typo: saturatiung_sub → saturating_sub in arithmetic tests.

Fixed comment typo in macro definition: “upto” → “up to”.