### PR TITLE
Misc improvements around E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.5",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -248,7 +248,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -294,12 +294,6 @@ dependencies = [
  "alloy-sol-macro",
  "serde",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -1471,15 +1465,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1678,7 +1671,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "contract-build"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#d844358fc1a5e289be71ca105d718a7aba3f3c52"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#db7ade0e3e72338fc1e8c5b29b3cc8a530211c46"
 dependencies = [
  "alloy-json-abi",
  "anyhow",
@@ -1720,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "contract-metadata"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#d844358fc1a5e289be71ca105d718a7aba3f3c52"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#db7ade0e3e72338fc1e8c5b29b3cc8a530211c46"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -2348,12 +2341,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2853,7 +2846,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2915,7 +2908,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3415,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -3532,6 +3525,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.106",
  "temp-env",
+ "tracing",
  "tracing-subscriber 0.3.20",
 ]
 
@@ -3650,6 +3644,24 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "ink_metadata"
+version = "6.0.0-alpha.1"
+source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
+dependencies = [
+ "derive_more 2.0.1",
+ "impl-serde",
+ "ink_prelude 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
+ "ink_primitives 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
+ "parity-scale-codec",
+ "scale-info",
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
+>>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
 name = "ink_prelude"
 version = "6.0.0-alpha.1"
 source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
@@ -3659,7 +3671,12 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
+<<<<<<< HEAD
 version = "6.0.0-alpha.3"
+=======
+version = "6.0.0-alpha.1"
+source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
+>>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
 dependencies = [
  "cfg-if",
 ]
@@ -3694,7 +3711,12 @@ dependencies = [
 
 [[package]]
 name = "ink_primitives"
+<<<<<<< HEAD
 version = "6.0.0-alpha.3"
+=======
+version = "6.0.0-alpha.1"
+source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
+>>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
 dependencies = [
  "alloy-sol-types",
  "cfg-if",
@@ -3738,6 +3760,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4166,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -5834,15 +5857,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6114,11 +6137,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6328,9 +6351,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation",
@@ -6341,9 +6364,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6443,7 +6466,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itoa",
  "memchr",
  "ryu",
@@ -6501,7 +6524,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -7845,15 +7868,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8080,7 +8103,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -8113,7 +8136,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -8343,9 +8366,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -8534,9 +8557,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
@@ -9318,7 +9350,7 @@ checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "memchr",
 ]
 
@@ -9330,6 +9362,6 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,8 +1670,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contract-build"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#db7ade0e3e72338fc1e8c5b29b3cc8a530211c46"
+version = "6.0.0-alpha.3"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#226c0e61f7f4fdefa7f1e21eed711ced287dc3ac"
 dependencies = [
  "alloy-json-abi",
  "anyhow",
@@ -1686,7 +1686,7 @@ dependencies = [
  "heck",
  "hex",
  "impl-serde",
- "ink_metadata 6.0.0-alpha.1",
+ "ink_metadata 6.0.0-alpha.3 (git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3)",
  "itertools 0.14.0",
  "parity-scale-codec",
  "polkavm-linker 0.29.0",
@@ -1712,8 +1712,8 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/cargo-contract?branch=master#db7ade0e3e72338fc1e8c5b29b3cc8a530211c46"
+version = "6.0.0-alpha.3"
+source = "git+https://github.com/use-ink/cargo-contract?branch=master#226c0e61f7f4fdefa7f1e21eed711ced287dc3ac"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -3093,9 +3093,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "humantime-serde"
@@ -3614,21 +3614,6 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
-dependencies = [
- "derive_more 2.0.1",
- "impl-serde",
- "ink_prelude 6.0.0-alpha.1",
- "ink_primitives 6.0.0-alpha.1",
- "parity-scale-codec",
- "scale-info",
- "schemars 0.8.22",
- "serde",
-]
-
-[[package]]
-name = "ink_metadata"
 version = "6.0.0-alpha.3"
 dependencies = [
  "derive_more 2.0.1",
@@ -3644,16 +3629,14 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
 name = "ink_metadata"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
+version = "6.0.0-alpha.3"
+source = "git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3#5dee03ccdc5bf3d26a53dfd287385eedb3d3a695"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde",
- "ink_prelude 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
- "ink_primitives 6.0.0-alpha.1 (git+https://github.com/use-ink/ink?branch=master)",
+ "ink_prelude 6.0.0-alpha.3 (git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3)",
+ "ink_primitives 6.0.0-alpha.3 (git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3)",
  "parity-scale-codec",
  "scale-info",
  "schemars 0.8.22",
@@ -3661,39 +3644,33 @@ dependencies = [
 ]
 
 [[package]]
->>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
 name = "ink_prelude"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
+version = "6.0.0-alpha.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_prelude"
-<<<<<<< HEAD
 version = "6.0.0-alpha.3"
-=======
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
->>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
+source = "git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3#5dee03ccdc5bf3d26a53dfd287385eedb3d3a695"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
+version = "6.0.0-alpha.3"
 dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "derive_more 2.0.1",
  "impl-trait-for-tuples",
- "ink_prelude 6.0.0-alpha.1",
+ "ink",
+ "ink_env",
+ "ink_prelude 6.0.0-alpha.3",
  "itertools 0.14.0",
  "num-traits",
- "pallet-revive",
  "pallet-revive-uapi",
  "parity-scale-codec",
  "paste",
@@ -3711,20 +3688,14 @@ dependencies = [
 
 [[package]]
 name = "ink_primitives"
-<<<<<<< HEAD
 version = "6.0.0-alpha.3"
-=======
-version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#60ec015922fda0261ce710b934690a7877212614"
->>>>>>> 24ce2ca995 (Misc cleanups and naming fixes)
+source = "git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3#5dee03ccdc5bf3d26a53dfd287385eedb3d3a695"
 dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "derive_more 2.0.1",
  "impl-trait-for-tuples",
- "ink",
- "ink_env",
- "ink_prelude 6.0.0-alpha.3",
+ "ink_prelude 6.0.0-alpha.3 (git+https://github.com/use-ink/ink?tag=v6.0.0-alpha.3)",
  "itertools 0.14.0",
  "num-traits",
  "pallet-revive-uapi",
@@ -5933,9 +5904,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 syn = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 ink = { path = "../../ink" }

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -52,12 +52,14 @@ impl Node {
     ///
     /// Returns `None` if [`Self::Auto`] and `CONTRACTS_NODE_URL` not specified.
     pub fn url(&self) -> Option<String> {
-        std::env::var("CONTRACTS_NODE_URL").ok().or_else(|| {
+        let url = std::env::var("CONTRACTS_NODE_URL").ok().or_else(|| {
             match self {
                 Node::Auto => None,
                 Node::Url(url) => Some(url.clone()),
             }
-        })
+        });
+        tracing::debug!("[E2E] Using node url {:?}", url);
+        url
     }
 }
 

--- a/crates/e2e/sandbox/Cargo.toml
+++ b/crates/e2e/sandbox/Cargo.toml
@@ -20,6 +20,7 @@ pallet-timestamp = { workspace = true }
 scale = { workspace = true }
 sp-core = { workspace = true }
 sp-externalities = { workspace = true }
+sp-runtime = { workspace = true }
 sp-io = { workspace = true }
 ink_primitives = { workspace = true }
 

--- a/crates/e2e/sandbox/src/api/balance_api.rs
+++ b/crates/e2e/sandbox/src/api/balance_api.rs
@@ -77,7 +77,7 @@ where
         dest: &AccountIdFor<T::Runtime>,
         value: BalanceOf<T::Runtime>,
     ) -> Result<(), DispatchError> {
-        // Convert AccountId into the proper Lookup::Source
+        // Convert AccountId into the proper `Lookup::Source`
         let dest =
             <<T::Runtime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
                 dest.clone(),

--- a/crates/e2e/sandbox/src/api/balance_api.rs
+++ b/crates/e2e/sandbox/src/api/balance_api.rs
@@ -1,11 +1,13 @@
 use crate::{
     AccountIdFor,
+    OriginFor,
     Sandbox,
 };
 use frame_support::{
     sp_runtime::DispatchError,
     traits::fungible::Mutate,
 };
+use pallet_revive::sp_runtime::traits::StaticLookup;
 
 type BalanceOf<R> = <R as pallet_balances::Config>::Balance;
 
@@ -36,6 +38,13 @@ where
         &mut self,
         account_id: &AccountIdFor<T::Runtime>,
     ) -> BalanceOf<T::Runtime>;
+
+    fn transfer_allow_death(
+        &mut self,
+        origin: &OriginFor<T::Runtime>,
+        dest: &AccountIdFor<T::Runtime>,
+        value: BalanceOf<T::Runtime>,
+    ) -> Result<(), DispatchError>;
 }
 
 impl<T> BalanceAPI<T> for T
@@ -59,6 +68,27 @@ where
     ) -> BalanceOf<T::Runtime> {
         self.execute_with(|| {
             pallet_balances::Pallet::<T::Runtime>::free_balance(account_id)
+        })
+    }
+
+    fn transfer_allow_death(
+        &mut self,
+        origin: &OriginFor<T::Runtime>,
+        dest: &AccountIdFor<T::Runtime>,
+        value: BalanceOf<T::Runtime>,
+    ) -> Result<(), DispatchError> {
+        // Convert AccountId into the proper Lookup::Source
+        let dest =
+            <<T::Runtime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
+                dest.clone(),
+            );
+
+        self.execute_with(|| {
+            pallet_balances::Pallet::<T::Runtime>::transfer_allow_death(
+                origin.clone(),
+                dest,
+                value,
+            )
         })
     }
 }

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ink_env::{
-    DefaultEnvironment,
-    Environment,
-    call::utils::DecodeMessageResult,
-};
-use ink_primitives::{
-    DepositLimit,
-    abi::AbiEncodeWith,
-};
-use jsonrpsee::core::async_trait;
-use pallet_revive::evm::CallTrace;
-use sp_weights::Weight;
-use subxt::dynamic::Value;
-
 use super::{
     H256,
     InstantiateDryRunResult,
@@ -44,10 +30,23 @@ use crate::{
     builders::CreateBuilderPartial,
     contract_results::BareInstantiationResult,
 };
+use ink_env::{
+    Environment,
+    call::utils::DecodeMessageResult,
+};
+use ink_primitives::{
+    DepositLimit,
+    H160,
+    abi::AbiEncodeWith,
+};
+use jsonrpsee::core::async_trait;
+use pallet_revive::evm::CallTrace;
+use sp_weights::Weight;
+use subxt::dynamic::Value;
 
 /// Full E2E testing backend: combines general chain API and contract-specific operations.
 #[async_trait]
-pub trait E2EBackend<E: Environment = DefaultEnvironment>:
+pub trait E2EBackend<E: Environment, Client>:
     ChainBackend + BuilderClient<E>
 {
 }
@@ -58,7 +57,7 @@ pub trait ChainBackend {
     /// Account type.
     type AccountId;
     /// Balance type.
-    type Balance: Send + From<u32>;
+    type Balance: Send + From<u32> + std::fmt::Debug;
     /// Error type.
     type Error;
     /// Event log type.
@@ -99,6 +98,17 @@ pub trait ChainBackend {
         call_name: &'a str,
         call_data: Vec<Value>,
     ) -> Result<Self::EventLog, Self::Error>;
+
+    /// Attempt to transfer the `value` from `origin` to `dest`.
+    ///
+    /// Returns `Ok` on success, and a [`subxt::Error`] if the extrinsic is
+    /// invalid (e.g. out of date nonce)
+    async fn transfer_allow_death(
+        &mut self,
+        origin: &Keypair,
+        dest: Self::AccountId,
+        value: Self::Balance,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Contract-specific operations.
@@ -274,6 +284,36 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
     where
         CallBuilderFinal<E, Args, RetType, Abi>: Clone;
 
+    /// Executes a dry-run `call`.
+    ///
+    /// Returns the result of the dry run, together with the decoded return value of the
+    /// invoked message.
+    async fn raw_call_dry_run<
+        RetType: Send + DecodeMessageResult<Abi>,
+        Abi: Sync + Clone,
+    >(
+        &mut self,
+        dest: H160,
+        input_data: Vec<u8>,
+        value: E::Balance,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+        signer: &Keypair,
+    ) -> Result<CallDryRunResult<E, RetType, Abi>, Self::Error>;
+
+    /// Executes a dry-run `call`.
+    ///
+    /// Returns the result of the dry run, together with the decoded return value of the
+    /// invoked message.
+    async fn raw_call(
+        &mut self,
+        dest: H160,
+        input_data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+        signer: &Keypair,
+    ) -> Result<(Self::EventLog, Option<CallTrace>), Self::Error>;
+
     /// Uploads the contract call.
     ///
     /// This function extracts the binary of the contract for the specified contract.
@@ -315,13 +355,33 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         Abi: Send + Sync + Clone,
     >(
         &mut self,
-        contract_name: &str,
+        code: Vec<u8>,
         caller: &Keypair,
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<BareInstantiationResult<Self::EventLog>, Self::Error>;
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error>;
+
+    async fn raw_instantiate(
+        &mut self,
+        code: Vec<u8>,
+        caller: &Keypair,
+        constructor: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error>;
+
+    async fn exec_instantiate(
+        &mut self,
+        signer: &Keypair,
+        contract_name: &str,
+        data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: E::Balance,
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error>;
 
     /// Dry run contract instantiation.
     async fn bare_instantiate_dry_run<
@@ -343,4 +403,9 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
 
     /// todo
     async fn map_account_dry_run(&mut self, caller: &Keypair) -> Result<(), Self::Error>;
+
+    /// Returns the `Environment::AccountId` for an `H160` address.
+    async fn to_account_id(&mut self, addr: &H160) -> Result<E::AccountId, Self::Error>;
+
+    fn load_code(&self, contract_name: &str) -> Vec<u8>;
 }

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ink_env::{
+    Environment,
+    call::utils::DecodeMessageResult,
+};
+use ink_primitives::{
+    DepositLimit,
+    H160,
+    abi::AbiEncodeWith,
+};
+use jsonrpsee::core::async_trait;
+use pallet_revive::evm::CallTrace;
+use sp_weights::Weight;
+use subxt::dynamic::Value;
+
 use super::{
     H256,
     InstantiateDryRunResult,
@@ -30,26 +44,10 @@ use crate::{
     builders::CreateBuilderPartial,
     contract_results::BareInstantiationResult,
 };
-use ink_env::{
-    Environment,
-    call::utils::DecodeMessageResult,
-};
-use ink_primitives::{
-    DepositLimit,
-    H160,
-    abi::AbiEncodeWith,
-};
-use jsonrpsee::core::async_trait;
-use pallet_revive::evm::CallTrace;
-use sp_weights::Weight;
-use subxt::dynamic::Value;
 
 /// Full E2E testing backend: combines general chain API and contract-specific operations.
 #[async_trait]
-pub trait E2EBackend<E: Environment, Client>:
-    ChainBackend + BuilderClient<E>
-{
-}
+pub trait E2EBackend<E: Environment>: ChainBackend + BuilderClient<E> {}
 
 /// General chain operations useful in contract testing.
 #[async_trait]

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -326,7 +326,7 @@ where
 
         let instantiate_result = B::bare_instantiate(
             self.client,
-            self.contract_name,
+            B::load_code(self.client, self.contract_name),
             self.caller,
             self.constructor,
             self.value,
@@ -339,6 +339,7 @@ where
 
         Ok(InstantiationResult {
             addr: instantiate_result.addr,
+            account_id: instantiate_result.account_id,
             dry_run,
             events: instantiate_result.events,
             trace: instantiate_result.trace,

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -94,45 +94,42 @@ pub type ContractExecResultFor<E> =
     ContractResult<ExecReturnValue, <E as Environment>::Balance>;
 
 /// Result of a contract instantiation using bare call.
-pub struct BareInstantiationResult<EventLog> {
-    /// The address at which the contract was instantiated.
+pub struct BareInstantiationResult<E: Environment, EventLog> {
+    // The address at which the contract was instantiated.
     pub addr: Address,
+    // The account id at which the contract was instantiated.
+    pub account_id: E::AccountId,
     /// Events that happened with the contract instantiation.
     pub events: EventLog,
-    /// todo
+    /// Trace of the instantiated contract.
     pub trace: Option<CallTrace>,
-    /// todo
+    /// Code hash of the instantiated contract.
     pub code_hash: H256,
 }
 
-impl<EventLog> BareInstantiationResult<EventLog> {
-    /// Returns the address at which the contract was instantiated.
-    /// todo why this strange name? shouldn't it be `fn addr()`?
-    pub fn call(&self) -> Address {
-        self.addr
-    }
-}
-
-/// We implement a custom `Debug` here, as to avoid requiring the trait bound `Debug` for
-/// `E`.
-impl<EventLog> Debug for BareInstantiationResult<EventLog>
+/// We implement a custom `Debug` here, as to avoid requiring the trait bound
+/// `Debug` for `E`.
+impl<E: Environment, EventLog> Debug for BareInstantiationResult<E, EventLog>
 where
     EventLog: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        // todo add missing fields
         f.debug_struct("BareInstantiationResult")
             .field("addr", &self.addr)
+            .field("account_id", &self.account_id.encode())
             .field("events", &self.events)
             .field("trace", &self.trace)
+            .field("code_hash", &self.code_hash)
             .finish()
     }
 }
 
 /// Result of a contract instantiation.
 pub struct InstantiationResult<E: Environment, EventLog, Abi> {
-    /// The account id at which the contract was instantiated.
+    /// The address at which the contract was instantiated.
     pub addr: Address,
+    /// The account id at which the contract was instantiated.
+    pub account_id: E::AccountId,
     /// The result of the dry run, contains debug messages
     /// if there were any.
     pub dry_run: InstantiateDryRunResult<E, Abi>,
@@ -369,6 +366,7 @@ impl<E: Environment, V: DecodeMessageResult<Abi>, Abi> CallDryRunResult<E, V, Ab
 }
 
 /// Result of the dry run of a contract call.
+#[derive(Clone)]
 pub struct InstantiateDryRunResult<E: Environment, Abi> {
     /// The result of the dry run, contains debug messages if there were any.
     pub contract_result: ContractInstantiateResultFor<E>,

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -35,16 +35,16 @@ pub enum Error<DispatchError: fmt::Debug + fmt::Display> {
     UploadDryRun(DispatchError),
     /// The `upload` extrinsic failed.
     #[error("Upload extrinsic error: {0}")]
-    UploadExtrinsic(DispatchError),
+    UploadExtrinsic(DispatchError, Option<CallTrace>),
     /// The `call` dry run failed.
     #[error("Call dry-run error: {0}")]
     CallDryRun(DryRunError<DispatchError>),
     /// The `call` extrinsic failed.
     #[error("Call extrinsic error: {0}")]
-    CallExtrinsic(DispatchError),
+    CallExtrinsic(DispatchError, Option<CallTrace>),
     /// The `remove_code` extrinsic failed.
     #[error("Remove code extrinsic error: {0}")]
-    RemoveCodeExtrinsic(DispatchError),
+    RemoveCodeExtrinsic(DispatchError, Option<CallTrace>),
     /// Error fetching account balance.
     #[error("Fetching account Balance error: {0}")]
     Balance(String),

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use pallet_revive::evm::CallTrace;
 use std::fmt;
 
 /// An error occurred while interacting with the E2E backend.
@@ -27,8 +28,8 @@ pub enum Error<DispatchError: fmt::Debug + fmt::Display> {
     /// The `instantiate_with_code` dry run failed.
     #[error("Instantiate dry-run error: {0}")]
     InstantiateDryRun(DryRunError<DispatchError>),
-    #[error("Instantiate extrinsic error: {0}")]
-    InstantiateExtrinsic(DispatchError),
+    #[error("Instantiate extrinsic error: {0} {1:?}")]
+    InstantiateExtrinsic(DispatchError, Option<CallTrace>),
     /// The `upload` dry run failed.
     #[error("Upload dry-run error: {0}")]
     UploadDryRun(DispatchError),

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -88,7 +88,6 @@ pub use tracing_subscriber;
 #[cfg(feature = "sandbox")]
 pub use ink_sandbox::DefaultSandbox;
 
-use frame_support::dispatch::RawOrigin;
 use ink::codegen::ContractCallBuilder;
 use ink_env::{
     ContractEnv,
@@ -99,6 +98,7 @@ use ink_primitives::{
     Address,
     DepositLimit,
     H256,
+    types::AccountIdMapper,
 };
 pub use sp_weights::Weight;
 use std::{
@@ -107,13 +107,6 @@ use std::{
 };
 use xts::ReviveApi;
 
-use ink_primitives::types::AccountIdMapper;
-use ink_sandbox::{
-    AccountIdFor,
-    Sandbox,
-    frame_system::pallet_prelude::OriginFor,
-    pallet_balances,
-};
 pub use subxt::PolkadotConfig;
 
 /// We use this to only initialize `env_logger` once.
@@ -186,18 +179,6 @@ pub fn address_from_keypair<AccountId: From<[u8; 32]> + AsRef<[u8]>>(
 /// Transforms a `Keypair` into an account id.
 pub fn keypair_to_account<AccountId: From<[u8; 32]>>(keypair: &Keypair) -> AccountId {
     AccountId::from(keypair.public_key().0)
-}
-
-/// Transforms a `Keypair` into an origin.
-pub fn caller_to_origin<S>(caller: &Keypair) -> OriginFor<S::Runtime>
-where
-    S: Sandbox,
-    S::Runtime: pallet_balances::Config + pallet_revive::Config,
-    AccountIdFor<S::Runtime>: From<[u8; 32]> + AsRef<[u8; 32]>,
-{
-    let caller = keypair_to_account(caller);
-    let origin = RawOrigin::Signed(caller);
-    OriginFor::<S::Runtime>::from(origin)
 }
 
 /// Creates a call builder for `Contract`, based on an account id.

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -108,6 +108,7 @@ use std::{
 use xts::ReviveApi;
 
 pub use subxt::PolkadotConfig;
+use ink::H160;
 
 /// We use this to only initialize `env_logger` once.
 pub static INIT: Once = Once::new();

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -108,7 +108,6 @@ use std::{
 use xts::ReviveApi;
 
 pub use subxt::PolkadotConfig;
-use ink::H160;
 
 /// We use this to only initialize `env_logger` once.
 pub static INIT: Once = Once::new();

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -353,7 +353,7 @@ where
 
         let addr_raw = match &result.result {
             Err(err) => {
-                log_error(&format!("Instantiation failed: {err:?}"));
+                log_error(&format!("instantiation failed: {err:?}"));
                 return Err(SandboxErr::new(format!("bare_instantiate: {err:?}")));
             }
             Ok(res) => res.addr,
@@ -446,7 +446,7 @@ where
         ) {
             Ok(result) => result,
             Err(err) => {
-                log_error(&format!("Upload failed: {err:?}"));
+                log_error(&format!("upload failed: {err:?}"));
                 return Err(SandboxErr::new(format!("bare_upload: {err:?}")))
             }
         };

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -250,7 +250,9 @@ where
 
         self.sandbox
             .transfer_allow_death(&origin, &dest, value)
-            .map_err(|err| SandboxErr::new(format!("transfer_allow_death: {err:?}")))
+            .map_err(|err| {
+                SandboxErr::new(format!("transfer_allow_death failed: {err:?}"))
+            })
     }
 }
 
@@ -361,12 +363,8 @@ where
             _ => None,
         };
 
-        fn to_fallback_account_id(address: &H160) -> [u8; 32] {
-            let mut account_id = [0xEE; 32];
-            account_id[..20].copy_from_slice(address.as_bytes());
-            account_id
-        }
-        let account_id = to_fallback_account_id(&addr_raw);
+        let account_id =
+            <S::Runtime as pallet_revive::Config>::AddressMapper::to_account_id(addr_raw);
 
         Ok(BareInstantiationResult {
             addr: addr_raw,

--- a/crates/e2e/src/sandbox_client.rs
+++ b/crates/e2e/src/sandbox_client.rs
@@ -74,6 +74,7 @@ use ink_sandbox::{
 };
 use jsonrpsee::core::async_trait;
 use pallet_revive::{
+    AddressMapper,
     CodeUploadReturnValue,
     InstantiateReturnValue,
     MomentOf,
@@ -364,7 +365,11 @@ where
         };
 
         let account_id =
-            <S::Runtime as pallet_revive::Config>::AddressMapper::to_account_id(addr_raw);
+            <S::Runtime as pallet_revive::Config>::AddressMapper::to_fallback_account_id(
+                &addr_raw,
+            )
+            .as_ref()
+            .to_owned();
 
         Ok(BareInstantiationResult {
             addr: addr_raw,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -16,6 +16,46 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
+use super::{
+    H256,
+    InstantiateDryRunResult,
+    Keypair,
+    ReviveApi,
+    builders::{
+        CreateBuilderPartial,
+        constructor_exec_input,
+    },
+    deposit_limit_to_balance,
+    events::{
+        CodeStoredEvent,
+        EventWithTopics,
+    },
+    log_error,
+    log_info,
+    sr25519,
+};
+use crate::{
+    ContractsBackend,
+    E2EBackend,
+    backend::{
+        BuilderClient,
+        ChainBackend,
+    },
+    client_utils::{
+        ContractsRegistry,
+        salt,
+    },
+    contract_results::{
+        BareInstantiationResult,
+        CallDryRunResult,
+        CallResult,
+        ContractResult,
+        UploadResult,
+    },
+    error::DryRunError,
+    events,
+    events::ContractInstantiatedEvent,
+};
 use ink::H160;
 use ink_env::{
     Environment,
@@ -55,47 +95,8 @@ use subxt::{
         Value,
         ValueDef,
     },
+    storage::dynamic,
     tx::Signer,
-};
-
-use super::{
-    H256,
-    InstantiateDryRunResult,
-    Keypair,
-    ReviveApi,
-    builders::{
-        CreateBuilderPartial,
-        constructor_exec_input,
-    },
-    deposit_limit_to_balance,
-    events::{
-        CodeStoredEvent,
-        EventWithTopics,
-    },
-    log_error,
-    log_info,
-    sr25519,
-};
-use crate::{
-    ContractsBackend,
-    E2EBackend,
-    backend::{
-        BuilderClient,
-        ChainBackend,
-    },
-    client_utils::{
-        ContractsRegistry,
-        salt,
-    },
-    contract_results::{
-        BareInstantiationResult,
-        CallDryRunResult,
-        CallResult,
-        ContractResult,
-        UploadResult,
-    },
-    error::DryRunError,
-    events,
 };
 
 pub type Error = crate::error::Error<DispatchError>;
@@ -117,11 +118,30 @@ where
     C: subxt::Config,
     E: Environment,
 {
-    // TODO (@peterwht): make private once call builder supports RLP
-    pub api: ReviveApi<C, E>,
+    api: ReviveApi<C, E>,
     pub contracts: ContractsRegistry,
     url: String,
 }
+
+/*
+trait FooClient {
+    /// Creates a new [`Client`] instance using a `subxt` client.
+    pub async fn new<P: Into<PathBuf>>(
+        client: subxt::backend::rpc::RpcClient,
+        contracts: impl IntoIterator<Item = P>,
+        url: String,
+    ) -> Result<Self, subxt::Error>;
+
+    pub async fn exec_instantiate(
+        &mut self,
+        signer: &Keypair,
+        code: Vec<u8>,
+        data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: E::Balance,
+    ) -> Result<BareInstantiationResult<E, ExtrinsicEvents<C>>, Error>
+    */
 
 impl<C, E> Client<C, E>
 where
@@ -151,6 +171,7 @@ where
         })
     }
 
+    /*
     // TODO (@peterwht): private after call builder supports RLP
     /// Executes an `instantiate_with_code` call and captures the resulting events.
     pub async fn exec_instantiate(
@@ -161,7 +182,7 @@ where
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: E::Balance,
-    ) -> Result<BareInstantiationResult<ExtrinsicEvents<C>>, Error> {
+    ) -> Result<BareInstantiationResult<E, ExtrinsicEvents<C>>, Error> {
         let salt = salt();
         // todo remove assert once salt() returns no more option
         assert!(salt.is_some());
@@ -178,11 +199,27 @@ where
             )
             .await;
 
+        let mut addr = None;
         for evt in events.iter() {
             let evt = evt.unwrap_or_else(|err| {
                 panic!("unable to unwrap event: {err:?}");
             });
-            if is_extrinsic_failed_event(&evt) {
+            if let Some(instantiated) = evt
+                .as_event::<ContractInstantiatedEvent>()
+                .unwrap_or_else(|err| {
+                    panic!("event conversion to `Instantiated` failed: {err:?}");
+                })
+            {
+                log_info(&format!(
+                    "contract was instantiated at {:?}",
+                    instantiated.contract
+                ));
+                addr = Some(instantiated.contract);
+
+                // We can't `break` here, we need to assign the account id from the
+                // last `ContractInstantiatedEvent`, in case the contract instantiates
+                // multiple accounts as part of its constructor!
+            } else if is_extrinsic_failed_event(&evt) {
                 let metadata = self.api.client.metadata();
                 let dispatch_error =
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
@@ -193,7 +230,11 @@ where
                 return Err(Error::InstantiateExtrinsic(dispatch_error))
             }
         }
+        let addr = addr.expect("cannot extract contract address from events");
+        let mut account_id = [0xEE; 32];
+        account_id[..20].copy_from_slice(addr.as_bytes());
 
+        /*
         let deployer = self.derive_keypair_address(signer);
         let addr = pallet_revive::create2(
             &deployer,
@@ -201,16 +242,89 @@ where
             &data[..],
             &salt.expect("todo make salt() return no option, but value"),
         );
+        */
 
         Ok(BareInstantiationResult {
             // The `account_id` must exist at this point. If the instantiation fails
             // the dry-run must already return that.
             addr,
+            account_id: E::AccountId::decode(&mut &account_id[..]).unwrap(),
             events,
             trace,
             code_hash: H256(crate::client_utils::code_hash(&code[..])),
         })
     }
+
+     */
+
+    /*
+    /// Executes an `instantiate_with_code` call and captures the resulting events.
+    async fn exec_instantiate(
+        &mut self,
+        signer: &Keypair,
+        code: Vec<u8>,
+        data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: Option<E::Balance>,
+    ) -> Result<BareInstantiationResult<E, ExtrinsicEvents<C>>, Error> {
+        let salt = salt();
+
+        let tx_events = self
+            .api
+            .instantiate_with_code(
+                value,
+                gas_limit.into(),
+                storage_deposit_limit,
+                code,
+                data.clone(),
+                salt,
+                signer,
+            )
+            .await;
+
+        let mut account_id = None;
+        for evt in tx_events.iter() {
+            let evt = evt.unwrap_or_else(|err| {
+                panic!("unable to unwrap event: {err:?}");
+            });
+
+            if let Some(instantiated) = evt
+                .as_event::<ContractInstantiatedEvent<E>>()
+                .unwrap_or_else(|err| {
+                    panic!("event conversion to `Instantiated` failed: {err:?}");
+                })
+            {
+                log_info(&format!(
+                    "contract was instantiated at {:?}",
+                    instantiated.contract
+                ));
+                account_id = Some(instantiated.contract);
+
+                // We can't `break` here, we need to assign the account id from the
+                // last `ContractInstantiatedEvent`, in case the contract instantiates
+                // multiple accounts as part of its constructor!
+            } else if is_extrinsic_failed_event(&evt) {
+                let metadata = self.api.client.metadata();
+                let dispatch_error =
+                    subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
+                        .map_err(|e| Error::Decoding(e.to_string()))?;
+                log_error(&format!(
+                    "extrinsic for instantiate failed: {dispatch_error}"
+                ));
+                return Err(Error::InstantiateExtrinsic(dispatch_error))
+            }
+        }
+        let account_id = account_id.expect("cannot extract `account_id` from events");
+
+        Ok(BareInstantiationResult {
+            // The `account_id` must exist at this point. If the instantiation fails
+            // the dry-run must already return that.
+            account_id,
+            events: tx_events,
+        })
+    }
+     */
 
     /// Executes an `upload` call and captures the resulting events.
     async fn exec_upload(
@@ -329,10 +443,13 @@ where
     }
 
     /// Returns the original mapped `AccountId32` for a `H160`.
+    ///
+    /// Returns `None` if no mapping is found in the `pallet-revive` runtime
+    /// storage; this is the case for e.g. contracts.
     async fn fetch_original_account(
         &self,
         addr: &H160,
-    ) -> Result<Option<C::AccountId>, Error> {
+    ) -> Result<Option<E::AccountId>, Error> {
         let original_account_entry = subxt::dynamic::storage(
             "Revive",
             "OriginalAccount",
@@ -354,7 +471,7 @@ where
                 let raw_account_id = value.as_type::<[u8; 32]>().map_err(|err| {
                     Error::Decoding(format!("unable to deserialize AccountId: {err}"))
                 })?;
-                let account: C::AccountId = Decode::decode(&mut &raw_account_id[..])
+                let account: E::AccountId = Decode::decode(&mut &raw_account_id[..])
                     .map_err(|err| {
                         Error::Decoding(format!("unable to decode AccountId: {err}"))
                     })?;
@@ -362,6 +479,25 @@ where
             }
             None => None,
         })
+    }
+
+    /// Returns the `AccountId` for a `H160`.
+    /// Queries runtime, fallsback if no result.
+    pub async fn to_account_id(&self, addr: &H160) -> Result<E::AccountId, Error> {
+        fn to_fallback_account_id(address: &H160) -> [u8; 32] {
+            let mut account_id = [0xEE; 32];
+            account_id[..20].copy_from_slice(address.as_bytes());
+            account_id
+        }
+
+        match self.fetch_original_account(addr).await? {
+            Some(v) => Ok(v),
+            None => {
+                let fallback = to_fallback_account_id(addr);
+                let account_id = E::AccountId::decode(&mut &fallback[..]).unwrap();
+                Ok(account_id)
+            }
+        }
     }
 }
 
@@ -412,7 +548,7 @@ where
         let origin_account_id = origin.public_key().to_account_id();
 
         self.api
-            .try_transfer_balance(origin, account_id.clone(), amount)
+            .transfer_allow_death(origin, account_id.clone(), amount)
             .await
             .unwrap_or_else(|err| {
                 panic!(
@@ -501,6 +637,20 @@ where
 
         Ok(tx_events)
     }
+
+    async fn transfer_allow_death(
+        &mut self,
+        origin: &Keypair,
+        dest: Self::AccountId,
+        value: Self::Balance,
+    ) -> Result<(), Self::Error> {
+        let dest = dest.encode();
+        let dest: C::AccountId = Decode::decode(&mut &dest[..]).unwrap();
+        self.api
+            .transfer_allow_death(origin, dest, value)
+            .await
+            .map_err(|err| Error::Balance(format!("{err:?}")))
+    }
 }
 
 #[async_trait]
@@ -527,6 +677,10 @@ where
         Clone + Debug + Send + Sync + From<u128> + scale::HasCompact + serde::Serialize,
     H256: Debug + Send + Sync + scale::Encode,
 {
+    fn load_code(&self, contract_name: &str) -> Vec<u8> {
+        self.contracts.load_code(contract_name)
+    }
+
     async fn bare_instantiate<
         Contract: Clone,
         Args: Send + Sync + AbiEncodeWith<Abi> + Clone,
@@ -534,21 +688,121 @@ where
         Abi: Send + Sync + Clone,
     >(
         &mut self,
-        contract_name: &str,
+        code: Vec<u8>,
         caller: &Keypair,
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R, Abi>,
         value: E::Balance,
         gas_limit: Weight,
         storage_deposit_limit: DepositLimit<E::Balance>,
-    ) -> Result<BareInstantiationResult<Self::EventLog>, Self::Error> {
-        let code = self.contracts.load_code(contract_name);
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error> {
         let data = constructor_exec_input(constructor.clone());
-        let storage_deposit_limit = deposit_limit_to_balance::<E>(storage_deposit_limit);
         let ret = self
-            .exec_instantiate(caller, code, data, value, gas_limit, storage_deposit_limit)
+            .raw_instantiate(code, caller, data, value, gas_limit, storage_deposit_limit)
             .await?;
-        log_info(&format!("instantiated contract at {:?}", ret.addr));
         Ok(ret)
+    }
+
+    async fn raw_instantiate(
+        &mut self,
+        code: Vec<u8>,
+        caller: &Keypair,
+        constructor: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error> {
+        let storage_deposit_limit = deposit_limit_to_balance::<E>(storage_deposit_limit);
+        let salt = salt();
+        // todo remove assert once salt() returns no more option
+        assert!(salt.is_some());
+        let (events, trace) = self
+            .api
+            .instantiate_with_code(
+                value,
+                gas_limit.into(),
+                storage_deposit_limit,
+                code.clone(),
+                constructor.clone(),
+                salt,
+                caller,
+            )
+            .await;
+
+        let mut addr = None;
+        for evt in events.iter() {
+            let evt = evt.unwrap_or_else(|err| {
+                panic!("unable to unwrap event: {err:?}");
+            });
+            if let Some(instantiated) = evt
+                .as_event::<ContractInstantiatedEvent>()
+                .unwrap_or_else(|err| {
+                    panic!("event conversion to `Instantiated` failed: {err:?}");
+                })
+            {
+                log_info(&format!(
+                    "contract was instantiated at {:?}",
+                    instantiated.contract
+                ));
+                addr = Some(instantiated.contract);
+
+                // We can't `break` here, we need to assign the account id from the
+                // last `ContractInstantiatedEvent`, in case the contract instantiates
+                // multiple accounts as part of its constructor!
+            } else if is_extrinsic_failed_event(&evt) {
+                let metadata = self.api.client.metadata();
+                let dispatch_error =
+                    subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
+                        .map_err(|e| Error::Decoding(e.to_string()))?;
+                log_error(&format!(
+                    "extrinsic for instantiate failed: {dispatch_error}"
+                ));
+                return Err(Error::InstantiateExtrinsic(dispatch_error))
+            }
+        }
+        let addr = addr.expect("cannot extract contract address from events");
+        let mut account_id = [0xEE; 32];
+        account_id[..20].copy_from_slice(addr.as_bytes());
+
+        /*
+        let deployer = self.derive_keypair_address(signer);
+        let addr = pallet_revive::create2(
+            &deployer,
+            &code[..],
+            &data[..],
+            &salt.expect("todo make salt() return no option, but value"),
+        );
+        */
+
+        Ok(BareInstantiationResult {
+            // The `account_id` must exist at this point. If the instantiation fails
+            // the dry-run must already return that.
+            addr,
+            account_id: E::AccountId::decode(&mut &account_id[..]).unwrap(),
+            events,
+            trace,
+            code_hash: H256(crate::client_utils::code_hash(&code[..])),
+        })
+    }
+
+    async fn exec_instantiate(
+        &mut self,
+        signer: &Keypair,
+        contract_name: &str,
+        data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: E::Balance,
+    ) -> Result<BareInstantiationResult<E, Self::EventLog>, Self::Error> {
+        let code = self.contracts.load_code(contract_name);
+        self.raw_instantiate(
+            code,
+            signer,
+            data,
+            value,
+            gas_limit,
+            DepositLimit::Balance(storage_deposit_limit),
+        )
+        .await
     }
 
     async fn bare_instantiate_dry_run<
@@ -657,16 +911,35 @@ where
         let addr = *message.clone().params().callee();
         let exec_input = message.clone().params().exec_input().encode();
         log_info(&format!("call: {exec_input:02X?}"));
+        self.raw_call(
+            addr,
+            exec_input,
+            value,
+            gas_limit,
+            storage_deposit_limit,
+            caller,
+        )
+        .await
+    }
 
+    async fn raw_call(
+        &mut self,
+        dest: H160,
+        input_data: Vec<u8>,
+        value: E::Balance,
+        gas_limit: Weight,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+        signer: &Keypair,
+    ) -> Result<(Self::EventLog, Option<CallTrace>), Self::Error> {
         let (tx_events, trace) = self
             .api
             .call(
-                addr,
+                dest,
                 value,
                 gas_limit.into(),
                 deposit_limit_to_balance::<E>(storage_deposit_limit),
-                exec_input,
-                caller,
+                input_data,
+                signer,
             )
             .await;
 
@@ -713,10 +986,12 @@ where
         let (exec_result, trace) = self
             .api
             .call_dry_run(
+                /*
                 Signer::<C>::account_id(caller), /* todo this param is not necessary,
                                                   * because the last argument is the
                                                   * caller and this value can be
                                                   * created in the function */
+                 */
                 dest,
                 exec_input,
                 value,
@@ -730,6 +1005,28 @@ where
             .contract_result_to_result(exec_result)
             .map_err(Error::CallDryRun)?;
 
+        Ok(CallDryRunResult {
+            exec_result,
+            trace,
+            _marker: Default::default(),
+        })
+    }
+
+    async fn raw_call_dry_run<
+        RetType: Send + DecodeMessageResult<Abi>,
+        Abi: Sync + Clone,
+    >(
+        &mut self,
+        dest: H160,
+        input_data: Vec<u8>,
+        value: E::Balance,
+        storage_deposit_limit: DepositLimit<E::Balance>,
+        signer: &Keypair,
+    ) -> Result<CallDryRunResult<E, RetType, Abi>, Self::Error> {
+        let (exec_result, trace) = self
+            .api
+            .call_dry_run(dest, input_data, value, storage_deposit_limit, signer)
+            .await;
         Ok(CallDryRunResult {
             exec_result,
             trace,
@@ -785,6 +1082,50 @@ where
 
         Ok(())
     }
+
+    async fn to_account_id(&mut self, addr: &H160) -> Result<E::AccountId, Self::Error> {
+        let contract_info_address =
+            dynamic("Revive", "OriginalAccount", vec![Value::from_bytes(addr)]);
+        let raw_value = self
+            .api
+            .client
+            .storage()
+            .at_latest()
+            .await
+            .map_err(|err| Error::Other(format!("failed to fetch latest: {err:?}")))?
+            .fetch(&contract_info_address)
+            .await
+            .map_err(|err| {
+                Error::Other(format!("failed to fetch account info: {err:?}"))
+            })?;
+        match raw_value {
+            None => {
+                // This typically happens when calling this function with a contract, for
+                // which there is no `AccountId`.
+                fn to_fallback_account_id(address: &H160) -> [u8; 32] {
+                    let mut account_id = [0xEE; 32];
+                    account_id[..20].copy_from_slice(address.as_bytes());
+                    account_id
+                }
+                let fallback = to_fallback_account_id(addr);
+                tracing::debug!(
+                    "No address suffix was found in the node for H160 address {:?}, using fallback {:?}",
+                    addr,
+                    fallback
+                );
+                let account_id = E::AccountId::decode(&mut &fallback[..]).unwrap();
+                Ok(account_id)
+            }
+            Some(raw_value) => {
+                let raw_account_id = raw_value.as_type::<[u8; 32]>().expect("oh");
+                let account: E::AccountId = Decode::decode(&mut &raw_account_id[..])
+                    .map_err(|err| {
+                        panic!("AccountId from `[u8; 32]` deserialization error: {}", err)
+                    })?;
+                Ok(account)
+            }
+        }
+    }
 }
 
 impl<C, E> ContractsBackend<E> for Client<C, E>
@@ -811,7 +1152,7 @@ where
     type EventLog = ExtrinsicEvents<C>;
 }
 
-impl<C, E> E2EBackend<E> for Client<C, E>
+impl<C, E, Cliente> E2EBackend<E, Cliente> for Client<C, E>
 where
     C: subxt::Config + Send + Sync,
     C::AccountId: Clone
@@ -833,6 +1174,7 @@ where
     E::Balance:
         Clone + Debug + Send + Sync + From<u128> + scale::HasCompact + serde::Serialize,
     H256: Debug + Send + Sync + scale::Encode,
+    Cliente: E2EBackend<E, Cliente>,
 {
 }
 
@@ -870,11 +1212,6 @@ impl<E: Environment, V, C: subxt::Config, Abi> CallResult<E, V, ExtrinsicEvents<
     pub fn contains_event(&self, pallet_name: &str, variant_name: &str) -> bool {
         self.events.iter().any(|event| {
             let event = event.unwrap();
-            eprintln!(
-                "pallet: {:?}, variant: {:?}",
-                event.pallet_name(),
-                event.variant_name()
-            );
             event.pallet_name() == pallet_name && event.variant_name() == variant_name
         })
     }

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -119,29 +119,9 @@ where
     E: Environment,
 {
     api: ReviveApi<C, E>,
-    pub contracts: ContractsRegistry,
+    contracts: ContractsRegistry,
     url: String,
 }
-
-/*
-trait FooClient {
-    /// Creates a new [`Client`] instance using a `subxt` client.
-    pub async fn new<P: Into<PathBuf>>(
-        client: subxt::backend::rpc::RpcClient,
-        contracts: impl IntoIterator<Item = P>,
-        url: String,
-    ) -> Result<Self, subxt::Error>;
-
-    pub async fn exec_instantiate(
-        &mut self,
-        signer: &Keypair,
-        code: Vec<u8>,
-        data: Vec<u8>,
-        value: E::Balance,
-        gas_limit: Weight,
-        storage_deposit_limit: E::Balance,
-    ) -> Result<BareInstantiationResult<E, ExtrinsicEvents<C>>, Error>
-    */
 
 impl<C, E> Client<C, E>
 where
@@ -1152,7 +1132,7 @@ where
     type EventLog = ExtrinsicEvents<C>;
 }
 
-impl<C, E, Cliente> E2EBackend<E, Cliente> for Client<C, E>
+impl<C, E> E2EBackend<E> for Client<C, E>
 where
     C: subxt::Config + Send + Sync,
     C::AccountId: Clone
@@ -1174,7 +1154,6 @@ where
     E::Balance:
         Clone + Debug + Send + Sync + From<u128> + scale::HasCompact + serde::Serialize,
     H256: Debug + Send + Sync + scale::Encode,
-    Cliente: E2EBackend<E, Cliente>,
 {
 }
 

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -171,7 +171,8 @@ where
             return Err(Error::UploadDryRun(dispatch_err))
         }
 
-        let (tx_events, trace) = self.api.upload(signer, code, storage_deposit_limit).await;
+        let (tx_events, trace) =
+            self.api.upload(signer, code, storage_deposit_limit).await;
 
         let mut hash = None;
         for evt in tx_events.iter() {
@@ -196,7 +197,9 @@ where
                     DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
 
-                log_error(&format!("extrinsic for upload failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for upload failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::UploadExtrinsic(dispatch_error, trace))
             }
         }
@@ -455,7 +458,9 @@ where
                 let dispatch_error =
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
-                log_error(&format!("extrinsic for call failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for call failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::CallExtrinsic(dispatch_error, trace))
             }
         }
@@ -702,7 +707,9 @@ where
                 let dispatch_error =
                     DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
-                log_error(&format!("extrinsic for remove code failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for remove code failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::RemoveCodeExtrinsic(dispatch_error, trace))
             }
         }
@@ -770,7 +777,9 @@ where
                 let dispatch_error =
                     DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
-                log_error(&format!("extrinsic for call failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for call failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::CallExtrinsic(dispatch_error, trace))
             }
         }
@@ -868,7 +877,9 @@ where
                 let dispatch_error =
                     DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
-                log_error(&format!("extrinsic for call failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for call failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::CallExtrinsic(dispatch_error, trace))
             }
         }
@@ -892,7 +903,9 @@ where
                 let dispatch_error =
                     DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::Decoding(e.to_string()))?;
-                log_error(&format!("extrinsic for call failed: {dispatch_error} {trace:?}"));
+                log_error(&format!(
+                    "extrinsic for call failed: {dispatch_error} {trace:?}"
+                ));
                 return Err(Error::CallExtrinsic(dispatch_error, trace))
             }
         }

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -811,19 +811,7 @@ where
 
         let (exec_result, trace) = self
             .api
-            .call_dry_run(
-                /*
-                Signer::<C>::account_id(caller), /* todo this param is not necessary,
-                                                  * because the last argument is the
-                                                  * caller and this value can be
-                                                  * created in the function */
-                 */
-                dest,
-                exec_input,
-                value,
-                storage_deposit_limit,
-                caller,
-            )
+            .call_dry_run(dest, exec_input, value, storage_deposit_limit, caller)
             .await;
         log_info(&format!("call dry run result: {:?}", &exec_result.result));
 
@@ -1036,7 +1024,12 @@ impl<E: Environment, V, C: subxt::Config, Abi> CallResult<E, V, ExtrinsicEvents<
     /// Returns true if the specified event was triggered by the call.
     pub fn contains_event(&self, pallet_name: &str, variant_name: &str) -> bool {
         self.events.iter().any(|event| {
-            let event = event.unwrap();
+            let event = event.expect("unable to extract event");
+            tracing::debug!(
+                "found event with pallet: {:?}, variant: {:?}",
+                event.pallet_name(),
+                event.variant_name()
+            );
             event.pallet_name() == pallet_name && event.variant_name() == variant_name
         })
     }

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -213,13 +213,6 @@ struct RpcCallRequest<C: subxt::Config, E: Environment> {
     input_data: Vec<u8>,
 }
 
-/// A struct that encodes RPC parameters required for calling the
-/// `pallet-revive` Runtime Api function `address()`.
-#[derive(scale::Encode)]
-struct RpcAddressRequest<C: subxt::Config> {
-    account_id: C::AccountId,
-}
-
 /// Reference to an existing code hash or a new contract binary.
 #[derive(serde::Serialize, scale::Encode)]
 #[serde(rename_all = "camelCase")]
@@ -770,24 +763,5 @@ where
     ) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::dynamic::tx(pallet_name, call_name, call_data);
         self.submit_extrinsic(&call, signer).await
-    }
-
-    /// Returns the `H160` for an account id.
-    ///
-    /// Queries the RPC server for the `pallet-revive` runtime api function `address`.
-    #[allow(dead_code)]
-    pub async fn address(&self, account_id: C::AccountId) -> H160 {
-        let call_request = RpcAddressRequest::<C> { account_id };
-        let func = "ReviveApi_address";
-        let params = scale::Encode::encode(&call_request);
-        let bytes = self
-            .rpc
-            .state_call(func, Some(&params), None)
-            .await
-            .unwrap_or_else(|err| {
-                panic!("error on ws request `ReviveApi_address`: {err:?}");
-            });
-        scale::Decode::decode(&mut bytes.as_ref())
-            .unwrap_or_else(|err| panic!("decoding `H160` failed: {err}"))
     }
 }

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -745,7 +745,10 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn map_account(&self, signer: &Keypair) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
+    pub async fn map_account(
+        &self,
+        signer: &Keypair,
+    ) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::tx::DefaultPayload::new("Revive", "map_account", MapAccount {})
             .unvalidated();
 

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -772,6 +772,7 @@ where
     /// Returns the `H160` for an account id.
     ///
     /// Queries the RPC server for the `pallet-revive` runtime api function `address`.
+    #[allow(dead_code)]
     pub async fn address(&self, account_id: C::AccountId) -> H160 {
         let call_request = RpcAddressRequest::<C> { account_id };
         let func = "ReviveApi_address";

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -597,7 +597,7 @@ where
         signer: &Keypair,
         code: Vec<u8>,
         storage_deposit_limit: E::Balance,
-    ) -> ExtrinsicEvents<C> {
+    ) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::tx::DefaultPayload::new(
             "Revive",
             "upload_code",
@@ -608,7 +608,7 @@ where
         )
         .unvalidated();
 
-        self.submit_extrinsic(&call, signer).await.0
+        self.submit_extrinsic(&call, signer).await
     }
 
     /// Submits an extrinsic to remove the code at the given hash.
@@ -619,7 +619,7 @@ where
         &self,
         signer: &Keypair,
         code_hash: H256,
-    ) -> ExtrinsicEvents<C> {
+    ) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::tx::DefaultPayload::new(
             "Revive",
             "remove_code",
@@ -627,7 +627,7 @@ where
         )
         .unvalidated();
 
-        self.submit_extrinsic(&call, signer).await.0
+        self.submit_extrinsic(&call, signer).await
     }
 
     /// Dry runs a call of the contract at `contract` with the given parameters.
@@ -745,11 +745,11 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn map_account(&self, signer: &Keypair) -> ExtrinsicEvents<C> {
+    pub async fn map_account(&self, signer: &Keypair) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::tx::DefaultPayload::new("Revive", "map_account", MapAccount {})
             .unvalidated();
 
-        self.submit_extrinsic(&call, signer).await.0
+        self.submit_extrinsic(&call, signer).await
     }
 
     /// Submit an extrinsic `call_name` for the `pallet_name`.
@@ -764,9 +764,9 @@ where
         pallet_name: &'a str,
         call_name: &'a str,
         call_data: Vec<subxt::dynamic::Value>,
-    ) -> ExtrinsicEvents<C> {
+    ) -> (ExtrinsicEvents<C>, Option<CallTrace>) {
         let call = subxt::dynamic::tx(pallet_name, call_name, call_data);
-        self.submit_extrinsic(&call, signer).await.0
+        self.submit_extrinsic(&call, signer).await
     }
 
     /// Returns the `H160` for an account id.

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -43,23 +43,19 @@ pub struct EmittedEvent {
     pub data: Vec<u8>,
 }
 
-/// Sets the balance of the account to the given balance.
+/// Sets the balance of a contract to the given balance.
 ///
 /// # Note
-///
-/// Note that account could refer to either a user account or
-/// a smart contract account.
 ///
 /// If a 0 balance is set, this would not fail. This is useful for
 /// reaping an account.
 ///
 /// # Errors
 ///
-/// - If `account` does not exist.
-/// - If the underlying `account` type does not match.
+/// - If `addr` does not exist.
 /// - If the underlying `new_balance` type does not match.
 /// - If the `new_balance` is less than the existential minimum.
-pub fn set_account_balance(addr: Address, new_balance: U256) {
+pub fn set_contract_balance(addr: Address, new_balance: U256) {
     let min = ChainSpec::default().minimum_balance;
     if new_balance < min && new_balance != U256::zero() {
         panic!("Balance must be at least [{min}]. Use 0 as balance to reap the account.");
@@ -70,19 +66,17 @@ pub fn set_account_balance(addr: Address, new_balance: U256) {
     })
 }
 
-/// Returns the balance of the account.
+/// Returns the balance of a contract.
 ///
 /// # Note
 ///
-/// Note that account could refer to either a user account or
-/// a smart contract account. This returns the same as `env::api::balance`
-/// if given the account id of the currently executed smart contract.
+/// This returns the same as `env::api::balance` if given the contract
+/// address of the currently executed smart contract.
 ///
 /// # Errors
 ///
-/// - If `account` does not exist.
-/// - If the underlying `account` type does not match.
-pub fn get_account_balance<T>(addr: Address) -> Result<U256> {
+/// - If `contract` does not exist.
+pub fn get_contract_balance<T>(addr: Address) -> Result<U256> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.get_balance(addr).map_err(Into::into)
     })
@@ -260,9 +254,8 @@ where
     f(default_accounts)
 }
 
-/// Returns the default accounts for testing purposes:
-/// Alice, Bob, Charlie, Django, Eve and Frank.
-/// todo should be `default_addresses`
+/// Returns the `H160` addresses of default accounts, for testing
+/// purposes: Alice, Bob, Charlie, Django, Eve and Frank.
 pub fn default_accounts() -> DefaultAccounts {
     DefaultAccounts {
         alice: AccountIdMapper::to_address(&[0x01; 32]),
@@ -274,19 +267,19 @@ pub fn default_accounts() -> DefaultAccounts {
     }
 }
 
-/// The default accounts.
+/// Addresses of the default accounts.
 pub struct DefaultAccounts {
-    /// The predefined `ALICE` account holding substantial amounts of value.
+    /// The predefined `ALICE` address holding substantial amounts of value.
     pub alice: Address,
-    /// The predefined `BOB` account holding some amounts of value.
+    /// The predefined `BOB` address holding some amounts of value.
     pub bob: Address,
-    /// The predefined `CHARLIE` account holding some amounts of value.
+    /// The predefined `CHARLIE` address holding some amounts of value.
     pub charlie: Address,
-    /// The predefined `DJANGO` account holding no value.
+    /// The predefined `DJANGO` address holding no value.
     pub django: Address,
-    /// The predefined `EVE` account holding no value.
+    /// The predefined `EVE` address holding no value.
     pub eve: Address,
-    /// The predefined `FRANK` account holding no value.
+    /// The predefined `FRANK` address holding no value.
     pub frank: Address,
 }
 

--- a/crates/env/src/engine/off_chain/tests.rs
+++ b/crates/env/src/engine/off_chain/tests.rs
@@ -17,7 +17,7 @@ use crate::{
     Result,
     engine::off_chain::{
         impls::TopicsBuilder,
-        test_api::set_account_balance,
+        test_api::set_contract_balance,
     },
     event::TopicsBuilderBackend,
 };
@@ -51,21 +51,21 @@ fn topics_builder() -> Result<()> {
 }
 
 #[test]
-fn test_set_account_balance() -> Result<()> {
+fn test_set_contract_balance() -> Result<()> {
     pub use ink_engine::ext::ChainSpec;
 
     crate::test::run_test::<DefaultEnvironment, _>(|_| {
         let minimum_balance = ChainSpec::default().minimum_balance;
 
         let result = std::panic::catch_unwind(|| {
-            set_account_balance(Address::from([0x1; 20]), minimum_balance - 1)
+            set_contract_balance(Address::from([0x1; 20]), minimum_balance - 1)
         });
 
         assert!(result.is_err());
 
-        set_account_balance(Address::from([0x1; 20]), U256::zero());
+        set_contract_balance(Address::from([0x1; 20]), U256::zero());
 
-        set_account_balance(Address::from([0x1; 20]), minimum_balance + 1);
+        set_contract_balance(Address::from([0x1; 20]), minimum_balance + 1);
 
         Ok(())
     })

--- a/crates/ink/codegen/src/generator/sol/metadata.rs
+++ b/crates/ink/codegen/src/generator/sol/metadata.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(feature = "std", allow(dead_code))]
+#![cfg_attr(feature = "std", allow(unused))]
+
 use derive_more::From;
 use ir::{
     Callable as _,

--- a/crates/ink/codegen/src/generator/sol/metadata.rs
+++ b/crates/ink/codegen/src/generator/sol/metadata.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "std", allow(dead_code))]
-#![cfg_attr(feature = "std", allow(unused))]
-
 use derive_more::From;
 use ir::{
     Callable as _,

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -320,45 +320,6 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Map between the native chain account id `T` and an Ethereum [`H160`].
-///
-/// This trait exists only to emulate specialization for different concrete
-/// native account ids. **Not** to make the mapping user configurable. Hence
-/// the trait is `Sealed` and depending on your runtime configuration you need
-/// to pick either [`AccountId32Mapper`] or [`H160Mapper`]. Picking the wrong
-/// one will result in a compilation error. No footguns here.
-///
-/// Please note that we assume that the native account is at least 20 bytes and
-/// only implement this type for a `T` where this is the case. Luckily, this is the
-/// case for all existing runtimes as of right now. Reasoning is that this will allow
-/// us to reverse an address -> account_id mapping by just stripping the prefix.
-///
-/// We require the mapping to be reversible. Since we are potentially dealing with types
-/// of different sizes one direction of the mapping is necessarily lossy. This requires
-/// the mapping to make use of the [`OriginalAccount`] storage item to reverse the
-/// mapping.
-pub trait AddressMapper<T: Environment> {
-    /// Convert an account id to an ethereum address.
-    fn to_address(account_id: &T::AccountId) -> H160;
-
-    /// Convert an ethereum address to a native account id.
-    fn to_account_id(address: &H160) -> T::AccountId;
-
-    /// Same as [`Self::to_account_id`] but always returns the fallback account.
-    ///
-    /// This skips the query into [`OriginalAccount`] and always returns the stateless
-    /// fallback account. This is useful when we know for a fact that the `address`
-    /// in question is originally a `H160`. This is usually only the case when we
-    /// generated a new contract address.
-    fn to_fallback_account_id(address: &H160) -> T::AccountId;
-
-    /// Returns true if the `account_id` is usable as an origin.
-    ///
-    /// This means either the `account_id` doesn't require a stateful mapping
-    /// or a stateful mapping exists.
-    fn is_mapped(account_id: &T::AccountId) -> bool;
-}
-
 /// The environmental types usable by contracts defined with ink!.
 ///
 /// The types and consts in this trait must be the same as the chain to which
@@ -517,6 +478,7 @@ pub enum Origin<E: Environment> {
     Signed(E::AccountId),
 }
 
+/// Copied from `pallet-revive`.
 pub struct AccountIdMapper {}
 impl AccountIdMapper {
     pub fn to_address(account_id: &[u8]) -> Address {

--- a/integration-tests/internal/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/internal/e2e-runtime-only-backend/lib.rs
@@ -37,13 +37,6 @@ pub mod flipper {
         pub fn get_contract_balance(&self) -> ink::U256 {
             self.env().balance()
         }
-
-        /// todo
-        /// Returns the `AccountId` of this contract.
-        #[ink(message)]
-        pub fn account_id(&mut self) -> AccountId {
-            self.env().account_id()
-        }
     }
 
     #[cfg(all(test, feature = "e2e-tests"))]
@@ -118,15 +111,6 @@ pub mod flipper {
                 .expect("deploy failed");
             let mut call_builder = contract.call_builder::<Flipper>();
 
-            // todo
-            let acc = call_builder.account_id();
-            let call_res = client
-                .call(&ink_e2e::alice(), &acc)
-                .submit()
-                .await
-                .expect("call failed");
-            let account_id: AccountId = call_res.return_value();
-
             let old_balance = client
                 .call(&ink_e2e::alice(), &call_builder.get_contract_balance())
                 .submit()
@@ -138,9 +122,7 @@ pub mod flipper {
 
             // when
             let call_data = vec![
-                // todo addr
-                Value::unnamed_variant("Id", [Value::from_bytes(account_id)]),
-                // todo check next line
+                Value::unnamed_variant("Id", [Value::from_bytes(contract.account_id)]),
                 Value::u128(ENDOWMENT),
             ];
             client

--- a/integration-tests/internal/lang-err/constructors-return-value/lib.rs
+++ b/integration-tests/internal/lang-err/constructors-return-value/lib.rs
@@ -247,7 +247,7 @@ pub mod constructors_return_value {
                 .await;
 
             assert!(
-                matches!(result, Err(ink_e2e::Error::InstantiateExtrinsic(_))),
+                matches!(result, Err(ink_e2e::Error::InstantiateExtrinsic(_, _))),
                 "Constructor should fail"
             );
 

--- a/integration-tests/internal/lang-err/integration-flipper/lib.rs
+++ b/integration-tests/internal/lang-err/integration-flipper/lib.rs
@@ -136,7 +136,7 @@ pub mod integration_flipper {
 
             assert!(matches!(
                 err_flip_call_result,
-                Err(ink_e2e::Error::CallExtrinsic(_))
+                Err(ink_e2e::Error::CallExtrinsic(_, _))
             ));
 
             let flipped_value = client

--- a/integration-tests/internal/overflow-safety/lib.rs
+++ b/integration-tests/internal/overflow-safety/lib.rs
@@ -113,7 +113,7 @@ pub mod overflow_safety {
             // when
             let add = call_builder.add(u8::MAX, 1u8);
             let add_res = client.call(&ink_e2e::bob(), &add).submit().await;
-            assert!(matches!(add_res, Err(ink_e2e::Error::CallExtrinsic(_))));
+            assert!(matches!(add_res, Err(ink_e2e::Error::CallExtrinsic(_, _))));
 
             Ok(())
         }
@@ -159,7 +159,7 @@ pub mod overflow_safety {
             // when
             let sub = call_builder.sub(u8::MIN, 1u8);
             let sub_res = client.call(&ink_e2e::bob(), &sub).submit().await;
-            assert!(matches!(sub_res, Err(ink_e2e::Error::CallExtrinsic(_))));
+            assert!(matches!(sub_res, Err(ink_e2e::Error::CallExtrinsic(_, _))));
 
             Ok(())
         }

--- a/integration-tests/public/contract-invocation/lib.rs
+++ b/integration-tests/public/contract-invocation/lib.rs
@@ -382,7 +382,7 @@ mod instantiate_contract {
             c: u32,
             d: u32,
         ) where
-            Client: E2EBackend<E>,
+            Client: E2EBackend<ink::env::DefaultEnvironment>,
             E: ink::env::Environment,
         {
             let r1 = ver1.call_builder::<VirtualContract>();

--- a/integration-tests/public/contract-invocation/lib.rs
+++ b/integration-tests/public/contract-invocation/lib.rs
@@ -382,7 +382,7 @@ mod instantiate_contract {
             c: u32,
             d: u32,
         ) where
-            Client: E2EBackend,
+            Client: E2EBackend<E>,
             E: ink::env::Environment,
         {
             let r1 = ver1.call_builder::<VirtualContract>();

--- a/integration-tests/public/contract-terminate/lib.rs
+++ b/integration-tests/public/contract-terminate/lib.rs
@@ -34,7 +34,7 @@ pub mod just_terminates {
             let accounts = ink::env::test::default_accounts();
             let contract_id = ink::env::test::callee();
             ink::env::test::set_caller(accounts.alice);
-            ink::env::test::set_account_balance(contract_id, 100.into());
+            ink::env::test::set_contract_balance(contract_id, 100.into());
             let mut contract = JustTerminate::new();
 
             // when

--- a/integration-tests/public/contract-transfer/Cargo.toml
+++ b/integration-tests/public/contract-transfer/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
-#ink_e2e = { path = "../../../crates/e2e" }
 ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
 
 [lib]

--- a/integration-tests/public/contract-transfer/lib.rs
+++ b/integration-tests/public/contract-transfer/lib.rs
@@ -189,7 +189,6 @@ pub mod give_me {
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-        //#[ink_e2e::test(backend(runtime_only))]
         #[ink_e2e::test]
         async fn e2e_sending_value_to_give_me_must_fail<Client: E2EBackend>(
             mut client: Client,

--- a/integration-tests/public/debugging-strategies/lib.rs
+++ b/integration-tests/public/debugging-strategies/lib.rs
@@ -253,7 +253,6 @@ mod debugging_strategies {
             // when
             let trace: ink_e2e::CallTrace = call_res.trace.expect("trace must exist");
             assert_eq!(trace.calls.len(), 2);
-            eprintln!("trace {:#?}", trace);
             // This is how the object looks:
             // ```
             // CallTrace {

--- a/integration-tests/public/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/public/e2e-call-runtime/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false, features = ["unstable-hostfn"] }
+static_assertions = "1"
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/public/e2e-call-runtime/lib.rs
+++ b/integration-tests/public/e2e-call-runtime/lib.rs
@@ -16,13 +16,6 @@ pub mod e2e_call_runtime {
         pub fn get_contract_balance(&self) -> ink::U256 {
             self.env().balance()
         }
-
-        /// todo
-        /// Returns the `AccountId` of this contract.
-        #[ink(message)]
-        pub fn account_id(&mut self) -> AccountId {
-            self.env().account_id()
-        }
     }
 
     #[cfg(all(test, feature = "e2e-tests"))]
@@ -34,6 +27,7 @@ pub mod e2e_call_runtime {
             ContractsBackend,
             subxt::dynamic::Value,
         };
+        use static_assertions::assert_type_eq_all;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -48,26 +42,24 @@ pub mod e2e_call_runtime {
                 .submit()
                 .await
                 .expect("instantiate failed");
+
+            let account_id = client.to_account_id(&contract.addr).await?;
+            assert_eq!(account_id, contract.account_id);
+
             let mut call_builder = contract.call_builder::<Contract>();
 
-            // todo
-            let acc = call_builder.account_id();
-            let call_res = client
-                .call(&ink_e2e::alice(), &acc)
-                .submit()
-                .await
-                .expect("call failed");
-            let account_id: AccountId = call_res.return_value();
-
-            // todo
-            let transfer_amount = 100_000_000_000u128;
+            // The generic `Environment::Balance` type must be `u128`
+            // for this test to work. This is because we encode `Value::u128`
+            // in the `call_data`.
+            assert_type_eq_all!(Balance, u128);
+            let transfer_amount: u128 = 100_000_000_000;
 
             // when
             let call_data = vec![
                 // A value representing a `MultiAddress<AccountId32, _>`. We want the
                 // "Id" variant, and that will ultimately contain the
                 // bytes for our destination address
-                Value::unnamed_variant("Id", [Value::from_bytes(account_id)]),
+                Value::unnamed_variant("Id", [Value::from_bytes(contract.account_id)]),
                 // A value representing the amount we'd like to transfer.
                 Value::u128(transfer_amount),
             ];

--- a/integration-tests/public/payment-channel/lib.rs
+++ b/integration-tests/public/payment-channel/lib.rs
@@ -302,13 +302,13 @@ mod payment_channel {
             ink::env::test::set_caller(caller);
         }
 
-        fn set_account_balance(account: Address, balance: U256) {
-            ink::env::test::set_account_balance(account, balance);
+        fn set_contract_balance(addr: Address, balance: U256) {
+            ink::env::test::set_contract_balance(addr, balance);
         }
 
-        fn get_account_balance(account: Address) -> U256 {
-            ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(account)
-                .expect("Cannot get account balance")
+        fn get_contract_balance(addr: Address) -> U256 {
+            ink::env::test::get_contract_balance::<ink::env::DefaultEnvironment>(addr)
+                .expect("Cannot get contract balance")
         }
 
         fn advance_block() {
@@ -373,8 +373,8 @@ mod payment_channel {
             let initial_balance = 10_000.into();
             let close_duration = 360_000;
             let mock_deposit_value = 1_000.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(accounts.bob, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(accounts.bob, initial_balance);
 
             // when
             // Push the new execution context with Alice as the caller and
@@ -383,7 +383,7 @@ mod payment_channel {
             set_next_caller(accounts.alice);
             let payment_channel = PaymentChannel::new(accounts.bob, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
 
             // then
             assert_eq!(payment_channel.get_balance(), mock_deposit_value);
@@ -398,14 +398,14 @@ mod payment_channel {
             let mock_deposit_value = 1_000.into();
             let amount = 500.into();
             let initial_balance = 10_000.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(dan, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(dan, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let mut payment_channel = PaymentChannel::new(dan, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
             set_next_caller(dan);
             let signature = sign(contract_id, amount);
 
@@ -416,7 +416,7 @@ mod payment_channel {
                 accounts.alice,
                 amount,
             );
-            assert_eq!(get_account_balance(dan), initial_balance + amount);
+            assert_eq!(get_contract_balance(dan), initial_balance + amount);
         }
 
         #[ink::test]
@@ -429,14 +429,14 @@ mod payment_channel {
             let amount = 400.into();
             let unexpected_amount = amount + U256::from(1);
             let initial_balance = 10_000.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(dan, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(dan, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let mut payment_channel = PaymentChannel::new(dan, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
             set_next_caller(dan);
             let signature = sign(contract_id, amount);
 
@@ -455,14 +455,14 @@ mod payment_channel {
             let mock_deposit_value = 1_000.into();
             let close_duration = 360_000;
             let amount = 500.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(dan, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(dan, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let mut payment_channel = PaymentChannel::new(dan, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
 
             set_next_caller(dan);
             let signature = sign(contract_id, amount);
@@ -472,7 +472,7 @@ mod payment_channel {
 
             // then
             assert_eq!(payment_channel.get_balance(), amount);
-            assert_eq!(get_account_balance(dan), initial_balance + amount);
+            assert_eq!(get_contract_balance(dan), initial_balance + amount);
         }
 
         #[ink::test]
@@ -485,14 +485,14 @@ mod payment_channel {
             let amount = 400.into();
             let unexpected_amount = amount + U256::from(1);
             let mock_deposit_value = 1_000.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(dan, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(dan, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let mut payment_channel = PaymentChannel::new(dan, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
             set_next_caller(dan);
             let signature = sign(contract_id, amount);
 
@@ -509,14 +509,14 @@ mod payment_channel {
             let initial_balance = 10_000.into();
             let mock_deposit_value = 1_000.into();
             let close_duration = 1;
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(accounts.bob, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(accounts.bob, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let mut payment_channel = PaymentChannel::new(accounts.bob, close_duration);
             let contract_id = contract_id();
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
 
             payment_channel
                 .start_sender_close()
@@ -535,14 +535,14 @@ mod payment_channel {
             let initial_balance = 10_000.into();
             let close_duration = 1;
             let mock_deposit_value = 1_000.into();
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(accounts.bob, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(accounts.bob, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let contract_id = contract_id();
             let mut payment_channel = PaymentChannel::new(accounts.bob, close_duration);
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
 
             payment_channel
                 .start_sender_close()
@@ -557,7 +557,7 @@ mod payment_channel {
                 mock_deposit_value,
             );
             assert_eq!(
-                get_account_balance(accounts.alice),
+                get_contract_balance(accounts.alice),
                 initial_balance + mock_deposit_value
             );
         }
@@ -569,14 +569,14 @@ mod payment_channel {
             let initial_balance = 10_000.into();
             let mock_deposit_value = 1_000.into();
             let close_duration = 360_000;
-            set_account_balance(accounts.alice, initial_balance);
-            set_account_balance(accounts.bob, initial_balance);
+            set_contract_balance(accounts.alice, initial_balance);
+            set_contract_balance(accounts.bob, initial_balance);
 
             // when
             set_next_caller(accounts.alice);
             let contract_id = contract_id();
             let payment_channel = PaymentChannel::new(accounts.bob, close_duration);
-            set_account_balance(contract_id, mock_deposit_value);
+            set_contract_balance(contract_id, mock_deposit_value);
 
             // then
             assert_eq!(payment_channel.get_sender(), accounts.alice);

--- a/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
@@ -9,8 +9,16 @@ use ink::{
     },
 };
 use ink_e2e::{
+    Address,
+    BuilderClient,
+    ChainBackend,
+    ContractsBackend,
+    E2EBackend,
     PolkadotConfig,
+    SolDecode,
+    SolEncode,
     Weight,
+    primitives::DepositLimit,
     subxt::tx::Signer,
     subxt_signer,
 };
@@ -26,12 +34,12 @@ const DEFAULT_GAS: Weight = Weight::from_parts(100_000_000_000, 1024 * 1024);
 const DEFAULT_STORAGE_DEPOSIT_LIMIT: u128 = 10_000_000_000_000;
 type E2EResult<T> = Result<T, Box<dyn Error>>;
 
-#[ink_e2e::test]
 // TODO: (@davidsemakula) Re-enable when "no space left" CI issue is fixed
 // See https://github.com/use-ink/ink/issues/2458 for details.
 // This test consistently triggers the issue in CI when running `npm install` for hardhat
 // scripts.
 #[ignore]
+#[ink_e2e::test]
 async fn solidity_calls_ink_works<Client: E2EBackend>(
     mut client: Client,
 ) -> E2EResult<()> {
@@ -50,10 +58,12 @@ async fn solidity_calls_ink_works<Client: E2EBackend>(
     acc_bytes[..20].copy_from_slice(acc_id.as_ref());
 
     client
-        .api
-        .try_transfer_balance(
+        .transfer_allow_death(
             &ink_e2e::alice(),
-            ink_e2e::subxt::utils::AccountId32::from(acc_bytes),
+            <ink::env::DefaultEnvironment as ink::env::Environment>::AccountId::from(
+                acc_bytes,
+            ),
+            // 10_000_000_000_000_000,
             1_000_000_000_000_000,
         )
         .await?;
@@ -61,15 +71,17 @@ async fn solidity_calls_ink_works<Client: E2EBackend>(
     let signer = ink_e2e::alice();
 
     // deploy ink! flipper (Sol encoded)
-    client.api.map_account(&signer).await;
+    let _ = client.map_account(&signer).await;
+    let input = exec_input.encode();
+    let storage_deposit_limit: Balance = 10_00_000_000_000_000_000;
     let ink_addr = client
         .exec_instantiate(
             &signer,
-            client.contracts.load_code("flipper"),
-            exec_input.encode(),
+            "flipper",
+            input,
             0,
             DEFAULT_GAS,
-            DEFAULT_STORAGE_DEPOSIT_LIMIT,
+            storage_deposit_limit,
         )
         .await?
         .addr;
@@ -114,20 +126,17 @@ async fn solidity_calls_ink_works<Client: E2EBackend>(
 
     let encoded = encode_ink_call("call_solidity_set(address)", sol_addr_encoded.clone());
     let encoded_get = encode_ink_call("call_solidity_get(address)", sol_addr_encoded);
-    assert_eq!(
-        call_ink::<u16>(&mut client, ink_addr, encoded_get.clone()).await,
-        42
-    );
+    let ret: u16 = call_ink(&mut client, ink_addr, encoded_get.clone()).await;
+    assert_eq!(ret, 42);
     call_ink_no_return(&mut client, ink_addr, encoded).await;
     // set_value uses hardcoded 77 for simplicity.
-    assert_eq!(
-        call_ink::<u16>(&mut client, ink_addr, encoded_get.clone()).await,
-        77
-    );
+    let ret: u16 = call_ink(&mut client, ink_addr, encoded_get.clone()).await;
+    assert_eq!(ret, 77);
 
     Ok(())
 }
 
+use ink::env::Environment;
 async fn call_ink<Ret>(
     client: &mut ink_e2e::Client<PolkadotConfig, DefaultEnvironment>,
     ink_addr: Address,
@@ -137,19 +146,19 @@ where
     Ret: SolDecode,
 {
     let signer = ink_e2e::alice();
-    let (exec_result, _trace) = client
-        .api
-        .call_dry_run(
-            <ink_e2e::Keypair as Signer<PolkadotConfig>>::account_id(&signer),
+    let exec_result = client
+        .raw_call_dry_run::<Vec<u8>, ink::abi::Sol>(
             ink_addr,
             data_sol,
-            0,
+            0u32.into(),
             ink::primitives::DepositLimit::UnsafeOnlyForDryRun,
             &signer,
         )
-        .await;
-
-    <Ret>::decode(&exec_result.result.unwrap().data[..]).expect("decode failed")
+        .await
+        .map_err(|_| "foo")
+        .unwrap(); // todo
+    <Ret>::decode(&exec_result.exec_result.result.unwrap().data[..])
+        .expect("decode failed")
 }
 
 async fn call_ink_no_return(
@@ -158,14 +167,14 @@ async fn call_ink_no_return(
     data_sol: Vec<u8>,
 ) {
     let signer = ink_e2e::alice();
+    let storage_deposit_limit: Balance = 10_000_000_000_000;
     let _ = client
-        .api
-        .call(
+        .raw_call(
             ink_addr,
+            data_sol,
             Balance::from(0u128),
             DEFAULT_GAS.into(),
-            DEFAULT_STORAGE_DEPOSIT_LIMIT,
-            data_sol,
+            DepositLimit::Balance(storage_deposit_limit),
             &signer,
         )
         .await;

--- a/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
@@ -151,8 +151,7 @@ where
             &signer,
         )
         .await
-        .map_err(|_| "foo")
-        .unwrap(); // todo
+        .expect("dry run failed");
     <Ret>::decode(&exec_result.exec_result.result.unwrap().data[..])
         .expect("decode failed")
 }
@@ -163,14 +162,13 @@ async fn call_ink_no_return(
     data_sol: Vec<u8>,
 ) {
     let signer = ink_e2e::alice();
-    let storage_deposit_limit: Balance = 10_000_000_000_000;
     let _ = client
         .raw_call(
             ink_addr,
             data_sol,
             Balance::from(0u128),
             DEFAULT_GAS.into(),
-            DepositLimit::Balance(storage_deposit_limit),
+            DepositLimit::Balance(Balance::MAX),
             &signer,
         )
         .await;

--- a/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
@@ -7,18 +7,15 @@ use ink::{
         Balance,
         DefaultEnvironment,
     },
+    primitives::DepositLimit,
 };
 use ink_e2e::{
-    Address,
     BuilderClient,
     ChainBackend,
     ContractsBackend,
     E2EBackend,
     PolkadotConfig,
-    SolDecode,
-    SolEncode,
     Weight,
-    primitives::DepositLimit,
     subxt::tx::Signer,
     subxt_signer,
 };

--- a/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/e2e_tests.rs
@@ -60,7 +60,6 @@ async fn solidity_calls_ink_works<Client: E2EBackend>(
             <ink::env::DefaultEnvironment as ink::env::Environment>::AccountId::from(
                 acc_bytes,
             ),
-            // 10_000_000_000_000_000,
             1_000_000_000_000_000,
         )
         .await?;

--- a/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
@@ -19,7 +19,8 @@ pub mod flipper {
         /// Creates a new flipper smart contract initialized with the given value.
         #[ink(constructor)]
         pub fn new(init_value: bool) -> Self {
-            Self { value: init_value }
+            assert!(init_value == false);
+            Self { value: false }
         }
 
         // solidity compatible selector (`keccack256("flip()")`)

--- a/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
@@ -19,8 +19,7 @@ pub mod flipper {
         /// Creates a new flipper smart contract initialized with the given value.
         #[ink(constructor)]
         pub fn new(init_value: bool) -> Self {
-            assert!(!init_value);
-            Self { value: false }
+            Self { value: init_value }
         }
 
         // solidity compatible selector (`keccack256("flip()")`)

--- a/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
+++ b/integration-tests/solidity-abi/solidity-calls-flipper/lib.rs
@@ -19,7 +19,7 @@ pub mod flipper {
         /// Creates a new flipper smart contract initialized with the given value.
         #[ink(constructor)]
         pub fn new(init_value: bool) -> Self {
-            assert!(init_value == false);
+            assert!(!init_value);
             Self { value: false }
         }
 


### PR DESCRIPTION
Adding a number of quality of life improvements and cleanups.

* New methods for the E2E API (`ChainBackend`). Available for Sandbox and the "real" E2E tests. Notably:
  * `transfer_allow_death`
  * `raw_call`
  * `raw_call_dry_run`
  * `raw_instantiate`
  * `to_account_id`
  * The `raw_*` methods take arbitrary `Vec<u8>`, allowing for using the E2E tests with any language that compiles to PolkaVM.
* Improved debugging. Traces of a failed extrinsic are automatically returned and printed, which helps immensely to figure out what went wrong.
* E2E API: new methods for account-address handling. Notably:
  * `address_from_account_id`
  * `address_from_keypair`
  * `keypair_to_account`
* Solve some todo comments,
* Remove some outdated todo comments,
* Rename the term `account` to `contract` where appropriate. 