### PR TITLE
Implement pre-compile support for `Storage` and `System` functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,7 @@ jobs:
               QUICKCHECK_TESTS: 2
           with:
             command: |
-                cargo contract test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml;
+                cargo contract test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml
 
                 INK_STATIC_BUFFER_SIZE=256 cargo test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml -- --ignored fallible_storage_methods_work
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,14 +596,14 @@ jobs:
           env:
               # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
               RUSTFLAGS: -Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code
-              # needed for `mapping::e2e_tests::fallible_storage_methods_work`
-              INK_STATIC_BUFFER_SIZE: 256
               # Run the quickcheck tests inside contracts, but not for the default amount
               # of times (as that would take quite long).
               QUICKCHECK_TESTS: 2
           with:
             command: |
-                cargo contract test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml
+                cargo contract test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml;
+
+                INK_STATIC_BUFFER_SIZE=256 cargo test --all-features --manifest-path integration-tests/internal/mapping/Cargo.toml -- --ignored fallible_storage_methods_work
 
   # TODO: (@davidsemakula) Add back to `examples-test` job when flakiness is fixed.
   examples-test-debugging-strategies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 
 ### Changed
-- Synchronized with `polkadot-sdk/c40b36c3a7c208f9a6837b80812473af3d9ba7f7` ‒ [2589](https://github.com/use-ink/ink/pull/2589)
+- Support functions of the `Storage` and `System` pre-compiles ‒ [2619](https://github.com/use-ink/ink/pull/2619)
+
+### Changed
+- Synchronize with `polkadot-sdk/c40b36c3a7c208f9a6837b80812473af3d9ba7f7` ‒ [2589](https://github.com/use-ink/ink/pull/2589)
+- Synchronize with `polkadot-sdk/a71ec19a94702ea71767ba5ac97603ea6c6305c1` ‒ [2619](https://github.com/use-ink/ink/pull/2619)
 
 ### Fixed
 - E2E: Fixes around correct handling of storage deposit limit ‒ [#2589](https://github.com/use-ink/ink/pull/2589)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ dependencies = [
  "url",
  "uzers",
  "walkdir",
- "which 8.0.0",
+ "which",
  "zip 3.0.0",
  "zip 4.3.0",
 ]
@@ -2615,6 +2615,22 @@ dependencies = [
  "scale-info",
  "scale-type-resolver",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "frame-decode"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c470df86cf28818dd3cd2fc4667b80dbefe2236c722c3dc1d09e7c6c82d6dfcd"
+dependencies = [
+ "frame-metadata 23.0.0",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-type-resolver",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3667,13 +3683,13 @@ dependencies = [
  "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "subxt",
- "subxt-metadata 0.42.1",
- "subxt-signer 0.42.1",
+ "subxt-metadata 0.44.0",
+ "subxt-signer 0.44.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.20",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
@@ -8341,9 +8357,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7533d39317bed01100b37158740dcec27c0e1933f3bca19bdf12110f242248"
+checksum = "ddbf938ac1d86a361a84709a71cdbae5d87f370770b563651d1ec052eed9d0b4"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -8362,10 +8378,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.42.1",
+ "subxt-core 0.44.0",
  "subxt-lightclient",
  "subxt-macro",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.44.0",
  "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
@@ -8378,9 +8394,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ded0fa15fa78c58b91e2a1c6bcef8a2bc68fe165d00e1dfb9787069351511c"
+checksum = "9c250ad8cd102d40ae47977b03295a2ff791375f30ddc7474d399fb56efb793b"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -8388,7 +8404,7 @@ dependencies = [
  "quote",
  "scale-info",
  "scale-typegen",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.44.0",
  "syn 2.0.104",
  "thiserror 2.0.12",
 ]
@@ -8425,36 +8441,6 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c3574b60050e57cf23edf6521263b06e98a880073df330813bb04242633083"
-dependencies = [
- "base58",
- "blake2",
- "derive-where",
- "frame-decode 0.8.0",
- "frame-metadata 23.0.0",
- "hashbrown 0.14.5",
- "hex",
- "impl-serde",
- "keccak-hash",
- "parity-scale-codec",
- "primitive-types 0.13.1",
- "scale-bits",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "scale-value",
- "serde",
- "serde_json",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-metadata 0.42.1",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "subxt-core"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25338dd11ae34293b8d0c5807064f2e00194ba1bd84cccfa694030c8d185b941"
@@ -8484,10 +8470,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "subxt-lightclient"
-version = "0.42.1"
+name = "subxt-core"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c546d42ca103c0a6a3434cadf4ca500d2a49e60af0842b0fdee6fbfa97aa02f"
+checksum = "5705c5b420294524e41349bf23c6b11aa474ce731de7317f4153390e1927f702"
+dependencies = [
+ "base58",
+ "blake2",
+ "derive-where",
+ "frame-decode 0.9.0",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "hex",
+ "impl-serde",
+ "keccak-hash",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subxt-metadata 0.44.0",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-lightclient"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e02732a6c9ae46bc282c1a741b3d3e494021b3e87e7e92cfb3620116d92911"
 dependencies = [
  "futures",
  "futures-util",
@@ -8502,9 +8518,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91d253492eb17c65bdb41e538d6a31508563757bd34ad6014cb03536cf31757"
+checksum = "501bf358698f5ab02a6199a1fcd3f1b482e2f5b6eb5d185411e6a74a175ec8e8"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -8512,7 +8528,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.44.0",
  "subxt-utils-fetchmetadata",
  "syn 2.0.104",
 ]
@@ -8525,21 +8541,6 @@ checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
  "frame-decode 0.7.1",
  "frame-metadata 20.0.0",
- "hashbrown 0.14.5",
- "parity-scale-codec",
- "scale-info",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "subxt-metadata"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243990ca4e0cdb74ef7458f1d5070a1bd5144d744cc146f23a32ab56d23e1db7"
-dependencies = [
- "frame-decode 0.8.0",
- "frame-metadata 23.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -8563,10 +8564,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "subxt-rpcs"
-version = "0.42.1"
+name = "subxt-metadata"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55313e3652f5360b5ed878bfe1d62fe181ecb8c130c81278ab89d1580f89a7ed"
+checksum = "01fb7c0bfafad78dda7084c6a2444444744af3bbf7b2502399198b9b4c20eddf"
+dependencies = [
+ "frame-decode 0.9.0",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab68a9c20ecedb0cb7d62d64f884e6add91bb70485783bf40aa8eac5c389c6e0"
 dependencies = [
  "derive-where",
  "frame-metadata 23.0.0",
@@ -8578,7 +8594,7 @@ dependencies = [
  "primitive-types 0.13.1",
  "serde",
  "serde_json",
- "subxt-core 0.42.1",
+ "subxt-core 0.44.0",
  "subxt-lightclient",
  "thiserror 2.0.12",
  "tokio-util",
@@ -8618,36 +8634,6 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58aeda7bebddedbef69ac55ae592fb9eef499927b50d42c43862d1664b5e5b3"
-dependencies = [
- "base64",
- "bip32",
- "bip39",
- "cfg-if",
- "crypto_secretbox",
- "hex",
- "hmac 0.12.1",
- "keccak-hash",
- "parity-scale-codec",
- "pbkdf2",
- "regex",
- "schnorrkel",
- "scrypt",
- "secp256k1 0.30.0",
- "secrecy 0.10.3",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.42.1",
- "thiserror 2.0.12",
- "zeroize",
-]
-
-[[package]]
-name = "subxt-signer"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
@@ -8677,10 +8663,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "subxt-utils-fetchmetadata"
-version = "0.42.1"
+name = "subxt-signer"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d3a6e9cb2fd2db8bf3cb0d03da691ac949259e620c9eb8f25764b2711805ca"
+checksum = "0fb6463f7f46817043de9f20ba11f485ee474378fcdbe4150aa849274523bd1c"
+dependencies = [
+ "base64",
+ "bip32",
+ "bip39",
+ "cfg-if",
+ "crypto_secretbox",
+ "hex",
+ "hmac 0.12.1",
+ "keccak-hash",
+ "parity-scale-codec",
+ "pbkdf2",
+ "regex",
+ "schnorrkel",
+ "scrypt",
+ "secp256k1 0.30.0",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subxt-core 0.44.0",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f6812a653c5a3e63a079aa3b60a3f4c362722753c3222286eaa1800f9002"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -9609,18 +9625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
-dependencies = [
- "either",
- "env_home",
- "rustix",
- "winsafe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-core"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad31216895d27d307369daa1393f5850b50bbbd372478a9fa951c095c210627e"
+checksum = "bfe6c56d58fbfa9f0f6299376e8ce33091fc6494239466814c3f54b55743cb09"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
+checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -104,7 +104,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -128,14 +128,14 @@ dependencies = [
  "alloy-rlp",
  "k256",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.27"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c219a87fb386a75780ddbdbbced242477321887e426b0f946c05815ceabe5e09"
+checksum = "2a15b4b0f6bab47aae017d52bb5a739bda381553c09fb9918b7172721ef5f5de"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -150,14 +150,14 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
+checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
+checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -177,14 +177,14 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -211,14 +211,14 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.27"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae653f049267ae7e040eab6c9b9a417064ca1a6cb21e3dd59b9f1131ef048f"
+checksum = "f1b3b1078b8775077525bc9fe9f6577e815ceaecd6c412a4f3b4d8aa2836e8f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -227,41 +227,41 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
+checksum = "d20d867dcf42019d4779519a1ceb55eba8d7f3d0e4f0a89bcba82b8f9eb01e48"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
+checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
+checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
 dependencies = [
  "const-hex",
  "dunce",
@@ -269,15 +269,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
+checksum = "fe8c27b3cf6b2bb8361904732f955bc7c05e00be5f469cec7e2280b6167f3ff0"
 dependencies = [
  "serde",
  "winnow",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
+checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -342,29 +342,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "approx"
@@ -386,14 +386,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -475,7 +475,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -580,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -618,7 +618,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -883,15 +883,14 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -911,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -925,14 +924,13 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
- "tracing",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -943,7 +941,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -954,13 +952,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -993,7 +991,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1060,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "hash-db",
  "log",
@@ -1150,9 +1148,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -1277,7 +1275,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1333,9 +1331,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -1369,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
 dependencies = [
  "serde",
 ]
@@ -1404,7 +1402,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "toml 0.8.23",
  "unicode-xid",
  "url",
@@ -1436,15 +1434,16 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -1465,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
@@ -1490,7 +1489,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1506,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1516,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1528,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1596,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+checksum = "dccd746bf9b1038c0507b7cec21eb2b11222db96a2902c96e8c185d6d20fb9c4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1689,7 +1688,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "contract-build"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#6a66778abfe07ecc8446a880e175efc236cc3271"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#3111d4769cef197c23d81f46a8f538d7e91633f1"
 dependencies = [
  "alloy-json-abi",
  "anyhow",
@@ -1707,7 +1706,7 @@ dependencies = [
  "ink_metadata 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
  "itertools 0.14.0",
  "parity-scale-codec",
- "polkavm-linker 0.26.0 (git+https://github.com/paritytech/polkavm.git)",
+ "polkavm-linker 0.29.0",
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.26",
@@ -1725,13 +1724,13 @@ dependencies = [
  "walkdir",
  "which",
  "zip 3.0.0",
- "zip 4.3.0",
+ "zip 4.6.1",
 ]
 
 [[package]]
 name = "contract-metadata"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#6a66778abfe07ecc8446a880e175efc236cc3271"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#3111d4769cef197c23d81f46a8f538d7e91633f1"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -1820,7 +1819,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "derive_more 2.0.1",
  "document-features",
@@ -1919,7 +1918,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1943,7 +1942,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1954,7 +1953,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1964,6 +1963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1972,6 +1972,12 @@ name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1996,29 +2002,29 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2029,7 +2035,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2058,7 +2064,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2070,7 +2076,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -2130,7 +2136,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2160,7 +2166,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.106",
  "termcolor",
  "toml 0.8.23",
  "walkdir",
@@ -2183,9 +2189,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duct"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ce170a0e8454fa0f9b0e5ca38a6ba17ed76a50916839d217eb5357e05cdfde"
+checksum = "d7478638a31d1f1f3d6c9f5e57c76b906a04ac4879d6fd0fb6245bc88f73fd0b"
 dependencies = [
  "libc",
  "os_pipe",
@@ -2201,9 +2207,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2246,16 +2252,17 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.14.5",
- "hex",
+ "hashbrown 0.15.5",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
+ "subtle",
  "zeroize",
 ]
 
@@ -2268,7 +2275,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2314,7 +2321,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2391,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "alloy-core",
 ]
@@ -2414,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2445,7 +2452,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2509,6 +2516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,9 +2547,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2568,24 +2581,24 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "static_assertions",
 ]
 
@@ -2605,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1276c23a1fb234d9f81b5f71c526437f2a55ab4419f29bfe1196ac4ee2f706c"
+checksum = "6e56c0e51972d7b26ff76966c4d0f2307030df9daa5ce0885149ece1ab7ca5ad"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -2630,7 +2643,7 @@ dependencies = [
  "scale-info",
  "scale-type-resolver",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2711,16 +2724,16 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "aquamarine",
  "array-bytes",
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata 23.0.0",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -2730,22 +2743,22 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-genesis-builder 0.8.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-staking 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-genesis-builder 0.8.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-staking 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "tt-call",
 ]
 
@@ -2766,27 +2779,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "docify",
  "expander",
- "frame-support-procedural-tools 10.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-support-procedural-tools 10.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2798,19 +2811,19 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
- "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2820,17 +2833,17 @@ source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea717
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2855,20 +2868,20 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -2937,9 +2950,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2956,7 +2969,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3026,7 +3039,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3051,15 +3064,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.6.7"
+version = "1.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a636fb6a653382a379ee1e5593dacdc628667994167024c143214cafd40c1a86"
+checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3078,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3088,7 +3101,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3137,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3289,13 +3302,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -3303,6 +3317,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3325,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3338,7 +3353,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3477,9 +3492,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3551,7 +3566,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3586,12 +3601,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -3600,7 +3615,7 @@ name = "ink"
 version = "6.0.0-alpha.1"
 dependencies = [
  "const_format",
- "deranged",
+ "deranged 0.4.0",
  "derive_more 2.0.1",
  "ink_env",
  "ink_ir",
@@ -3649,7 +3664,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3658,7 +3673,7 @@ version = "6.0.0-alpha.1"
 dependencies = [
  "cargo_metadata 0.21.0",
  "contract-build",
- "deranged",
+ "deranged 0.4.0",
  "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "funty",
  "impl-serde",
@@ -3685,7 +3700,7 @@ dependencies = [
  "subxt",
  "subxt-metadata 0.44.0",
  "subxt-signer 0.44.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.20",
@@ -3704,7 +3719,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.106",
  "temp-env",
  "tracing-subscriber 0.3.20",
 ]
@@ -3771,7 +3786,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3790,7 +3805,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3813,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#915985369ad647efbbff89f6c42194fdd341d4b7"
+source = "git+https://github.com/use-ink/ink?branch=master#23103110df9b552eda9335b700196662a4a0dd29"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde",
@@ -3835,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#915985369ad647efbbff89f6c42194fdd341d4b7"
+source = "git+https://github.com/use-ink/ink?branch=master#23103110df9b552eda9335b700196662a4a0dd29"
 dependencies = [
  "cfg-if",
 ]
@@ -3872,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#915985369ad647efbbff89f6c42194fdd341d4b7"
+source = "git+https://github.com/use-ink/ink?branch=master#23103110df9b552eda9335b700196662a4a0dd29"
 dependencies = [
  "alloy-sol-types",
  "cfg-if",
@@ -3881,8 +3896,8 @@ dependencies = [
  "ink_prelude 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
  "itertools 0.14.0",
  "num-traits",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "parity-scale-codec",
  "paste",
  "primitive-types 0.13.1",
@@ -3890,10 +3905,10 @@ dependencies = [
  "scale-encode",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "xxhash-rust",
 ]
 
@@ -3972,11 +3987,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -4031,9 +4046,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jam-codec"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72f2fb8cfd27f6c52ea7d0528df594f7f2ed006feac153e9393ec567aafea98"
+checksum = "cb948eace373d99de60501a02fb17125d30ac632570de20dccc74370cdd611b9"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -4047,14 +4062,14 @@ dependencies = [
 
 [[package]]
 name = "jam-codec-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09985146f40378e13af626964ac9c206d9d9b67c40c70805898d9954f709bcf5"
+checksum = "319af585c4c8a6b5552a52b7787a1ab3e4d59df7614190b1f85b9b842488789d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4081,9 +4096,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4244,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -4256,11 +4271,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -4329,7 +4344,7 @@ checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4355,9 +4370,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -4371,9 +4386,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -4381,7 +4396,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4392,7 +4407,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4404,7 +4419,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4418,7 +4433,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4429,7 +4444,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4440,7 +4455,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4470,23 +4485,13 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memory-db"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6da20dba965bd218a14c3b335b90d3e07c09ede190c7c19b50deb23d418a322"
-dependencies = [
- "hash-db",
- "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "memory-db"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e300c54e3239a86f9c61cc63ab0f03862eb40b1c6e065dc6fd6ceaeff6da93d"
 dependencies = [
  "foldhash",
  "hash-db",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4692,7 +4697,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4830,16 +4835,16 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
  "environmental",
- "ethereum-standards 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "ethereum-standards 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "ethereum-types",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "hex-literal 0.4.1",
  "humantime-serde",
  "impl-trait-for-tuples",
@@ -4847,27 +4852,27 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "pallet-revive-fixtures 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "pallet-revive-fixtures 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "parity-scale-codec",
  "paste",
  "polkavm 0.26.0",
- "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.26.0",
  "rand 0.8.5",
  "ripemd",
  "rlp 0.6.1",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-consensus-aura 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-consensus-babe 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-consensus-aura 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-consensus-babe 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "substrate-bn",
  "subxt-signer 0.41.0",
 ]
@@ -4892,14 +4897,14 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.15.4",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "polkavm-linker 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "polkavm-linker 0.26.0",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "toml 0.8.23",
 ]
 
@@ -4910,17 +4915,17 @@ source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea717
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4940,10 +4945,10 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "bitflags 1.3.2",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "parity-scale-codec",
  "polkavm-derive 0.26.0",
  "scale-info",
@@ -4985,16 +4990,16 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -5036,7 +5041,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5103,10 +5108,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
+name = "pem-rfc7468"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -5115,7 +5129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -5149,7 +5163,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5178,7 +5192,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5223,7 +5237,7 @@ dependencies = [
  "libc",
  "log",
  "polkavm-assembler 0.26.0",
- "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.26.0",
  "polkavm-linux-raw 0.26.0",
 ]
 
@@ -5271,11 +5285,6 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.26.0"
-source = "git+https://github.com/paritytech/polkavm.git#da9a904909d7770477637783c70c30b3fc6df2ac"
-
-[[package]]
-name = "polkavm-common"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19805789e7bf778ac5855f6fe9350353f6a1697c2aab9bfb6fc7c831be54fad"
@@ -5284,6 +5293,11 @@ dependencies = [
  "log",
  "polkavm-assembler 0.27.0",
 ]
+
+[[package]]
+name = "polkavm-common"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkavm.git#db1df41408242e6a29fd5c0ef658e5b319ef8bb4"
 
 [[package]]
 name = "polkavm-derive"
@@ -5309,10 +5323,10 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6069dc7995cde6e612b868a02ce48b54397c6d2582bd1b97b63aabbe962cd779"
 dependencies = [
- "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.26.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5324,7 +5338,7 @@ dependencies = [
  "polkavm-common 0.27.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5334,7 +5348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
 dependencies = [
  "polkavm-derive-impl 0.26.0",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5344,7 +5358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a45173d70138aa1879892c50777ed0d8b0c8556f7678372f09fa1d89bbbddb4"
 dependencies = [
  "polkavm-derive-impl 0.27.0",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5358,22 +5372,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "object",
- "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regalloc2",
- "rustc-demangle",
-]
-
-[[package]]
-name = "polkavm-linker"
-version = "0.26.0"
-source = "git+https://github.com/paritytech/polkavm.git#da9a904909d7770477637783c70c30b3fc6df2ac"
-dependencies = [
- "dirs",
- "gimli",
- "hashbrown 0.14.5",
- "log",
- "object",
- "polkavm-common 0.26.0 (git+https://github.com/paritytech/polkavm.git)",
+ "polkavm-common 0.26.0",
  "regalloc2",
  "rustc-demangle",
 ]
@@ -5395,6 +5394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-linker"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkavm.git#db1df41408242e6a29fd5c0ef658e5b319ef8bb4"
+dependencies = [
+ "dirs",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "object",
+ "polkavm-common 0.29.0",
+ "regalloc2",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "polkavm-linux-raw"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,17 +5422,16 @@ checksum = "061088785efd93e4367faf12f341bb356208c06bab43aa942d472068af80d1c4"
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5434,9 +5447,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -5468,12 +5481,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5563,7 +5576,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5574,14 +5587,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -5608,10 +5621,10 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5645,7 +5658,7 @@ checksum = "f71ee38b42f8459a88d3362be6f9b841ad2d5421844f61eb1c59c11bff3ac14a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5682,9 +5695,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5747,11 +5760,11 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -5782,7 +5795,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5800,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5812,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5823,9 +5836,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "revm"
@@ -6010,7 +6023,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -6083,9 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6100,7 +6113,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp 0.5.2",
  "ruint-macro",
  "serde",
@@ -6116,9 +6129,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -6158,22 +6171,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -6245,9 +6258,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -6324,7 +6337,7 @@ dependencies = [
  "scale-decode-derive",
  "scale-type-resolver",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -6336,7 +6349,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6351,7 +6364,7 @@ dependencies = [
  "scale-encode-derive",
  "scale-type-resolver",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -6364,7 +6377,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6391,7 +6404,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6413,8 +6426,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.104",
- "thiserror 2.0.12",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -6432,7 +6445,7 @@ dependencies = [
  "scale-encode",
  "scale-type-resolver",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "yap",
 ]
 
@@ -6490,7 +6503,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6592,7 +6605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes 0.14.0",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -6652,11 +6665,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6711,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+checksum = "34836a629bcbc6f1afdf0907a744870039b1e14c0561cb26094fa683b158eff3"
 dependencies = [
  "erased-serde",
  "serde",
@@ -6747,7 +6760,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6758,16 +6771,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6782,7 +6795,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6825,7 +6838,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6844,7 +6857,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6940,9 +6953,9 @@ dependencies = [
 
 [[package]]
 name = "shared_thread"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a6f98357c6bb0ebace19b22220e5543801d9de90ffe77f8abb27c056bac064"
+checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
 
 [[package]]
 name = "shlex"
@@ -6984,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -7003,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
  "num-complex",
@@ -7083,7 +7096,7 @@ dependencies = [
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "hex",
  "hmac 0.12.1",
  "itertools 0.14.0",
@@ -7109,7 +7122,7 @@ dependencies = [
  "slab",
  "smallvec",
  "soketto",
- "twox-hash 2.1.1",
+ "twox-hash 2.1.2",
  "wasmi",
  "x25519-dalek",
  "zeroize",
@@ -7133,7 +7146,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -7149,16 +7162,6 @@ dependencies = [
  "smol",
  "smoldot",
  "zeroize",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7211,22 +7214,22 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "docify",
  "hash-db",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 15.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api-proc-macro 15.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
 ]
 
@@ -7241,13 +7244,13 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "Inflector",
  "blake2",
@@ -7255,7 +7258,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7273,13 +7276,13 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7299,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -7329,17 +7332,17 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7363,19 +7366,19 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7392,12 +7395,12 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7450,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -7481,14 +7484,13 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "substrate-bip39 0.4.7 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -7525,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7542,17 +7544,17 @@ source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea717
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7562,17 +7564,17 @@ source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea717
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7588,11 +7590,11 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7610,13 +7612,13 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7635,13 +7637,13 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
 ]
 
@@ -7674,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "bytes",
  "docify",
@@ -7685,14 +7687,14 @@ dependencies = [
  "polkavm-derive 0.26.0",
  "rustversion",
  "secp256k1 0.28.2",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-keystore 0.34.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-keystore 0.34.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "tracing",
  "tracing-core",
 ]
@@ -7721,12 +7723,12 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7742,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -7761,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "backtrace",
  "regex",
@@ -7799,9 +7801,9 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -7814,13 +7816,13 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "tracing",
  "tuplex",
 ]
@@ -7846,19 +7848,18 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive 0.26.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "static_assertions",
 ]
 
@@ -7872,20 +7873,20 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7904,14 +7905,14 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -7937,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "hash-db",
  "log",
@@ -7945,10 +7946,10 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -7962,7 +7963,7 @@ source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea717
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 
 [[package]]
 name = "sp-storage"
@@ -7979,13 +7980,13 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -8003,12 +8004,12 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
 ]
 
@@ -8027,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -8044,8 +8045,8 @@ dependencies = [
  "ahash",
  "foldhash",
  "hash-db",
- "hashbrown 0.15.4",
- "memory-db 0.34.0",
+ "hashbrown 0.15.5",
+ "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot",
@@ -8064,20 +8065,22 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "ahash",
+ "foldhash",
  "hash-db",
- "memory-db 0.33.0",
+ "hashbrown 0.15.5",
+ "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot",
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "substrate-prometheus-endpoint 0.17.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "substrate-prometheus-endpoint 0.17.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -8104,17 +8107,17 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-version-proc-macro 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-version-proc-macro 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
  "thiserror 1.0.69",
 ]
 
@@ -8127,19 +8130,19 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8156,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -8181,15 +8184,15 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
 ]
 
 [[package]]
@@ -8281,7 +8284,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8299,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -8338,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4#cb629d46ebf00aa65624013a61f9c69ebf02b0b4"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -8383,7 +8386,7 @@ dependencies = [
  "subxt-macro",
  "subxt-metadata 0.44.0",
  "subxt-rpcs",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8405,8 +8408,8 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata 0.44.0",
- "syn 2.0.104",
- "thiserror 2.0.12",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8435,7 +8438,7 @@ dependencies = [
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata 0.41.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -8448,7 +8451,7 @@ dependencies = [
  "base58",
  "blake2",
  "derive-where",
- "frame-decode 0.8.0",
+ "frame-decode 0.8.3",
  "frame-metadata 23.0.0",
  "hashbrown 0.14.5",
  "hex",
@@ -8465,7 +8468,7 @@ dependencies = [
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata 0.43.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -8495,7 +8498,7 @@ dependencies = [
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata 0.44.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -8510,7 +8513,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smoldot-light",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8530,7 +8533,7 @@ dependencies = [
  "subxt-codegen",
  "subxt-metadata 0.44.0",
  "subxt-utils-fetchmetadata",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8545,7 +8548,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8554,13 +8557,13 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
 dependencies = [
- "frame-decode 0.8.0",
+ "frame-decode 0.8.3",
  "frame-metadata 23.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8575,7 +8578,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8596,7 +8599,7 @@ dependencies = [
  "serde_json",
  "subxt-core 0.44.0",
  "subxt-lightclient",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio-util",
  "tracing",
  "url",
@@ -8628,7 +8631,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core 0.41.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -8658,7 +8661,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core 0.43.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -8688,7 +8691,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core 0.44.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -8700,7 +8703,7 @@ checksum = "e450f6812a653c5a3e63a079aa3b60a3f4c362722753c3222286eaa1800f9002"
 dependencies = [
  "hex",
  "parity-scale-codec",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8716,9 +8719,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8727,14 +8730,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
+checksum = "a0b198d366dbec045acfcd97295eb653a7a2b40e4dc764ef1e79aafcad439d3c"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8745,7 +8748,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8771,15 +8774,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8812,11 +8815,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -8827,18 +8830,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8861,12 +8864,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
- "deranged",
- "itoa",
+ "deranged 0.5.3",
  "num-conv",
  "powerfmt",
  "serde",
@@ -8876,15 +8878,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8911,9 +8913,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8938,7 +8940,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -8951,7 +8953,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8977,9 +8979,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9003,11 +9005,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -9040,7 +9042,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9050,9 +9052,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
@@ -9095,7 +9097,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -9187,7 +9189,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.2",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -9216,9 +9218,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"
@@ -9313,9 +9315,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -9461,44 +9463,45 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9509,9 +9512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9519,22 +9522,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
@@ -9586,14 +9589,14 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9615,14 +9618,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.1",
+ "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9666,11 +9669,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -9687,7 +9690,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -9700,7 +9703,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -9711,7 +9714,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -9721,12 +9724,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9735,7 +9744,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9780,7 +9789,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -9831,10 +9849,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -10027,9 +10046,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -10041,13 +10060,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -10084,7 +10100,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10125,28 +10141,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10166,7 +10182,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -10187,7 +10203,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10203,9 +10219,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10220,7 +10236,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10231,18 +10247,18 @@ checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "memchr",
 ]
 
 [[package]]
 name = "zip"
-version = "4.3.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "k256",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c219a87fb386a75780ddbdbbced242477321887e426b0f946c05815ceabe5e09"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,8 +198,31 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec 0.7.6",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae653f049267ae7e040eab6c9b9a417064ca1a6cb21e3dd59b9f1131ef048f"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -352,6 +434,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +647,35 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -853,6 +976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1001,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
@@ -911,7 +1050,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hash-db",
  "log",
@@ -1102,6 +1241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bollard"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1349,21 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -1608,6 +1774,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -2202,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "alloy-core",
 ]
@@ -2363,24 +2544,24 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-support-procedural 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-storage 19.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "static_assertions",
 ]
 
@@ -2473,16 +2654,16 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "aquamarine",
  "array-bytes",
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "binary-merkle-tree 13.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata 23.0.0",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support-procedural 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -2492,22 +2673,22 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-genesis-builder 0.8.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-staking 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-genesis-builder 0.8.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-inherents 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-metadata-ir 0.6.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-staking 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-state-machine 0.35.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-tracing 16.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-trie 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "tt-call",
 ]
 
@@ -2555,20 +2736,20 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "docify",
  "expander",
- "frame-support-procedural-tools 10.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support-procedural-tools 10.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "syn 2.0.104",
 ]
 
@@ -2595,9 +2776,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
- "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -2619,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2639,20 +2820,20 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-version 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -2857,6 +3038,16 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a636fb6a653382a379ee1e5593dacdc628667994167024c143214cafd40c1a86"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "group"
@@ -3404,12 +3595,12 @@ dependencies = [
  "ink_storage",
  "keccak-const",
  "linkme",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "staging-xcm",
  "tokio",
  "trybuild",
@@ -3437,7 +3628,7 @@ dependencies = [
  "ink_primitives 6.0.0-alpha.1",
  "itertools 0.14.0",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "proc-macro2",
  "quote",
  "serde",
@@ -3452,7 +3643,7 @@ dependencies = [
  "cargo_metadata 0.21.0",
  "contract-build",
  "deranged",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "funty",
  "impl-serde",
  "ink",
@@ -3462,26 +3653,26 @@ dependencies = [
  "ink_sandbox",
  "itertools 0.14.0",
  "jsonrpsee",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "regex",
  "scale-info",
  "serde",
  "serde_json",
  "sha3",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "sp-keyring",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "subxt",
  "subxt-metadata 0.42.1",
  "subxt-signer 0.42.1",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.20",
  "which 7.0.3",
 ]
 
@@ -3499,7 +3690,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.104",
  "temp-env",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -3510,8 +3701,8 @@ dependencies = [
  "derive_more 2.0.1",
  "hex-literal 1.0.0",
  "ink_primitives 6.0.0-alpha.1",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -3535,10 +3726,10 @@ dependencies = [
  "ink_primitives 6.0.0-alpha.1",
  "ink_storage_traits",
  "num-traits",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "scale-decode",
  "scale-encode",
  "scale-info",
@@ -3546,8 +3737,8 @@ dependencies = [
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "sha3",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "staging-xcm",
  "static_assertions",
 ]
@@ -3646,8 +3837,8 @@ dependencies = [
  "ink_prelude 6.0.0-alpha.1",
  "itertools 0.14.0",
  "num-traits",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "paste",
  "primitive-types 0.13.1",
@@ -3655,10 +3846,10 @@ dependencies = [
  "scale-encode",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "xxhash-rust",
 ]
 
@@ -3695,19 +3886,19 @@ name = "ink_sandbox"
 version = "6.0.0-alpha.1"
 dependencies = [
  "frame-metadata 23.0.0",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "ink_primitives 6.0.0-alpha.1",
  "pallet-balances",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "pallet-timestamp",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "sha3",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -3724,7 +3915,7 @@ dependencies = [
  "ink_primitives 6.0.0-alpha.1",
  "ink_storage_traits",
  "itertools 0.14.0",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "quickcheck",
  "quickcheck_macros",
@@ -3741,8 +3932,8 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -4367,6 +4558,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,6 +4616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,6 +4655,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4500,34 +4738,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
  "environmental",
- "ethereum-standards 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "ethereum-standards 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "ethereum-types",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "hex-literal 0.4.1",
  "humantime-serde",
  "impl-trait-for-tuples",
@@ -4535,29 +4785,30 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "pallet-revive-fixtures 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "pallet-revive-fixtures 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-revive-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "pallet-transaction-payment 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "paste",
- "polkavm",
- "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm 0.27.0",
+ "polkavm-common 0.27.0",
  "rand 0.8.5",
+ "revm",
  "ripemd",
  "rlp 0.6.1",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-consensus-aura 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-consensus-babe 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-consensus-aura 0.32.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-consensus-babe 0.32.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "substrate-bn",
- "subxt-signer 0.41.0",
+ "subxt-signer 0.43.0",
 ]
 
 [[package]]
@@ -4586,7 +4837,7 @@ dependencies = [
  "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
  "parity-scale-codec",
  "paste",
- "polkavm",
+ "polkavm 0.26.0",
  "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "ripemd",
@@ -4608,14 +4859,17 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
+ "alloy-core",
  "anyhow",
  "cargo_metadata 0.15.4",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "polkavm-linker 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "hex",
+ "pallet-revive-uapi 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "polkavm-linker 0.27.0",
+ "serde_json",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "toml 0.8.23",
 ]
 
@@ -4636,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4656,12 +4910,14 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bitflags 1.3.2",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "const-crypto",
+ "hex-literal 0.4.1",
+ "pallet-revive-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.27.0",
  "scale-info",
 ]
 
@@ -4673,41 +4929,41 @@ dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "scale-info",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-inherents 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-storage 19.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-timestamp 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-benchmarking 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "frame-system 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -4848,6 +5104,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,9 +5206,22 @@ checksum = "fa028f713d0613f0f08b8b3367402cb859218854f6b96fcbe39a501862894d6f"
 dependencies = [
  "libc",
  "log",
- "polkavm-assembler",
+ "polkavm-assembler 0.26.0",
  "polkavm-common 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "polkavm-linux-raw",
+ "polkavm-linux-raw 0.26.0",
+]
+
+[[package]]
+name = "polkavm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef5796e5aaa109df210fed7c6ff82e89c7bf94c28f6332d57bd0efb865fdc2a"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler 0.27.0",
+ "polkavm-common 0.27.0",
+ "polkavm-linux-raw 0.27.0",
 ]
 
 [[package]]
@@ -4923,6 +5234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-assembler"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf3be2911acc089dfe54a92bfec22002f4fbf423b8fa771d1f7e7227f0195f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "polkavm-common"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +5250,7 @@ checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
 dependencies = [
  "blake3",
  "log",
- "polkavm-assembler",
+ "polkavm-assembler 0.26.0",
 ]
 
 [[package]]
@@ -4939,12 +5259,32 @@ version = "0.26.0"
 source = "git+https://github.com/paritytech/polkavm.git#da9a904909d7770477637783c70c30b3fc6df2ac"
 
 [[package]]
+name = "polkavm-common"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19805789e7bf778ac5855f6fe9350353f6a1697c2aab9bfb6fc7c831be54fad"
+dependencies = [
+ "blake3",
+ "log",
+ "polkavm-assembler 0.27.0",
+]
+
+[[package]]
 name = "polkavm-derive"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
 dependencies = [
- "polkavm-derive-impl-macro",
+ "polkavm-derive-impl-macro 0.26.0",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eea46a17d87cbf3c0f3f6156f6300f60cec67cf9eaca296c770e0873f8389d6"
+dependencies = [
+ "polkavm-derive-impl-macro 0.27.0",
 ]
 
 [[package]]
@@ -4960,12 +5300,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-derive-impl"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abdd1210d96b1dda9ac21199ec469448fd628cea102e2ff0e0df1667c4c3b5f"
+dependencies = [
+ "polkavm-common 0.27.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "polkavm-derive-impl-macro"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
 dependencies = [
- "polkavm-derive-impl",
+ "polkavm-derive-impl 0.26.0",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a45173d70138aa1879892c50777ed0d8b0c8556f7678372f09fa1d89bbbddb4"
+dependencies = [
+ "polkavm-derive-impl 0.27.0",
  "syn 2.0.104",
 ]
 
@@ -5001,10 +5363,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-linker"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fe3704d21e96c5d1e6a1b1a43ac57f9dce110d3331fbf8299e9f57d5884066"
+dependencies = [
+ "dirs",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "object",
+ "polkavm-common 0.27.0",
+ "regalloc2",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "polkavm-linux-raw"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28919f542476f4158cc71e6c072b1051f38f4b514253594ac3ad80e3c0211fc8"
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061088785efd93e4367faf12f341bb356208c06bab43aa942d472068af80d1c4"
 
 [[package]]
 name = "polling"
@@ -5074,6 +5458,15 @@ checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5419,6 +5812,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "revm"
+version = "27.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6bf82101a1ad8a2b637363a37aef27f88b4efc8a6e24c72bf5f64923dc5532"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90302642d21c8f93e0876e201f3c5f7913c4fcb66fb465b0fd7b707dfe1c79"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1529c8050e663be64010e80ec92bf480315d21b1f2dbf65540028653a621b27d"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78db140e332489094ef314eaeb0bd1849d6d01172c113ab0eb6ea8ab9372926"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9d7d9d71e8a33740b277b602165b6e3d25fff091ba3d7b5a8d373bf55f28a7"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cee3f336b83621294b4cfe84d817e3eef6f3d0fce00951973364cc7f860424d"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-bn254",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "libsecp256k1",
+ "once_cell",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "20.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+dependencies = [
+ "bitflags 2.9.1",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5469,6 +6051,18 @@ checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rug"
+version = "1.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
 ]
 
 [[package]]
@@ -5976,6 +6570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand 0.9.1",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,6 +6603,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -6137,6 +6751,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6200,7 +6815,20 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_with_macros",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6545,22 +7173,22 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "hash-db",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 15.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api-proc-macro 15.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-metadata-ir 0.6.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-state-machine 0.35.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-trie 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-version 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
 ]
 
@@ -6589,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "blake2",
@@ -6617,13 +7245,13 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6641,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -6669,17 +7297,17 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-inherents 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-timestamp 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6701,19 +7329,19 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-consensus-slots 0.32.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-inherents 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-timestamp 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6737,12 +7365,12 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-timestamp 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6759,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -6790,13 +7418,13 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-storage 19.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "substrate-bip39 0.4.7 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -6868,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6894,10 +7522,10 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "syn 2.0.104",
 ]
 
@@ -6914,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6934,11 +7562,11 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-storage 19.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6954,13 +7582,13 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-api 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -6978,13 +7606,13 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
 ]
 
@@ -7004,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "docify",
@@ -7012,17 +7640,17 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "rustversion",
  "secp256k1 0.28.2",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-keystore 0.34.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-keystore 0.34.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-state-machine 0.35.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-tracing 16.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-trie 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "tracing",
  "tracing-core",
 ]
@@ -7038,7 +7666,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
@@ -7056,22 +7684,22 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "strum",
 ]
 
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -7088,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -7108,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "backtrace",
  "regex",
@@ -7126,9 +7754,9 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "binary-merkle-tree 13.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -7141,13 +7769,13 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-application-crypto 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-io 30.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-trie 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "tracing",
  "tuplex",
 ]
@@ -7184,18 +7812,18 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "polkavm-derive 0.26.0",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-storage 19.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-tracing 16.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "static_assertions",
 ]
 
@@ -7207,7 +7835,7 @@ dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.26.0",
  "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa65624013a61f9c69ebf02b0b4)",
@@ -7221,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "expander",
@@ -7247,14 +7875,14 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -7273,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hash-db",
  "log",
@@ -7281,10 +7909,10 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-panic-handler 13.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-trie 29.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -7313,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 
 [[package]]
 name = "sp-std"
@@ -7323,13 +7951,13 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=cb629d46ebf00aa
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -7347,12 +7975,12 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-inherents 26.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
 ]
 
@@ -7371,13 +7999,13 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "regex",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -7389,13 +8017,13 @@ dependencies = [
  "regex",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "ahash",
  "foldhash",
@@ -7408,9 +8036,9 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "substrate-prometheus-endpoint 0.17.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-core 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-externalities 0.25.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "substrate-prometheus-endpoint 0.17.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -7443,17 +8071,17 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-version-proc-macro 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-std 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-version-proc-macro 13.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "thiserror 1.0.69",
 ]
 
@@ -7477,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -7501,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7523,15 +8151,15 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-arithmetic 23.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
 ]
 
 [[package]]
@@ -7588,20 +8216,20 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "array-bytes",
  "bounded-collections",
  "derive-where",
  "environmental",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "frame-support 28.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "hex-literal 0.4.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7)",
+ "sp-runtime 31.0.1 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
+ "sp-weights 27.0.0 (git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1)",
  "tracing",
  "xcm-procedural",
 ]
@@ -7643,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -7680,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -7826,6 +8454,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "subxt-core"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25338dd11ae34293b8d0c5807064f2e00194ba1bd84cccfa694030c8d185b941"
+dependencies = [
+ "base58",
+ "blake2",
+ "derive-where",
+ "frame-decode 0.8.0",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "hex",
+ "impl-serde",
+ "keccak-hash",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subxt-metadata 0.43.0",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "subxt-lightclient"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7879,6 +8537,21 @@ name = "subxt-metadata"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243990ca4e0cdb74ef7458f1d5070a1bd5144d744cc146f23a32ab56d23e1db7"
+dependencies = [
+ "frame-decode 0.8.0",
+ "frame-metadata 23.0.0",
+ "hashbrown 0.14.5",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-metadata"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
 dependencies = [
  "frame-decode 0.8.0",
  "frame-metadata 23.0.0",
@@ -7969,6 +8642,36 @@ dependencies = [
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core 0.42.1",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "subxt-signer"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9bd240ae819f64ac6898d7ec99a88c8b838dba2fb9d83b843feb70e77e34c8"
+dependencies = [
+ "base64",
+ "bip32",
+ "bip39",
+ "cfg-if",
+ "crypto_secretbox",
+ "hex",
+ "hmac 0.12.1",
+ "keccak-hash",
+ "parity-scale-codec",
+ "pbkdf2",
+ "regex",
+ "schnorrkel",
+ "scrypt",
+ "secp256k1 0.30.0",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subxt-core 0.43.0",
  "thiserror 2.0.12",
  "zeroize",
 ]
@@ -8129,6 +8832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -8388,6 +9100,15 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -9354,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=c40b36c3a7c208f9a6837b80812473af3d9ba7f7#c40b36c3a7c208f9a6837b80812473af3d9ba7f7"
+source = "git+https://github.com/use-ink/polkadot-sdk.git?rev=a71ec19a94702ea71767ba5ac97603ea6c6305c1#a71ec19a94702ea71767ba5ac97603ea6c6305c1"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,22 +82,22 @@ const_env = { version = "0.1" }
 
 # Substrate dependencies
 frame-metadata = { version = "23.0.0", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+frame-system = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-support = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-balances = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-timestamp = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["unstable-hostfn"] }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-revive-uapi = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["unstable-hostfn"] }
 
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+sp-externalities = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
+sp-core = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-keyring = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-runtime = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
+sp-weights = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 # PolkaVM dependencies
 polkavm-derive = { version = "0.26.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,9 @@ serde_json = { version = "1.0.137" }
 sha2 = { version = "0.10" }
 sha3 = { version = "0.10" }
 static_assertions = { version = "1.1" }
-subxt = { version = "0.42.1" }
-subxt-metadata = { version = "0.42.1" }
-subxt-signer = { version = "0.42.1" }
+subxt = { version = "0.44.0" }
+subxt-metadata = { version = "0.44.0" }
+subxt-signer = { version = "0.44.0" }
 syn = { version = "2" }
 synstructure = { version = "0.13.1" }
 thiserror = { version = "2.0.11" }
@@ -76,7 +76,7 @@ tokio = { version = "1.47.1" }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.20" }
 trybuild = { version = "1.0.110" }
-which = { version = "7.0.0" }
+which = { version = "8.0.0" }
 xxhash-rust = { version = "0.8" }
 const_env = { version = "0.1" }
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -49,8 +49,8 @@ sp-weights = { workspace = true }
 regex = "1.11.1"
 itertools = "0.14.0"
 
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
 
 # todo Pin until https://github.com/jhpratt/deranged/issues/18 is resolved
 deranged = { version = "=0.4.0", default-features = false }

--- a/crates/e2e/sandbox/src/api/revive_api.rs
+++ b/crates/e2e/sandbox/src/api/revive_api.rs
@@ -175,7 +175,9 @@ where
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<BalanceOf<Self::T>>,
     ) -> ContractResultInstantiate<Self::T> {
+        eprintln!("0----------- attempt {:?}", storage_deposit_limit);
         let storage_deposit_limit = storage_deposit_limit_fn(storage_deposit_limit);
+        eprintln!("1----------- attempt {:?}", storage_deposit_limit);
         self.execute_with(|| {
             pallet_revive::Pallet::<Self::T>::bare_instantiate(
                 origin,

--- a/crates/e2e/sandbox/src/macros.rs
+++ b/crates/e2e/sandbox/src/macros.rs
@@ -218,6 +218,7 @@ mod construct_runtime {
             //ERC20<Self, InlineIdConfig<0x320>, PoolAssetsInstance>,
             //XcmPrecompile<Self>,
         );
+        type AllowEVMBytecode = ConstBool<false>;
     }
 
     // Implement `crate::Sandbox` trait

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -225,7 +225,6 @@ where
     Contract: Clone,
     B: BuilderClient<E>,
     Abi: Send + Sync + Clone,
-    //<E as Environment>::Balance: std::fmt::Debug
 {
     /// Initialize a call builder with essential values.
     pub fn new(
@@ -315,12 +314,6 @@ where
             self.storage_deposit_limit.clone(),
         )
         .await?;
-        //let foo = dry_run.contract_result.storage_deposit;
-        //eprintln!("-------------------submit dry run deposit {:#?}\n\n", foo.encode());
-        eprintln!(
-            "-------------------submit dry run result {:#?}\n\n",
-            dry_run.contract_result.result
-        );
 
         let gas_limit = if let Some(limit) = self.gas_limit {
             limit
@@ -339,8 +332,8 @@ where
             self.value,
             gas_limit,
             balance_to_deposit_limit::<E>(Some(
-                dry_run.contract_result.storage_deposit.charge_or_zero()
-                    * 100_000_000u32.into(),
+                dry_run.contract_result.storage_deposit.charge_or_zero(),
+                // * 100_000_000u32.into(), // todo
             )),
         )
         .await?;

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -333,7 +333,6 @@ where
             gas_limit,
             balance_to_deposit_limit::<E>(Some(
                 dry_run.contract_result.storage_deposit.charge_or_zero(),
-                // * 100_000_000u32.into(), // todo
             )),
         )
         .await?;

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -225,6 +225,7 @@ where
     Contract: Clone,
     B: BuilderClient<E>,
     Abi: Send + Sync + Clone,
+    //<E as Environment>::Balance: std::fmt::Debug
 {
     /// Initialize a call builder with essential values.
     pub fn new(
@@ -314,6 +315,12 @@ where
             self.storage_deposit_limit.clone(),
         )
         .await?;
+        //let foo = dry_run.contract_result.storage_deposit;
+        //eprintln!("-------------------submit dry run deposit {:#?}\n\n", foo.encode());
+        eprintln!(
+            "-------------------submit dry run result {:#?}\n\n",
+            dry_run.contract_result.result
+        );
 
         let gas_limit = if let Some(limit) = self.gas_limit {
             limit
@@ -332,7 +339,8 @@ where
             self.value,
             gas_limit,
             balance_to_deposit_limit::<E>(Some(
-                dry_run.contract_result.storage_deposit.charge_or_zero(),
+                dry_run.contract_result.storage_deposit.charge_or_zero()
+                    * 100_000_000u32.into(),
             )),
         )
         .await?;

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -346,8 +346,9 @@ impl<E: Environment, V: DecodeMessageResult<Abi>, Abi> CallDryRunResult<E, V, Ab
         let data = &self.exec_return_value().data;
         DecodeMessageResult::decode_output(data.as_ref(), self.did_revert()).unwrap_or_else(|env_err| {
             panic!(
-                "Decoding dry run result to ink! message return type failed: {env_err:?} {:?}",
-                self.exec_return_value()
+                "Decoding dry run result to ink! message return type failed: {env_err:?} {:?}\n\nAttempt to stringify returned data: {:?}",
+                self.exec_return_value(),
+                String::from_utf8_lossy(&self.exec_return_value().data[..])
             )
         })
     }

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -346,7 +346,8 @@ impl<E: Environment, V: DecodeMessageResult<Abi>, Abi> CallDryRunResult<E, V, Ab
         let data = &self.exec_return_value().data;
         DecodeMessageResult::decode_output(data.as_ref(), self.did_revert()).unwrap_or_else(|env_err| {
             panic!(
-                "Decoding dry run result to ink! message return type failed: {env_err:?} {:?}\n\nAttempt to stringify returned data: {:?}",
+                "Decoding dry run result to ink! message return type failed: {env_err:?} {:?}\n\n\
+                Attempt to stringify returned data: {:?}",
                 self.exec_return_value(),
                 String::from_utf8_lossy(&self.exec_return_value().data[..])
             )

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -148,6 +148,12 @@ where
                 .mint_into(account, TOKENS.into())
                 .unwrap_or_else(|_| panic!("Failed to mint {TOKENS} tokens"));
         }
+
+        let acc = pallet_revive::Pallet::<S::Runtime>::account_id();
+        let ed = pallet_balances::Pallet::<S::Runtime>::minimum_balance();
+        sandbox
+            .mint_into(&acc, ed)
+            .unwrap_or_else(|_| panic!("Failed to mint {TOKENS} tokens"));
     }
 }
 
@@ -265,6 +271,10 @@ where
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
     ) -> Result<BareInstantiationResult<Self::EventLog>, Self::Error> {
+        eprintln!(
+            "-------------------bare instantiate {:?}",
+            storage_deposit_limit
+        );
         let _ =
             <Client<AccountId, S> as BuilderClient<E>>::map_account(self, caller).await;
 

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -151,9 +151,9 @@ where
 
         let acc = pallet_revive::Pallet::<S::Runtime>::account_id();
         let ed = pallet_balances::Pallet::<S::Runtime>::minimum_balance();
-        sandbox
-            .mint_into(&acc, ed)
-            .unwrap_or_else(|_| panic!("Failed to mint {TOKENS} tokens"));
+        sandbox.mint_into(&acc, ed).unwrap_or_else(|_| {
+            panic!("Failed to mint existential deposit into `pallet-revive` account")
+        });
     }
 }
 
@@ -271,10 +271,6 @@ where
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
     ) -> Result<BareInstantiationResult<Self::EventLog>, Self::Error> {
-        eprintln!(
-            "-------------------bare instantiate {:?}",
-            storage_deposit_limit
-        );
         let _ =
             <Client<AccountId, S> as BuilderClient<E>>::map_account(self, caller).await;
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -32,15 +32,15 @@ xcm = { workspace = true }
 hex-literal = "1"
 const-crypto = "0.3.0"
 
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 polkavm-derive = { workspace = true, default-features = false }
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies]
 ink_engine = { workspace = true, default-features = true, optional = true }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 # Hashes for the off-chain environment.
 sha2 = { workspace = true, optional = true }

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -172,13 +172,9 @@ where
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
-pub fn minimum_balance<E>() -> E::Balance
-where
-    E: Environment,
-{
+pub fn minimum_balance() -> U256 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::minimum_balance::<E>(instance)
+        TypedEnvBackend::minimum_balance(instance)
     })
 }
 

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -342,7 +342,6 @@ where
 /// - If the instantiation process runs out of gas.
 /// - If given insufficient endowment.
 /// - If the returned account ID failed to decode properly.
-#[cfg(feature = "unstable-hostfn")]
 pub fn instantiate_contract<E, ContractRef, Args, R, Abi>(
     params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,
 ) -> Result<

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -886,3 +886,10 @@ where
         TypedEnvBackend::xcm_send::<E, _>(instance, dest, msg)
     })
 }
+
+/// Returns the size of the buffer that is remaining in the backend.
+pub fn remaining_buffer() -> usize {
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        EnvBackend::remaining_buffer(instance)
+    })
+}

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -24,13 +24,6 @@ use ink_primitives::{
 use ink_storage_traits::Storable;
 use pallet_revive_uapi::ReturnFlags;
 
-#[cfg(feature = "unstable-hostfn")]
-use crate::call::{
-    ConstructorReturnType,
-    CreateParams,
-    FromAddr,
-    LimitParamsV2,
-};
 use crate::{
     backend::{
         EnvBackend,
@@ -40,7 +33,11 @@ use crate::{
         utils::DecodeMessageResult,
         Call,
         CallParams,
+        ConstructorReturnType,
+        CreateParams,
         DelegateCall,
+        FromAddr,
+        LimitParamsV2,
     },
     engine::{
         EnvInstance,
@@ -120,7 +117,6 @@ where
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
 pub fn account_id<E>() -> E::AccountId
 where
     E: Environment,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -227,7 +227,6 @@ where
 /// # Errors
 ///
 /// - If the decoding of the typed value failed (`KeyNotFound`)
-#[cfg(feature = "unstable-hostfn")]
 pub fn take_contract_storage<K, R>(key: &K) -> Result<Option<R>>
 where
     K: scale::Encode,
@@ -242,7 +241,6 @@ where
 /// storage.
 ///
 /// If a value is stored under the specified key, the size of the value is returned.
-#[cfg(feature = "unstable-hostfn")]
 pub fn contains_contract_storage<K>(key: &K) -> Option<u32>
 where
     K: scale::Encode,
@@ -256,7 +254,6 @@ where
 ///
 /// If a value was stored under the specified storage key, the size of the value is
 /// returned.
-#[cfg(feature = "unstable-hostfn")]
 pub fn clear_contract_storage<K>(key: &K) -> Option<u32>
 where
     K: scale::Encode,
@@ -656,7 +653,6 @@ pub fn code_hash(addr: &Address) -> Result<H256> {
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
 pub fn own_code_hash() -> Result<H256> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         TypedEnvBackend::own_code_hash(instance)
@@ -676,7 +672,6 @@ pub fn own_code_hash() -> Result<H256> {
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
 pub fn caller_is_origin<E>() -> bool
 where
     E: Environment,
@@ -697,7 +692,6 @@ where
 /// # Errors
 ///
 /// If the returned value cannot be properly decoded.
-#[cfg(feature = "unstable-hostfn")]
 pub fn caller_is_root<E>() -> bool
 where
     E: Environment,

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -363,7 +363,6 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`instantiate_contract`][`crate::instantiate_contract`]
-    #[cfg(feature = "unstable-hostfn")]
     fn instantiate_contract<E, ContractRef, Args, R, Abi>(
         &mut self,
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -241,6 +241,9 @@ pub trait EnvBackend {
     /// - If the supplied `code_hash` cannot be found on-chain.
     #[cfg(feature = "unstable-hostfn")]
     fn set_code_hash(&mut self, code_hash: &H256) -> Result<()>;
+
+    /// Returns the size of the buffer that is remaining in the backend.
+    fn remaining_buffer(&mut self) -> usize;
 }
 
 /// Environmental contract functionality.

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -23,19 +23,16 @@ use ink_primitives::{
 use ink_storage_traits::Storable;
 pub use pallet_revive_uapi::ReturnFlags;
 
-#[cfg(feature = "unstable-hostfn")]
-use crate::call::{
-    ConstructorReturnType,
-    CreateParams,
-    FromAddr,
-    LimitParamsV2,
-};
 use crate::{
     call::{
         utils::DecodeMessageResult,
         Call,
         CallParams,
+        ConstructorReturnType,
+        CreateParams,
         DelegateCall,
+        FromAddr,
+        LimitParamsV2,
     },
     event::{
         Event,
@@ -281,7 +278,6 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`account_id`][`crate::account_id`]
-    #[cfg(feature = "unstable-hostfn")]
     fn account_id<E: Environment>(&mut self) -> E::AccountId;
 
     /// Returns the address of the executed contract.

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -77,14 +77,12 @@ pub trait EnvBackend {
     /// # Errors
     ///
     /// - If the decoding of the typed value failed
-    #[cfg(feature = "unstable-hostfn")]
     fn take_contract_storage<K, R>(&mut self, key: &K) -> Result<Option<R>>
     where
         K: scale::Encode,
         R: Storable;
 
     /// Returns the size of a value stored under the given storage key is returned if any.
-    #[cfg(feature = "unstable-hostfn")]
     fn contains_contract_storage<K>(&mut self, key: &K) -> Option<u32>
     where
         K: scale::Encode;
@@ -92,7 +90,6 @@ pub trait EnvBackend {
     /// Clears the contract's storage key entry under the given storage key.
     ///
     /// Returns the size of the previously stored value at the specified key if any.
-    #[cfg(feature = "unstable-hostfn")]
     fn clear_contract_storage<K>(&mut self, key: &K) -> Option<u32>
     where
         K: scale::Encode;
@@ -411,7 +408,6 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`caller_is_origin`][`crate::caller_is_origin`]
-    #[cfg(feature = "unstable-hostfn")]
     fn caller_is_origin<E>(&mut self) -> bool
     where
         E: Environment;
@@ -421,7 +417,6 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`caller_is_root`][`crate::caller_is_root`]
-    #[cfg(feature = "unstable-hostfn")]
     fn caller_is_root<E>(&mut self) -> bool
     where
         E: Environment;
@@ -438,7 +433,6 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`own_code_hash`][`crate::own_code_hash`]
-    #[cfg(feature = "unstable-hostfn")]
     fn own_code_hash(&mut self) -> Result<H256>;
 
     #[cfg(feature = "unstable-hostfn")]

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -314,8 +314,7 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`minimum_balance`][`crate::minimum_balance`]
-    #[cfg(feature = "unstable-hostfn")]
-    fn minimum_balance<E: Environment>(&mut self) -> E::Balance;
+    fn minimum_balance(&mut self) -> U256;
 
     /// Emits an event with the given event data.
     ///

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -24,8 +24,6 @@ use ink_primitives::{
     U256,
 };
 
-#[cfg(feature = "unstable-hostfn")]
-use crate::Error;
 use crate::{
     call::{
         utils::{
@@ -40,6 +38,7 @@ use crate::{
     },
     types::Environment,
     ContractEnv,
+    Error,
 };
 
 pub mod state {
@@ -294,7 +293,6 @@ where
     /// those use the [`try_instantiate`][`CreateParams::try_instantiate`] method
     /// instead.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn instantiate(&self) -> <R as ConstructorReturnType<ContractRef, Abi>>::Output {
         crate::instantiate_contract(self)
             .unwrap_or_else(|env_error| {
@@ -313,7 +311,6 @@ where
     /// [`ink::primitives::LangError`][`ink_primitives::LangError`], both of which can be
     /// handled by the caller.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_instantiate(
         &self,
     ) -> Result<
@@ -768,7 +765,6 @@ where
     /// those use the [`try_instantiate`][`CreateBuilder::try_instantiate`] method
     /// instead.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn instantiate(
         self,
     ) -> <RetType as ConstructorReturnType<ContractRef, Abi>>::Output {
@@ -784,7 +780,6 @@ where
     /// [`ink::primitives::LangError`][`ink_primitives::LangError`], both of which can be
     /// handled by the caller.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_instantiate(
         self,
     ) -> Result<

--- a/crates/env/src/engine/mod.rs
+++ b/crates/env/src/engine/mod.rs
@@ -13,17 +13,14 @@
 // limitations under the License.
 
 use cfg_if::cfg_if;
-#[cfg(feature = "unstable-hostfn")]
 use ink_primitives::ConstructorResult;
-#[cfg(feature = "unstable-hostfn")]
 use pallet_revive_uapi::ReturnErrorCode;
 
-use crate::backend::{
-    EnvBackend,
-    TypedEnvBackend,
-};
-#[cfg(feature = "unstable-hostfn")]
 use crate::{
+    backend::{
+        EnvBackend,
+        TypedEnvBackend,
+    },
     call::{
         utils::{
             ConstructorError,

--- a/crates/env/src/engine/mod.rs
+++ b/crates/env/src/engine/mod.rs
@@ -75,7 +75,6 @@ cfg_if! {
 
 // We only use this function when 1) compiling for PolkaVM 2) compiling for tests.
 #[cfg_attr(all(feature = "std", not(test)), allow(dead_code))]
-#[cfg(feature = "unstable-hostfn")] // only usages are when unstable-hostfn is enabled
 pub(crate) fn decode_instantiate_result<I, ContractRef, R, Abi>(
     instantiate_result: EnvResult<()>,
     out_address: &mut I,
@@ -101,7 +100,6 @@ where
 }
 
 #[cfg_attr(all(feature = "std", not(test)), allow(dead_code))]
-#[cfg(feature = "unstable-hostfn")] // only usages are when unstable-hostfn is enabled
 fn decode_instantiate_err<ContractRef, R, Abi>(
     out_return_value: &[u8],
 ) -> EnvResult<ConstructorResult<<R as ConstructorReturnType<ContractRef, Abi>>::Output>>

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -692,7 +692,6 @@ impl TypedEnvBackend for EnvInstance {
         )
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn instantiate_contract<E, ContractRef, Args, R, Abi>(
         &mut self,
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -587,7 +587,6 @@ impl TypedEnvBackend for EnvInstance {
             })
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn account_id<E: Environment>(&mut self) -> E::AccountId {
         // todo should not use `Engine::account_id`
         self.get_property::<E::AccountId>(Engine::address)
@@ -849,9 +848,5 @@ impl TypedEnvBackend for EnvInstance {
         E: Environment,
     {
         unimplemented!("off-chain environment does not support `xcm_send`")
-    }
-
-    fn account_id<E: Environment>(&mut self) -> E::AccountId {
-        unimplemented!("off-chain environment does not support `account_id`")
     }
 }

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -385,6 +385,10 @@ impl EnvBackend for EnvInstance {
         }
     }
 
+    fn remaining_buffer(&mut self) -> usize {
+        BUFFER_SIZE
+    }
+
     fn contains_contract_storage<K>(&mut self, key: &K) -> Option<u32>
     where
         K: scale::Encode,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -375,7 +375,6 @@ impl EnvBackend for EnvInstance {
         }
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn take_contract_storage<K, R>(&mut self, key: &K) -> Result<Option<R>>
     where
         K: scale::Encode,
@@ -391,7 +390,6 @@ impl EnvBackend for EnvInstance {
         }
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn contains_contract_storage<K>(&mut self, key: &K) -> Option<u32>
     where
         K: scale::Encode,
@@ -399,7 +397,6 @@ impl EnvBackend for EnvInstance {
         self.engine.contains_storage(&key.encode())
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn clear_contract_storage<K>(&mut self, key: &K) -> Option<u32>
     where
         K: scale::Encode,
@@ -794,7 +791,6 @@ impl TypedEnvBackend for EnvInstance {
         self.engine.is_contract(account)
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn caller_is_origin<E>(&mut self) -> bool
     where
         E: Environment,
@@ -802,7 +798,6 @@ impl TypedEnvBackend for EnvInstance {
         unimplemented!("off-chain environment does not support cross-contract calls")
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn caller_is_root<E>(&mut self) -> bool
     where
         E: Environment,
@@ -821,7 +816,6 @@ impl TypedEnvBackend for EnvInstance {
         }
     }
 
-    #[cfg(feature = "unstable-hostfn")]
     fn own_code_hash(&mut self) -> Result<H256> {
         let callee = &self.engine.get_callee();
         let code_hash = self.engine.database.get_code_hash(callee);

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -625,9 +625,8 @@ impl TypedEnvBackend for EnvInstance {
             })
     }
 
-    #[cfg(feature = "unstable-hostfn")]
-    fn minimum_balance<E: Environment>(&mut self) -> E::Balance {
-        self.get_property::<E::Balance>(Engine::minimum_balance)
+    fn minimum_balance(&mut self) -> U256 {
+        self.get_property::<U256>(Engine::minimum_balance)
             .unwrap_or_else(|error| {
                 panic!("could not read `minimum_balance` property: {error:?}")
             })

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -62,7 +62,6 @@ pub struct EmittedEvent {
 /// - If the underlying `account` type does not match.
 /// - If the underlying `new_balance` type does not match.
 /// - If the `new_balance` is less than the existential minimum.
-#[cfg(feature = "unstable-hostfn")] // todo check this is needed here
 pub fn set_account_balance(addr: Address, new_balance: U256) {
     let min = ChainSpec::default().minimum_balance;
     if new_balance < min && new_balance != U256::zero() {

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -128,7 +128,7 @@ impl<'a> ScopedBuffer<'a> {
     /// Splits the scoped buffer into yet another piece to operate on it temporarily.
     ///
     /// The split buffer will have an offset of 0 but be offset by `self`'s offset.
-    pub fn split(&mut self) -> ScopedBuffer {
+    pub fn split(&mut self) -> ScopedBuffer<'_> {
         ScopedBuffer {
             offset: 0,
             buffer: &mut self.buffer[self.offset..],

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -231,4 +231,16 @@ impl<'a> ScopedBuffer<'a> {
         debug_assert!(!self.buffer.is_empty());
         self.buffer
     }
+
+    /// Returns the size of all remaining bytes in the buffer.
+    ///
+    /// # Developer Note
+    ///
+    /// The function requires `&mut self` because `self.buffer` is
+    /// already a mutable reference in the struct.
+    ///
+    /// _The function does not actually mutate state._
+    pub fn remaining_buffer(&mut self) -> usize {
+        self.buffer.len()
+    }
 }

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -205,7 +205,7 @@ impl<'a> ScopedBuffer<'a> {
     /// Appends the given bytes to the scoped buffer.
     ///
     /// Does not return the buffer immediately so that other values can be appended
-    /// afterwards. The [`take_appended`] method shall be used to return the buffer
+    /// afterward. The [`take_appended`] method shall be used to return the buffer
     /// that includes all appended encodings as a single buffer.
     #[inline(always)]
     pub fn append_bytes(&mut self, bytes: &[u8]) {
@@ -225,7 +225,7 @@ impl<'a> ScopedBuffer<'a> {
         self.take(offset)
     }
 
-    /// Returns all of the remaining bytes of the buffer as mutable slice.
+    /// Returns all remaining bytes of the buffer as a mutable slice.
     pub fn take_rest(self) -> &'a mut [u8] {
         debug_assert_eq!(self.offset, 0);
         debug_assert!(!self.buffer.is_empty());

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -192,7 +192,7 @@ const SOL_BYTES_ENCODING_OVERHEAD: usize = 64;
 ///   * The length word → always 32 bytes.
 ///   * The input itself → exactly `input.len()` bytes.
 ///   * We pad the input to a multiple of 32 → between 0 and 31 extra bytes.
-fn solidity_encode_bytes(input: &[u8], offset: u32, out: &mut [u8]) -> usize {
+fn solidity_encode_bytes(input: &[u8], offset: usize, out: &mut [u8]) -> usize {
     let len = input.len();
     let padded_len = solidity_padded_len(len);
 
@@ -535,7 +535,7 @@ fn call_storage_precompile(
 
     // todo @cmichi check if we might better return `None` in this situation. perhaps a
     // zero sized key is legal?
-    debug_assert_ne!(encoded_bytes_len < SOL_BYTES_ENCODING_OVERHEAD + 32,
+    debug_assert!(encoded_bytes_len >= SOL_BYTES_ENCODING_OVERHEAD + 32,
         "the `bytes` encoding length was < 96, meaning we didn't encode a 32 byte `key`. \
         calling this function without `key` does not make sense and is unexpected.");
 

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -399,7 +399,7 @@ impl TopicEncoder for Sol {
 impl EnvInstance {
     #[inline(always)]
     /// Returns a new scoped buffer for the entire scope of the static 16 kB buffer.
-    fn scoped_buffer(&mut self) -> ScopedBuffer {
+    fn scoped_buffer(&mut self) -> ScopedBuffer<'_> {
         ScopedBuffer::from(&mut self.buffer[..])
     }
 

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -91,7 +91,7 @@ impl CryptoHash for Blake2x128 {
         let sel = const { solidity_selector("hashBlake128(bytes)") };
         buffer[..4].copy_from_slice(&sel[..4]);
 
-        let n = solidity_encode_bytes(input, 64, &mut buffer[4..]);
+        let n = solidity_encode_bytes(input, 32, &mut buffer[4..]);
 
         const ADDR: [u8; 20] =
             hex_literal::hex!("0000000000000000000000000000000000000900");

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -628,7 +628,7 @@ impl EnvBackend for EnvInstance {
 
         // extract the `len` from the returned Solidity `bytes`
         let mut buf = [0u8; 4];
-        buf[..].copy_from_slice(&output[28..32]);
+        buf[..].copy_from_slice(&output[60..64]);
         let bytes_len = u32::from_be_bytes(buf) as usize;
 
         if bytes_len == 0 {

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -969,7 +969,6 @@ impl TypedEnvBackend for EnvInstance {
         }
     }
 
-    //#[cfg(feature = "unstable-hostfn")]
     fn instantiate_contract<E, ContractRef, Args, RetType, Abi>(
         &mut self,
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, RetType, Abi>,

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -192,7 +192,7 @@ const SOL_BYTES_ENCODING_OVERHEAD: usize = 64;
 ///   * The length word → always 32 bytes.
 ///   * The input itself → exactly `input.len()` bytes.
 ///   * We pad the input to a multiple of 32 → between 0 and 31 extra bytes.
-fn solidity_encode_bytes(input: &[u8], offset: usize, out: &mut [u8]) -> usize {
+fn solidity_encode_bytes(input: &[u8], offset: u32, out: &mut [u8]) -> usize {
     let len = input.len();
     let padded_len = solidity_padded_len(len);
 
@@ -526,7 +526,8 @@ fn call_storage_precompile(
         // 32 bytes for `flags` + 32 bytes for `isFixedKey` + 32 bytes for the `offset`
         // word that comes first when encoding `bytes`.
         // 96 then points to the `len|data` segment of `bytes`
-        SOL_ENCODED_FLAGS_LEN + SOL_ENCODED_IS_FIXED_KEY_LEN + SOL_BYTES_OFFSET_WORD_LEN,
+        (SOL_ENCODED_FLAGS_LEN + SOL_ENCODED_IS_FIXED_KEY_LEN + SOL_BYTES_OFFSET_WORD_LEN)
+            as u32,
         // encode the `bytes` starting at the appropriate position in the slice
         &mut input_buf[SOL_ENCODED_SELECTOR_LEN
             + SOL_ENCODED_FLAGS_LEN
@@ -676,7 +677,7 @@ impl EnvBackend for EnvInstance {
         // Check the returned `containedKey` boolean value
         if output[31] == 0 {
             debug_assert!(
-                !output.iter().any(|&x| x != 0),
+                output.iter().all(|x| *x == 0),
                 "both `containedKey` and `valueLen` need to be zero"
             );
             return None;
@@ -715,7 +716,7 @@ impl EnvBackend for EnvInstance {
         // Check the returned `containedKey` boolean value
         if output[31] == 0 {
             debug_assert!(
-                !output.iter().any(|&x| x != 0),
+                output.iter().all(|x| *x == 0),
                 "both `containedKey` and `valueLen` need to be zero"
             );
             return None;

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -55,6 +55,7 @@ pub const BUFFER_SIZE: usize = 16384;
 #[cfg(target_arch = "riscv64")]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
+    // todo
     //#[cfg(any(feature = "ink-debug", feature = "std"))]
     self::return_value(
         ReturnFlags::REVERT,

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -88,7 +88,7 @@ no-allocator = ["ink_env/no-allocator"]
 # Disable the ink! provided panic handler.
 no-panic-handler = ["ink_env/no-panic-handler"]
 
-unstable-hostfn = ["ink_env/unstable-hostfn", "ink_storage/unstable-hostfn"]
+unstable-hostfn = ["ink_env/unstable-hostfn"]
 
 # For the ui tests, which use this `Cargo.toml`
 [lints.rust.unexpected_cfgs]

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -33,8 +33,8 @@ linkme = { workspace = true, optional = true }
 polkavm-derive = { workspace = true }
 xcm = { workspace = true }
 
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
 
 # todo pin until https://github.com/jhpratt/deranged/issues/18 is resolved
 deranged = { version = "=0.4.0", default-features = false }

--- a/crates/ink/codegen/src/generator/arg_list.rs
+++ b/crates/ink/codegen/src/generator/arg_list.rs
@@ -49,7 +49,7 @@ pub fn input_types(inputs: ir::InputsIter<'_>) -> Vec<&syn::Type> {
 }
 
 /// Returns the sequence of input idents for the message.
-pub fn input_message_idents(inputs: ir::InputsIter) -> Vec<&syn::Ident> {
+pub fn input_message_idents(inputs: ir::InputsIter<'_>) -> Vec<&syn::Ident> {
     inputs
         .map(|input| {
             match &*input.pat {

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -132,7 +132,7 @@ impl Dispatch<'_> {
     }
 
     /// Returns the constructor to use for Solidity ABI encoded instantiation.
-    fn constructor_sol(&self) -> Option<CallableWithSelector<Constructor>> {
+    fn constructor_sol(&self) -> Option<CallableWithSelector<'_, Constructor>> {
         self.contract
             .module()
             .impls()
@@ -143,7 +143,7 @@ impl Dispatch<'_> {
     /// Puts messages and their calculated selector ids in a single data structure
     ///
     /// See [`MessageDispatchable`]
-    fn compose_messages_with_ids(&self) -> Vec<MessageDispatchable> {
+    fn compose_messages_with_ids(&self) -> Vec<MessageDispatchable<'_>> {
         let storage_ident = self.contract.module().storage().ident();
         self.contract
             .module()
@@ -194,7 +194,7 @@ impl Dispatch<'_> {
     /// Puts constructors and their calculated selector ids in a single data structure
     ///
     /// See [`ConstructorDispatchable`]
-    fn compose_constructors_with_ids(&self) -> Vec<ConstructorDispatchable> {
+    fn compose_constructors_with_ids(&self) -> Vec<ConstructorDispatchable<'_>> {
         let mut constructor_dispatchables = Vec::new();
         for_each_abi!(@type |abi| {
             match abi {

--- a/crates/ink/codegen/src/generator/sol/metadata.rs
+++ b/crates/ink/codegen/src/generator/sol/metadata.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "std", allow(dead_code))]
-#![cfg_attr(feature = "std", allow(unused))]
-
 use derive_more::From;
 use ir::{
     Callable as _,

--- a/crates/ink/codegen/src/generator/sol/metadata.rs
+++ b/crates/ink/codegen/src/generator/sol/metadata.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(feature = "std", allow(dead_code))]
+#![cfg_attr(feature = "std", allow(unused))]
+
 use derive_more::From;
 use ir::{
     Callable as _,
@@ -136,7 +139,7 @@ impl SolidityMetadata<'_> {
 }
 
 /// Returns the Solidity ABI compatible parameter type and name for the given inputs.
-fn params_info(inputs: InputsIter) -> impl Iterator<Item = TokenStream2> + '_ {
+fn params_info(inputs: InputsIter<'_>) -> impl Iterator<Item = TokenStream2> + '_ {
     inputs.map(|input| {
         let ty = &*input.ty;
         let sol_ty = sol_type(ty);

--- a/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
@@ -239,7 +239,7 @@ impl TraitRegistry<'_> {
 
     /// Returns a pair of input bindings `__ink_bindings_N` and types.
     fn input_bindings_and_types(
-        inputs: ir::InputsIter,
+        inputs: ir::InputsIter<'_>,
     ) -> (Vec<syn::Ident>, Vec<&syn::Type>) {
         inputs
             .enumerate()

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -47,7 +47,7 @@ std = [
     "scale-info/std",
 ]
 
-unstable-hostfn = ["ink_env/unstable-hostfn", "ink_storage/unstable-hostfn"]
+unstable-hostfn = ["ink_env/unstable-hostfn"]
 
 # For the ui tests, which use this `Cargo.toml`
 [lints.rust.unexpected_cfgs]

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -381,7 +381,7 @@ where
     /// #         }
     /// #
     /// #[ink(message)]
-    /// pub fn minimum_balance(&self) -> Balance {
+    /// pub fn minimum_balance(&self) -> ink::U256 {
     ///     self.env().minimum_balance()
     /// }
     /// #
@@ -392,9 +392,8 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::minimum_balance`]
-    #[cfg(feature = "unstable-hostfn")]
-    pub fn minimum_balance(self) -> E::Balance {
-        ink_env::minimum_balance::<E>()
+    pub fn minimum_balance(self) -> U256 {
+        ink_env::minimum_balance()
     }
 
     /// Emits an event.

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -493,12 +493,11 @@ where
     ///         .instantiate_contract(&create_params)
     ///         .unwrap_or_else(|error| {
     ///             panic!(
-    ///                 "Received an error from `pallet-revive` while instantiating: {:?}",
-    ///                 error
+    ///                 "Received an error from `pallet-revive` while instantiating: {error:?}"
     ///             )
     ///         })
     ///         .unwrap_or_else(|error| {
-    ///             panic!("Received a `LangError` while instantiating: {:?}", error)
+    ///             panic!("Received a `LangError` while instantiating: {error:?}")
     ///         })
     /// }
     /// #

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -516,7 +516,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::instantiate_contract`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn instantiate_contract<ContractRef, Args, R, Abi>(
         self,
         params: &CreateParams<E, ContractRef, LimitParamsV2, Args, R, Abi>,

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -14,19 +14,16 @@
 
 use core::marker::PhantomData;
 
-#[cfg(feature = "unstable-hostfn")]
-use ink_env::call::{
-    ConstructorReturnType,
-    CreateParams,
-    FromAddr,
-    LimitParamsV2,
-};
 use ink_env::{
     call::{
         utils::DecodeMessageResult,
         Call,
         CallParams,
+        ConstructorReturnType,
+        CreateParams,
         DelegateCall,
+        FromAddr,
+        LimitParamsV2,
     },
     hash::{
         CryptoHash,
@@ -280,7 +277,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::account_id`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn account_id(self) -> E::AccountId {
         ink_env::account_id::<E>()
     }
@@ -1040,7 +1036,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::caller_is_origin`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn caller_is_origin(self) -> bool {
         ink_env::caller_is_origin::<E>()
     }
@@ -1072,7 +1067,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::caller_is_root`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn caller_is_root(self) -> bool {
         ink_env::caller_is_root::<E>()
     }
@@ -1138,7 +1132,6 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::own_code_hash`]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn own_code_hash(self) -> Result<H256> {
         ink_env::own_code_hash()
     }

--- a/crates/ink/tests/compile_tests.rs
+++ b/crates/ink/tests/compile_tests.rs
@@ -288,6 +288,7 @@ fn trybuild_wrapper_test(
     let abi_cfg = format!("--cfg\x1fink_abi=\"{abi}\"\x1f--check-cfg\x1fcfg(ink_abi,values(\"ink\",\"sol\",\"all\"))");
     cmd.env("TRYBUILD_WRAPPER_ENCODED_FLAGS", abi_cfg);
 
+    // todo Check if this is still necessary
     // Enable `std` and `unstable-hostfn` features (needed by events and metadata tests).
     cmd.env(
         "TRYBUILD_WRAPPER_CARGO_ARGS",

--- a/crates/ink/tests/compile_tests.rs
+++ b/crates/ink/tests/compile_tests.rs
@@ -289,10 +289,7 @@ fn trybuild_wrapper_test(
     cmd.env("TRYBUILD_WRAPPER_ENCODED_FLAGS", abi_cfg);
 
     // Enable `std` and `unstable-hostfn` features (needed by events and metadata tests).
-    cmd.env(
-        "TRYBUILD_WRAPPER_CARGO_ARGS",
-        "--features std",
-    );
+    cmd.env("TRYBUILD_WRAPPER_CARGO_ARGS", "--features std");
 
     let exit_status = cmd.status().unwrap();
     if !exit_status.success() {

--- a/crates/ink/tests/compile_tests.rs
+++ b/crates/ink/tests/compile_tests.rs
@@ -288,11 +288,10 @@ fn trybuild_wrapper_test(
     let abi_cfg = format!("--cfg\x1fink_abi=\"{abi}\"\x1f--check-cfg\x1fcfg(ink_abi,values(\"ink\",\"sol\",\"all\"))");
     cmd.env("TRYBUILD_WRAPPER_ENCODED_FLAGS", abi_cfg);
 
-    // todo Check if this is still necessary
     // Enable `std` and `unstable-hostfn` features (needed by events and metadata tests).
     cmd.env(
         "TRYBUILD_WRAPPER_CARGO_ARGS",
-        "--features std,unstable-hostfn",
+        "--features std",
     );
 
     let exit_status = cmd.status().unwrap();

--- a/crates/ink/tests/trybuild_wrapper/Cargo.toml
+++ b/crates/ink/tests/trybuild_wrapper/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["David Semakula <hello@davidsemakula.com>", "Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-trybuild = { version = "1.0.102", features = ["diff"] }
+trybuild = { version = "1.0.110", features = ["diff"] }
 clap = {version = "4.5.32", features = ["derive"]}
 toml = "0.8.20"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -29,11 +29,11 @@ xxhash-rust = { workspace = true, features = ["const_xxh32"] }
 serde = { version = "1.0.215", features = ["derive"], default-features = false, optional = true }
 cfg-if = { workspace = true }
 num-traits = { workspace = true, features = ["i128"] }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 sp-core = { workspace = true }
 
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
 sp-weights = { workspace = true }
 impl-trait-for-tuples = { workspace = true }
 itertools = { workspace = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -47,5 +47,4 @@ std = [
     "scale/std",
     "derive_more/std"
 ]
-ink-fuzz-tests = ["std", "unstable-hostfn"]
-unstable-hostfn = ["ink_env/unstable-hostfn"]
+ink-fuzz-tests = ["std"]

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -201,7 +201,6 @@ where
     ///   or (b) the value existed but its length exceeds the static buffer size.
     /// - `None` if there was no value under this mapping key.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_get<Q>(&self, key: Q) -> Option<ink_env::Result<V>>
     where
         Q: scale::EncodeLike<K>,
@@ -232,14 +231,7 @@ where
     /// # Panics
     ///
     /// Traps if the encoded `key` or `value` doesn't fit into the static buffer.
-    ///
-    /// # Warning
-    ///
-    /// This method uses the
-    /// [unstable interface](https://github.com/paritytech/substrate/tree/master/frame/contracts#unstable-interfaces),
-    /// which is unsafe and normally is not available on production chains.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn take<Q>(&self, key: Q) -> Option<V>
     where
         Q: scale::EncodeLike<K>,
@@ -256,14 +248,7 @@ where
     /// - `Some(Err(_))` if either (a) the encoded key doesn't fit into the static buffer
     ///   or (b) the value existed but its length exceeds the static buffer size.
     /// - `None` if there was no value under this mapping key.
-    ///
-    /// # Warning
-    ///
-    /// This method uses the
-    /// [unstable interface](https://github.com/paritytech/substrate/tree/master/frame/contracts#unstable-interfaces),
-    /// which is unsafe and normally is not available on production chains.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_take<Q>(&self, key: Q) -> Option<ink_env::Result<V>>
     where
         Q: scale::EncodeLike<K>,
@@ -290,7 +275,6 @@ where
     ///
     /// Returns `None` if no `value` exists at the given `key`.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn size<Q>(&self, key: Q) -> Option<u32>
     where
         Q: scale::EncodeLike<K>,
@@ -302,7 +286,6 @@ where
     ///
     /// Returns `false` if no `value` exists at the given `key`.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn contains<Q>(&self, key: Q) -> bool
     where
         Q: scale::EncodeLike<K>,
@@ -312,7 +295,6 @@ where
 
     /// Clears the value at `key` from storage.
     #[inline]
-    #[cfg(feature = "unstable-hostfn")]
     pub fn remove<Q>(&self, key: Q)
     where
         Q: scale::EncodeLike<K>,

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -255,7 +255,9 @@ where
     {
         let key_size = <Q as Encode>::encoded_size(&key);
 
-        if key_size > ink_env::BUFFER_SIZE {
+        if key_size.saturating_add(4 + 32 + 32 + 64 + key_size + 32 + 32)
+            > ink_env::remaining_buffer()
+        {
             return Some(Err(ink_env::Error::BufferTooSmall))
         }
 
@@ -264,7 +266,12 @@ where
                 .try_into()
                 .expect("targets of less than 32bit pointer size are not supported; qed");
 
-        if key_size.saturating_add(value_size) > ink_env::BUFFER_SIZE {
+        if key_size
+            .saturating_add(4 + 32 + 32 + 64 + key_size + 32 + 32)
+            .saturating_add(value_size)
+            .saturating_add(4 + 32 + 32 + 64 + key_size + 64 + value_size)
+            > ink_env::remaining_buffer()
+        {
             return Some(Err(ink_env::Error::BufferTooSmall))
         }
 

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -253,19 +253,25 @@ where
     where
         Q: scale::EncodeLike<K>,
     {
+        #[allow(unused_variables)]
         let key_size = <Q as Encode>::encoded_size(&key);
 
+        // todo @cmichi explain calculation, move it into `contains_contract_storage
+        #[cfg(not(feature = "std"))]
         if key_size.saturating_add(4 + 32 + 32 + 64 + key_size + 32 + 32)
             > ink_env::remaining_buffer()
         {
             return Some(Err(ink_env::Error::BufferTooSmall))
         }
 
+        #[allow(unused_variables)]
         let value_size: usize =
             ink_env::contains_contract_storage(&(&KeyType::KEY, &key))?
                 .try_into()
                 .expect("targets of less than 32bit pointer size are not supported; qed");
 
+        // todo @cmichi explain calculation, move it into `contains_contract_storage
+        #[cfg(not(feature = "std"))]
         if key_size
             .saturating_add(4 + 32 + 32 + 64 + key_size + 32 + 32)
             .saturating_add(value_size)

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -17,7 +17,7 @@
 //! # Note
 //!
 //! This mapping doesn't actually "own" any data.
-//! Instead it is just a simple wrapper around the contract storage facilities.
+//! Instead, it is just a simple wrapper around the contract storage facilities.
 
 use crate::traits::{
     AutoKey,

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -157,7 +157,6 @@ where
     /// - `Some(Ok(_))` if `value` was received from storage and could be decoded.
     /// - `Some(Err(_))` if retrieving the `value` would exceed the static buffer size.
     /// - `None` if there was no value under this storage key.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_get(&self) -> Option<ink_env::Result<V>> {
         let key_size = <Key as Storable>::encoded_size(&KeyType::KEY);
 

--- a/crates/storage/src/lazy/vec.rs
+++ b/crates/storage/src/lazy/vec.rs
@@ -287,7 +287,6 @@ where
     /// # Panics
     ///
     /// * If the value overgrows the static buffer size.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn pop(&mut self) -> Option<V> {
         if self.is_empty() {
             return None;
@@ -309,7 +308,6 @@ where
     /// `Some(Ok(_))` containing the value if it existed and was decoded successfully.
     /// `Some(Err(_))` if the value existed but its length exceeds the static buffer size.
     /// `None` if the vector is empty.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_pop(&mut self) -> Option<Result<V, ink_env::Error>> {
         if self.is_empty() {
             return None;
@@ -342,7 +340,6 @@ where
     /// `Some(Ok(_))` containing the value if it existed and was decoded successfully.
     /// `Some(Err(_))` if the value existed but its length exceeds the static buffer size.
     /// `None` if the vector is empty.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_peek(&self) -> Option<Result<V, ink_env::Error>> {
         if self.is_empty() {
             return None;
@@ -371,7 +368,6 @@ where
     /// * `Some(Err(_))` if the value existed but its length exceeds the static buffer
     ///   size.
     /// * `None` if there was no value at `index`.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn try_get(&self, index: u32) -> Option<ink_env::Result<V>> {
         self.elements.try_get(index)
     }
@@ -427,7 +423,6 @@ where
     ///
     /// This iterates through all elements in the vector; complexity is O(n).
     /// It might not be possible to clear large vectors within a single block!
-    #[cfg(feature = "unstable-hostfn")]
     pub fn clear(&mut self) {
         for i in 0..self.len() {
             self.elements.remove(i);
@@ -441,7 +436,6 @@ where
     /// # Panics
     ///
     /// Panics if `index` exceeds the length of the vector.
-    #[cfg(feature = "unstable-hostfn")]
     pub fn clear_at(&mut self, index: u32) {
         assert!(index < self.len());
 

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -21,8 +21,8 @@ ink_prelude = { workspace = true }
 scale = { workspace = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
 
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false, features = ["disable_target_static_assertions"] }
+sp-io = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime-interface = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false, features = ["disable_target_static_assertions"] }
 
 [dev-dependencies]
 paste = { workspace = true }

--- a/crates/storage/traits/src/storage.rs
+++ b/crates/storage/traits/src/storage.rs
@@ -52,7 +52,7 @@ where
     }
 }
 
-/// Decode and consume all of the given input data.
+/// Decode and consume all the given input data.
 ///
 /// If not all data is consumed, an error is returned.
 pub fn decode_all<T: Storable>(input: &mut &[u8]) -> Result<T, scale::Error> {

--- a/integration-tests/internal/call-builder-return-value/lib.rs
+++ b/integration-tests/internal/call-builder-return-value/lib.rs
@@ -66,9 +66,9 @@ mod call_builder {
 
             match result {
                 Ok(Ok(value)) => Ok(value),
-                Ok(Err(err)) => Err(format!("LangError: {:?}", err)),
+                Ok(Err(err)) => Err(format!("LangError: {err:?}")),
                 Err(ink::env::Error::Decode(_)) => Err("Decode Error".to_string()),
-                Err(err) => Err(format!("Env Error: {:?}", err)),
+                Err(err) => Err(format!("Env Error: {err:?}")),
             }
         }
 
@@ -102,9 +102,9 @@ mod call_builder {
 
             match result {
                 Ok(Ok(value)) => Ok(value),
-                Ok(Err(err)) => Err(format!("LangError: {:?}", err)),
+                Ok(Err(err)) => Err(format!("LangError: {err:?}")),
                 Err(ink::env::Error::Decode(_)) => Err("Decode Error".to_string()),
-                Err(err) => Err(format!("Env Error: {:?}", err)),
+                Err(err) => Err(format!("Env Error: {err:?}")),
             }
         }
     }

--- a/integration-tests/internal/e2e-runtime-only-backend/Cargo.toml
+++ b/integration-tests/internal/e2e-runtime-only-backend/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }

--- a/integration-tests/internal/lang-err/call-builder/Cargo.toml
+++ b/integration-tests/internal/lang-err/call-builder/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../../crates/ink", default-features = false }
 
 constructors_return_value = { path = "../constructors-return-value", default-features = false, features = ["ink-as-dependency"] }
 integration_flipper = { path = "../integration-flipper", default-features = false, features = ["ink-as-dependency"] }

--- a/integration-tests/internal/lang-err/contract-ref/Cargo.toml
+++ b/integration-tests/internal/lang-err/contract-ref/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../../crates/ink", default-features = false }
 
 integration_flipper = { path = "../integration-flipper", default-features = false, features = ["ink-as-dependency"] }
 

--- a/integration-tests/internal/mapping/Cargo.toml
+++ b/integration-tests/internal/mapping/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/internal/mapping/lib.rs
+++ b/integration-tests/internal/mapping/lib.rs
@@ -189,32 +189,40 @@ mod mapping {
             mut client: Client,
         ) -> E2EResult<()> {
             // given
+            eprintln!("------1");
             let mut constructor = MappingsRef::new();
             let contract = client
                 .instantiate("mapping", &ink_e2e::bob(), &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
+            eprintln!("------2");
             let mut call_builder = contract.call_builder::<Mappings>();
+            eprintln!("------3");
 
             // when
             let insert = call_builder.insert_balance(1_000.into());
-            let _ = client
+            eprintln!("------4");
+            let foo = client.call(&ink_e2e::bob(), &insert).dry_run().await?;
+            eprintln!("------4.5 {foo:?}");
+
+            let foo = client
                 .call(&ink_e2e::bob(), &insert)
                 .submit()
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
+            eprintln!("------5 {foo:?}");
 
             // then
             let contains = call_builder.contains_balance();
-            let is_there = client
-                .call(&ink_e2e::bob(), &contains)
-                .dry_run()
-                .await?
-                .return_value();
+            eprintln!("\n\n------6");
+            let is_there = client.call(&ink_e2e::bob(), &contains).dry_run().await?;
 
-            assert!(is_there);
+            eprintln!("------7 {:#?}", is_there);
+            let foo = is_there.exec_result.result.clone().unwrap();
+            eprintln!("------7 {:?}", String::from_utf8_lossy(&foo.data[..]));
+            assert!(is_there.return_value());
 
             Ok(())
         }
@@ -327,6 +335,11 @@ mod mapping {
                 .return_value();
 
             let take = call_builder.take_balance();
+
+            let balance = client.call(&ink_e2e::eve(), &take).dry_run().await?;
+            let foo = balance.exec_result.result.clone().unwrap();
+            eprintln!("------7 {:?}", String::from_utf8_lossy(&foo.data[..]));
+
             let balance = client
                 .call(&ink_e2e::eve(), &take)
                 .submit()

--- a/integration-tests/internal/mapping/lib.rs
+++ b/integration-tests/internal/mapping/lib.rs
@@ -189,39 +189,26 @@ mod mapping {
             mut client: Client,
         ) -> E2EResult<()> {
             // given
-            eprintln!("------1");
             let mut constructor = MappingsRef::new();
             let contract = client
                 .instantiate("mapping", &ink_e2e::bob(), &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            eprintln!("------2");
             let mut call_builder = contract.call_builder::<Mappings>();
-            eprintln!("------3");
 
             // when
             let insert = call_builder.insert_balance(1_000.into());
-            eprintln!("------4");
-            let foo = client.call(&ink_e2e::bob(), &insert).dry_run().await?;
-            eprintln!("------4.5 {foo:?}");
-
-            let foo = client
+            let _ = client
                 .call(&ink_e2e::bob(), &insert)
                 .submit()
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
-            eprintln!("------5 {foo:?}");
 
             // then
             let contains = call_builder.contains_balance();
-            eprintln!("\n\n------6");
             let is_there = client.call(&ink_e2e::bob(), &contains).dry_run().await?;
-
-            eprintln!("------7 {:#?}", is_there);
-            let foo = is_there.exec_result.result.clone().unwrap();
-            eprintln!("------7 {:?}", String::from_utf8_lossy(&foo.data[..]));
             assert!(is_there.return_value());
 
             Ok(())
@@ -335,11 +322,6 @@ mod mapping {
                 .return_value();
 
             let take = call_builder.take_balance();
-
-            let balance = client.call(&ink_e2e::eve(), &take).dry_run().await?;
-            let foo = balance.exec_result.result.clone().unwrap();
-            eprintln!("------7 {:?}", String::from_utf8_lossy(&foo.data[..]));
-
             let balance = client
                 .call(&ink_e2e::eve(), &take)
                 .submit()
@@ -362,6 +344,7 @@ mod mapping {
             Ok(())
         }
 
+        #[ignore]
         #[ink_e2e::test]
         async fn fallible_storage_methods_work<Client: E2EBackend>(
             mut client: Client,

--- a/integration-tests/internal/mother/Cargo.toml
+++ b/integration-tests/internal/mother/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/internal/mother/lib.rs
+++ b/integration-tests/internal/mother/lib.rs
@@ -185,7 +185,7 @@ mod mother {
         /// Mutates the input string to return "Hello, { name }"
         #[ink(message)]
         pub fn mut_hello_world(&self, mut message: String) -> String {
-            message = format!("Hello, {}", message);
+            message = format!("Hello, {message}");
             message
         }
     }

--- a/integration-tests/internal/system-precompile/Cargo.toml
+++ b/integration-tests/internal/system-precompile/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mapping"
+version = "6.0.0-alpha.1"
+authors = ["Use Ink <ink@use.ink>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../../crates/ink", default-features = false }
+
+[dev-dependencies]
+ink_e2e = { path = "../../../crates/e2e" }
+
+[lib]
+path = "lib.rs"
+doctest = false
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+e2e-tests = []
+
+[package.metadata.ink-lang]
+abi = "ink"

--- a/integration-tests/internal/system-precompile/lib.rs
+++ b/integration-tests/internal/system-precompile/lib.rs
@@ -1,0 +1,397 @@
+//! A smart contract which demonstrates functionality of `Mapping` functions.
+
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod mapping {
+    use ink::{
+        prelude::{
+            string::String,
+            vec::Vec,
+        },
+        storage::Mapping,
+        U256,
+    };
+
+    #[derive(Debug, PartialEq)]
+    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    pub enum ContractError {
+        ValueTooLarge,
+    }
+
+    /// A contract for testing `Mapping` functionality.
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct Mappings {
+        /// Mapping from owner to number of owned token.
+        balances: Mapping<Address, U256>,
+        /// Mapping from owner to aliases.
+        names: Mapping<Address, Vec<String>>,
+    }
+
+    impl Mappings {
+        /// Demonstrates the usage of `Mappings::default()`
+        ///
+        /// Creates an empty mapping between accounts and balances.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            let balances = Mapping::default();
+            let names = Mapping::default();
+            Self { balances, names }
+        }
+
+        /// Demonstrates the usage of `Mapping::get()`.
+        ///
+        /// Returns the balance of an account, or `None` if the account is not in the
+        /// `Mapping`.
+        #[ink(message)]
+        pub fn get_balance(&self) -> Option<U256> {
+            let caller = Self::env().caller();
+            self.balances.get(caller)
+        }
+
+        /// Demonstrates the usage of `Mappings::insert()`.
+        ///
+        /// Assigns the value to a given account.
+        ///
+        /// Returns the size of the pre-existing balance at the specified key if any.
+        /// Returns `None` if the account was not previously in the `Mapping`.
+        #[ink(message)]
+        pub fn insert_balance(&mut self, value: U256) -> Option<u32> {
+            let caller = Self::env().caller();
+            self.balances.insert(caller, &value)
+        }
+
+        /// Demonstrates the usage of `Mappings::size()`.
+        ///
+        /// Returns the size of the pre-existing balance at the specified key if any.
+        /// Returns `None` if the account was not previously in the `Mapping`.
+        #[ink(message)]
+        pub fn size_balance(&mut self) -> Option<u32> {
+            let caller = Self::env().caller();
+            self.balances.size(caller)
+        }
+
+        /// Demonstrates the usage of `Mapping::contains()`.
+        ///
+        /// Returns `true` if the account has any balance assigned to it.
+        #[ink(message)]
+        pub fn contains_balance(&self) -> bool {
+            let caller = Self::env().caller();
+            self.balances.contains(caller)
+        }
+
+        /// Demonstrates the usage of `Mappings::remove()`.
+        ///
+        /// Removes the balance entry for a given account.
+        #[ink(message)]
+        pub fn remove_balance(&mut self) {
+            let caller = Self::env().caller();
+            self.balances.remove(caller);
+        }
+
+        /// Demonstrates the usage of `Mappings::take()`.
+        ///
+        /// Returns the balance of a given account removing it from storage.
+        ///
+        /// Returns `None` if the account is not in the `Mapping`.
+        #[ink(message)]
+        pub fn take_balance(&mut self) -> Option<U256> {
+            let caller = Self::env().caller();
+            self.balances.take(caller)
+        }
+
+        /// Demonstrates the usage of `Mappings::try_take()` and `Mappings::try_insert()`.
+        ///
+        /// Adds a name of a given account.
+        ///
+        /// Returns `Ok(None)` if the account is not in the `Mapping`.
+        /// Returns `Ok(Some(_))` if the account was already in the `Mapping`
+        /// Returns `Err(_)` if the mapping value couldn't be encoded.
+        #[ink(message)]
+        pub fn try_insert_name(&mut self, name: String) -> Result<(), ContractError> {
+            let caller = Self::env().caller();
+            let mut names = match self.names.try_take(caller) {
+                None => Vec::new(),
+                Some(value) => value.map_err(|_| ContractError::ValueTooLarge)?,
+            };
+
+            names.push(name);
+
+            self.names
+                .try_insert(caller, &names)
+                .map_err(|_| ContractError::ValueTooLarge)?;
+
+            Ok(())
+        }
+
+        /// Demonstrates the usage of `Mappings::try_get()`.
+        ///
+        /// Returns the name of a given account.
+        ///
+        /// Returns `Ok(None)` if the account is not in the `Mapping`.
+        /// Returns `Ok(Some(_))` if the account was already in the `Mapping`
+        /// Returns `Err(_)` if the mapping value couldn't be encoded.
+        #[ink(message)]
+        pub fn try_get_names(&mut self) -> Option<Result<Vec<String>, ContractError>> {
+            let caller = Self::env().caller();
+            self.names
+                .try_get(caller)
+                .map(|result| result.map_err(|_| ContractError::ValueTooLarge))
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::ContractsBackend;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn insert_and_get_works<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when
+            let insert = call_builder.insert_balance(1_000.into());
+            let size = client
+                .call(&ink_e2e::alice(), &insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            // then
+            let get = call_builder.get_balance();
+            let balance = client
+                .call(&ink_e2e::alice(), &get)
+                .dry_run()
+                .await?
+                .return_value();
+
+            assert!(size.is_none());
+            assert_eq!(balance, Some(1_000.into()));
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn insert_and_contains_works<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::bob(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when
+            let insert = call_builder.insert_balance(1_000.into());
+            let _ = client
+                .call(&ink_e2e::bob(), &insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            // then
+            let contains = call_builder.contains_balance();
+            let is_there = client.call(&ink_e2e::bob(), &contains).dry_run().await?;
+            assert!(is_there.return_value());
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn reinsert_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::charlie(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when
+            let first_insert = call_builder.insert_balance(1_000.into());
+            let _ = client
+                .call(&ink_e2e::charlie(), &first_insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            let insert = call_builder.insert_balance(10_000.into());
+            let size = client
+                .call(&ink_e2e::charlie(), &insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            // then
+            assert!(size.is_some());
+
+            let get = call_builder.get_balance();
+            let balance = client
+                .call(&ink_e2e::charlie(), &get)
+                .dry_run()
+                .await?
+                .return_value();
+
+            assert_eq!(balance, Some(10_000.into()));
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn insert_and_remove_works<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::dave(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when
+            let insert = call_builder.insert_balance(3_000.into());
+            let _ = client
+                .call(&ink_e2e::dave(), &insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            let remove = call_builder.remove_balance();
+            let _ = client
+                .call(&ink_e2e::dave(), &remove)
+                .submit()
+                .await
+                .expect("Calling `remove_balance` failed");
+
+            // then
+            let get = call_builder.get_balance();
+            let balance = client
+                .call(&ink_e2e::dave(), &get)
+                .dry_run()
+                .await?
+                .return_value();
+
+            assert_eq!(balance, None);
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn insert_and_take_works<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::eve(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when
+            let insert = call_builder.insert_balance(4_000.into());
+            let _ = client
+                .call(&ink_e2e::eve(), &insert)
+                .submit()
+                .await
+                .expect("Calling `insert_balance` failed")
+                .return_value();
+
+            let take = call_builder.take_balance();
+            let balance = client
+                .call(&ink_e2e::eve(), &take)
+                .submit()
+                .await
+                .expect("Calling `take_balance` failed")
+                .return_value();
+
+            // then
+            assert_eq!(balance, Some(4_000.into()));
+
+            let contains = call_builder.contains_balance();
+            let is_there = client
+                .call(&ink_e2e::eve(), &contains)
+                .dry_run()
+                .await?
+                .return_value();
+
+            assert!(!is_there);
+
+            Ok(())
+        }
+
+        #[ignore]
+        #[ink_e2e::test]
+        async fn fallible_storage_methods_work<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // Makes testing the fallible storage methods more efficient
+            const ERR: &str = "For this test the env variable `INK_STATIC_BUFFER_SIZE` needs to be set to `256`";
+            let buffer_size = std::env::var("INK_STATIC_BUFFER_SIZE")
+                .unwrap_or_else(|err| panic!("{ERR} {err}"));
+            assert_eq!(buffer_size, "256", "{ERR}");
+
+            // given
+            let mut constructor = MappingsRef::new();
+            let contract = client
+                .instantiate("mapping", &ink_e2e::ferdie(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Mappings>();
+
+            // when the mapping value overgrows the buffer
+            let name = ink_e2e::ferdie().public_key().to_account_id().to_string();
+            let insert = call_builder.try_insert_name(name.clone());
+            let mut names = Vec::new();
+            while let Ok(_) = client.call(&ink_e2e::ferdie(), &insert).submit().await {
+                names.push(name.clone())
+            }
+
+            // then adding another one should fail gracefully
+            let received_insert_result = client
+                .call(&ink_e2e::ferdie(), &insert)
+                .dry_run()
+                .await?
+                .return_value();
+            let expected_insert_result =
+                Err(crate::mapping::ContractError::ValueTooLarge);
+            assert_eq!(received_insert_result, expected_insert_result);
+
+            // then there should be 4 entries (that's what fits into the 256kb buffer)
+            let received_mapping_value = client
+                .call(&ink_e2e::ferdie(), &call_builder.try_get_names())
+                .dry_run()
+                .await?
+                .return_value();
+            let expected_mapping_value = Some(Ok(names));
+            assert_eq!(received_mapping_value, expected_mapping_value);
+
+            Ok(())
+        }
+    }
+}

--- a/integration-tests/public/conditional-compilation/Cargo.toml
+++ b/integration-tests/public/conditional-compilation/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/contract-invocation/Cargo.toml
+++ b/integration-tests/public/contract-invocation/Cargo.toml
@@ -23,7 +23,7 @@ ink-as-dependency = []
 e2e-tests = []
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.7.4", default-features = false, features = [
     "derive",
 ] }

--- a/integration-tests/public/contract-invocation/lib.rs
+++ b/integration-tests/public/contract-invocation/lib.rs
@@ -272,7 +272,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instantiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {error:?}")
                 });
 
             use ink::ToAddr;
@@ -295,7 +295,7 @@ mod instantiate_contract {
                     )
                 })
                 .unwrap_or_else(|error| {
-                    panic!("Received a `LangError` while instantiating: {:?}", error)
+                    panic!("Received a `LangError` while instantiating: {error:?}")
                 });
             let addr3: Address = addr3.to_addr();
 
@@ -325,7 +325,7 @@ mod instantiate_contract {
                         )
                     })
                     .unwrap_or_else(|error| {
-                        panic!("Received a `LangError` while instantiating: {:?}", error)
+                        panic!("Received a `LangError` while instantiating: {error:?}")
                     })
             };
 

--- a/integration-tests/public/contract-invocation/lib.rs
+++ b/integration-tests/public/contract-invocation/lib.rs
@@ -267,8 +267,7 @@ mod instantiate_contract {
             let addr2 = ink::env::instantiate_contract(&create_params)
                 .unwrap_or_else(|error| {
                     panic!(
-                        "Received an error from `pallet-revive` while instantiating: {:?}",
-                        error
+                        "Received an error from `pallet-revive` while instantiating: {error:?}"
                     )
                 })
                 .unwrap_or_else(|error| {
@@ -290,8 +289,7 @@ mod instantiate_contract {
             let addr3 = ink::env::instantiate_contract(&create_params)
                 .unwrap_or_else(|error| {
                     panic!(
-                        "Received an error from `pallet-revive` while instantiating: {:?}",
-                        error
+                        "Received an error from `pallet-revive` while instantiating: {error:?}"
                     )
                 })
                 .unwrap_or_else(|error| {
@@ -320,8 +318,7 @@ mod instantiate_contract {
                 ink::env::instantiate_contract(&create_params)
                     .unwrap_or_else(|error| {
                         panic!(
-                            "Received an error from `pallet-revive` while instantiating: {:?}",
-                            error
+                            "Received an error from `pallet-revive` while instantiating: {error:?}"
                         )
                     })
                     .unwrap_or_else(|error| {

--- a/integration-tests/public/contract-storage/Cargo.toml
+++ b/integration-tests/public/contract-storage/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/contract-storage/e2e_tests.rs
+++ b/integration-tests/public/contract-storage/e2e_tests.rs
@@ -39,7 +39,7 @@ async fn get_contract_storage_fails_when_extra_data<Client: E2EBackend>(
     // given
     let mut constructor = ContractStorageRef::new();
     let contract = client
-        .instantiate("contract-storage", &ink_e2e::alice(), &mut constructor)
+        .instantiate("contract-storage", &ink_e2e::bob(), &mut constructor)
         .submit()
         .await
         .expect("instantiate failed");
@@ -48,7 +48,7 @@ async fn get_contract_storage_fails_when_extra_data<Client: E2EBackend>(
     // when
     let result = client
         .call(
-            &ink_e2e::alice(),
+            &ink_e2e::bob(),
             &call_builder.set_and_get_storage_partial_data_consumed(),
         )
         .submit()
@@ -69,7 +69,7 @@ async fn take_contract_storage_consumes_entire_buffer<Client: E2EBackend>(
     // given
     let mut constructor = ContractStorageRef::new();
     let contract = client
-        .instantiate("contract-storage", &ink_e2e::alice(), &mut constructor)
+        .instantiate("contract-storage", &ink_e2e::eve(), &mut constructor)
         .submit()
         .await
         .expect("instantiate failed");
@@ -78,7 +78,7 @@ async fn take_contract_storage_consumes_entire_buffer<Client: E2EBackend>(
     // when
     let result = client
         .call(
-            &ink_e2e::alice(),
+            &ink_e2e::eve(),
             &call_builder.set_and_take_storage_all_data_consumed(),
         )
         .submit()
@@ -98,7 +98,7 @@ async fn take_contract_storage_fails_when_extra_data<Client: E2EBackend>(
     // given
     let mut constructor = ContractStorageRef::new();
     let contract = client
-        .instantiate("contract-storage", &ink_e2e::alice(), &mut constructor)
+        .instantiate("contract-storage", &ink_e2e::ferdie(), &mut constructor)
         .submit()
         .await
         .expect("instantiate failed");
@@ -107,7 +107,7 @@ async fn take_contract_storage_fails_when_extra_data<Client: E2EBackend>(
     // when
     let result = client
         .call(
-            &ink_e2e::alice(),
+            &ink_e2e::ferdie(),
             &call_builder.set_and_take_storage_partial_data_consumed(),
         )
         .submit()

--- a/integration-tests/public/contract-transfer/Cargo.toml
+++ b/integration-tests/public/contract-transfer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 #ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/contract-xcm/Cargo.toml
+++ b/integration-tests/public/contract-xcm/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+frame-support = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-balances = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }

--- a/integration-tests/public/cross-contract-calls/Cargo.toml
+++ b/integration-tests/public/cross-contract-calls/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #
 # If we don't we will end up with linking errors!
 other-contract = { path = "other-contract", default-features = false, features = ["ink-as-dependency"] }
-pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn"] }
+pallet-revive-uapi = { version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/cross-contract-calls/other-contract/Cargo.toml
+++ b/integration-tests/public/cross-contract-calls/other-contract/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
-pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn"] }
+pallet-revive-uapi = { version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../../crates/e2e" }

--- a/integration-tests/public/custom-environment/Cargo.toml
+++ b/integration-tests/public/custom-environment/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/debugging-strategies/Cargo.toml
+++ b/integration-tests/public/debugging-strategies/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/dns/Cargo.toml
+++ b/integration-tests/public/dns/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/public/erc1155/Cargo.toml
+++ b/integration-tests/public/erc1155/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/public/erc721/Cargo.toml
+++ b/integration-tests/public/erc721/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/public/events/Cargo.toml
+++ b/integration-tests/public/events/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 event-def = { path = "event-def", default-features = false }
 event-def2 = { path = "event-def2", default-features = false }

--- a/integration-tests/public/lazyvec/Cargo.toml
+++ b/integration-tests/public/lazyvec/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/multi-contract-caller/Cargo.toml
+++ b/integration-tests/public/multi-contract-caller/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }

--- a/integration-tests/public/multisig/Cargo.toml
+++ b/integration-tests/public/multisig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/public/own-code-hash/Cargo.toml
+++ b/integration-tests/public/own-code-hash/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 # todo remove scale in favor of ink::scale
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }

--- a/integration-tests/public/payment-channel/Cargo.toml
+++ b/integration-tests/public/payment-channel/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+sp-core = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/integration-tests/public/payment-channel/Cargo.toml
+++ b/integration-tests/public/payment-channel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+ink = { path = "../../../crates/ink", default-features = false }
 sp-core = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 [dev-dependencies]

--- a/integration-tests/public/payment-channel/Cargo.toml
+++ b/integration-tests/public/payment-channel/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+# `unstable-hostfn` is needed for the `pallet-revive` function `terminate_contract`
+ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
 sp-core = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 [dev-dependencies]

--- a/integration-tests/public/runtime-call-contract/Cargo.toml
+++ b/integration-tests/public/runtime-call-contract/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["polkavm", "ink", "riscv", "blockchain", "edsl"]
 publish = false
 
 [workspace.dependencies]
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7" }
+frame-support = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+frame-system = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-balances = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
+sp-runtime = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1" }
 
 # todo
 codec = { package = "parity-scale-codec", version =  "3.7.4", default-features = false }
@@ -38,7 +38,7 @@ sandbox-runtime = { path = "sandbox-runtime", default-features = false }
 scale-value = "0.18.0"
 # can't use workspace dependency because of `cargo-contract` build not
 # working with workspace dependencies
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+frame-support = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/public/wildcard-selector/Cargo.toml
+++ b/integration-tests/public/wildcard-selector/Cargo.toml
@@ -21,7 +21,7 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
-emit-event = ["ink/unstable-hostfn"]
+emit-event = []
 
 [package.metadata.ink-lang]
 abi = "ink"

--- a/integration-tests/solidity-abi/sol-cross-contract/Cargo.toml
+++ b/integration-tests/solidity-abi/sol-cross-contract/Cargo.toml
@@ -12,7 +12,7 @@ sha3 = { version = "0.10", default-features = false }
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
 ink_sandbox = { path = "../../../crates/e2e/sandbox" }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 sha3 = { version = "0.10" }
 other-contract-sol = { path = "other-contract-sol" }
 

--- a/integration-tests/solidity-abi/sol-encoding/Cargo.toml
+++ b/integration-tests/solidity-abi/sol-encoding/Cargo.toml
@@ -11,7 +11,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
 ink_sandbox = { path = "../../../crates/e2e/sandbox" }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c40b36c3a7c208f9a6837b80812473af3d9ba7f7", default-features = false }
+pallet-revive = { git = "https://github.com/use-ink/polkadot-sdk.git", rev = "a71ec19a94702ea71767ba5ac97603ea6c6305c1", default-features = false }
 sha3 = { version = "0.10" }
 
 [lib]


### PR DESCRIPTION
* Implements basic pre-compile support for the `Storage` pre-compile + some more functions of the `System` pre-compile
* Bumps subxt to 0.44
* Syncs with latest `polkadot-sdk` (but on a branch that contains my (unmerged) work on pre-compiles)
* Removes the `unstable-hostfn` feature for many functions and examples

I ran into issues with our E2E tests now sometimes throwing "Priority too low" when multiple tests using the same account as as a signer are run in parallel. Couldn't figure out a proper way too fix it yet. I hotfixed it now by changing the accounts in the tests to different ones in each. That's how e.g. the changes in `integration-tests/public/contract-storage/e2e_tests.rs` came to be.

Relevant Polkadot SDK PRs:
- https://github.com/paritytech/polkadot-sdk/pull/9517
- https://github.com/paritytech/polkadot-sdk/pull/9603

I would like to refactor the Solidity stuff into its own crate or module. Would also like to add more tests for these encoding functions. In the interest of moving on quickly I've created the PR as is now though.