### PR TITLE
fix(test): correct typo "falliable" -> "fallible" in call-builder test

### DIFF
--- a/integration-tests/internal/lang-err/call-builder/lib.rs
+++ b/integration-tests/internal/lang-err/call-builder/lib.rs
@@ -423,7 +423,7 @@ mod call_builder {
 
             assert!(
                 matches!(call_result, Some(Ok(_))),
-                "Call to falliable constructor failed, when it should have succeeded."
+                "Call to fallible constructor failed, when it should have succeeded."
             );
 
             Ok(())


### PR DESCRIPTION
Corrected assertion message in integration-tests/internal/lang-err/call-builder/lib.rs:
changed "Call to falliable constructor failed, when it should have succeeded." → "Call to fallible constructor failed, when it should have succeeded."