### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Before working on a pull request please make sure that the work has not already 
 
 For complex implementations you are advised to first discuss the feature implementation or bug fix using an issue.
 
-A pull request should be doing or implementing exactly one semantic issue. So for example, when you refactor the code base in a pull request you should not also include code formattings into the same pull request.
+A pull request should be doing or implementing exactly one semantic issue. So for example, when you refactor the code base in a pull request you should not also include code formatting into the same pull request.
 
 It's totally fine to extract changes made in one pull request to multiple pull requests. It makes the review process easier (and hey, more 🟩 for you!).
 

--- a/integration-tests/public/debugging-strategies/lib.rs
+++ b/integration-tests/public/debugging-strategies/lib.rs
@@ -140,7 +140,7 @@ mod debugging_strategies {
                 .expect("calling `get` message failed");
 
             // then
-            // the contract wil have emitted an event
+            // the contract will have emitted an event
             assert!(call_res.contains_event("Revive", "ContractEmitted"));
             let contract_events = call_res.contract_emitted_events()?;
             assert_eq!(1, contract_events.len());

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { workspace = true, features = ["net"] }
 dylint_testing = "4.1.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
-# library with `--default-features=std` (see the `features` section bellow).
+# library with `--default-features=std` (see the `features` section below).
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.


### PR DESCRIPTION
## Summary

fix some typos in comment


Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
