### PR TITLE
fix: correct typos in doc comments for Engine, DebugInfo, and delegate call

### DIFF
--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -81,7 +81,7 @@ impl Default for ChainSpec {
 }
 
 impl Engine {
-    // Creates a new `Engine instance.
+    // Creates a new `Engine` instance.
     pub fn new() -> Self {
         Self {
             database: Database::new(),

--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -57,7 +57,7 @@ impl Default for DebugInfo {
 }
 
 impl DebugInfo {
-    // Creates a new `RecInstance instance.
+    // Creates a new `RecInstance` instance.
     pub fn new() -> Self {
         Self {
             emitted_events: Vec::new(),

--- a/crates/env/src/call/call_builder/delegate.rs
+++ b/crates/env/src/call/call_builder/delegate.rs
@@ -174,7 +174,7 @@ where
     ///
     /// # Note
     ///
-    /// On failure this an [`ink::env::Error`][`crate::Error`] which can be handled by the
+    /// On failure this returns an [`ink::env::Error`][`crate::Error`] which can be handled by the
     /// caller.
     pub fn try_invoke(self) -> Result<ink_primitives::MessageResult<()>, Error> {
         self.params().try_invoke()


### PR DESCRIPTION
- Fixed typo in crates/engine/src/ext.rs: "Engine instance" → "Engine` instance"

- Fixed typo in crates/engine/src/test_api.rs: "RecInstance instance" → "RecInstance` instance"

- Fixed doc comment in crates/env/src/call/call_builder/delegate.rs: "On failure this an" → "On failure this returns an"