### PR TITLE
docs(prelude, primitives, storage): fix typos in Rustdoc comments

### DIFF
--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -31,7 +31,7 @@ extern crate alloc;
 
 use cfg_if::cfg_if;
 
-/// A well know selector reserved for the message required to be defined
+/// A well known selector reserved for the message required to be defined
 /// alongside a wildcard selector. See [IIP-2](https://github.com/use-ink/ink/issues/1676).
 ///
 /// Calculated from `selector_bytes!("IIP2_WILDCARD_COMPLEMENT")`

--- a/crates/primitives/src/sol/macros.rs
+++ b/crates/primitives/src/sol/macros.rs
@@ -16,7 +16,7 @@
 ///
 /// # Note
 ///
-/// The callee is typical a macro that implements a trait for tuples.
+/// The callee is a typical macro that implements a trait for tuples.
 ///
 /// We follow the Rust standard library's convention of implementing traits for tuples up
 /// to twelve items long.

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -256,7 +256,7 @@ where
     /// - `Some(Err(_))` if either (a) the encoded key doesn't fit into the static buffer
     ///   or (b) the value existed but its length exceeds the static buffer size.
     /// - `None` if there was no value under this mapping key.
-    ////
+    ///
     /// # Warning
     ///
     /// This method uses the

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -40,7 +40,7 @@ use scale::{
 /// # Important
 ///
 /// The mapping requires its own pre-defined storage key where to store values. By
-/// default, the is automatically calculated using [`AutoKey`](crate::traits::AutoKey)
+/// default, the key is automatically calculated using [`AutoKey`](crate::traits::AutoKey)
 /// during compilation. However, anyone can specify a storage key using
 /// [`ManualKey`](crate::traits::ManualKey). Specifying the storage key can be helpful for
 /// upgradeable contracts or you want to be resistant to future changes of storage key
@@ -183,7 +183,7 @@ where
     ///
     /// # Panics
     ///
-    /// Traps if the the encoded `key` or `value` doesn't fit into the static buffer.
+    /// Traps if the encoded `key` or `value` doesn't fit into the static buffer.
     #[inline]
     pub fn get<Q>(&self, key: Q) -> Option<V>
     where


### PR DESCRIPTION
crates/prelude/src/lib.rs: corrected typo "well know" → "well known".

crates/primitives/src/sol/macros.rs: fixed grammar "is typical a macro" → "is a typical macro".

crates/storage/src/lazy/mapping.rs:

- corrected typo "the is automatically" → "the key is automatically".

- removed duplicate word "the the" → "the".

- removed stray //// line in doc comment.