### PR TITLE
Improve abstractions for Solidity ABI encoding `Result` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Error on message and constructor `selector` overrides in Solidity ABI mode - [#2638](https://github.com/use-ink/ink/pull/2638)
+- Improve abstractions for Solidity ABI encoding `Result` types - [#2635](https://github.com/use-ink/ink/pull/2635)
 
 ### Fixed
 - Bring intended panic handler behavior back ‒ [2636](https://github.com/use-ink/ink/pull/2636)

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -431,7 +431,7 @@ where
 ///
 /// # Note
 ///
-/// This function  stops the execution of the contract immediately.
+/// This function stops the execution of the contract immediately.
 #[cfg(not(feature = "std"))]
 pub fn return_value<R>(return_flags: ReturnFlags, return_value: &R) -> !
 where
@@ -462,7 +462,7 @@ where
 ///
 /// # Note
 ///
-/// This function  stops the execution of the contract immediately.
+/// This function stops the execution of the contract immediately.
 pub fn return_value_solidity<R>(return_flags: ReturnFlags, return_value: &R) -> !
 where
     R: for<'a> SolResultEncode<'a>,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -17,9 +17,9 @@
 use ink_primitives::{
     Address,
     H256,
-    SolEncode,
     U256,
     abi::AbiEncodeWith,
+    sol::SolResultEncode,
 };
 use ink_storage_traits::Storable;
 use pallet_revive_uapi::ReturnFlags;
@@ -465,7 +465,7 @@ where
 /// This function  stops the execution of the contract immediately.
 pub fn return_value_solidity<R>(return_flags: ReturnFlags, return_value: &R) -> !
 where
-    R: for<'a> SolEncode<'a>,
+    R: for<'a> SolResultEncode<'a>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         EnvBackend::return_value_solidity::<R>(instance, return_flags, return_value)

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -15,9 +15,9 @@
 use ink_primitives::{
     Address,
     H256,
-    SolEncode,
     U256,
     abi::AbiEncodeWith,
+    sol::SolResultEncode,
     types::Environment,
 };
 use ink_storage_traits::Storable;
@@ -146,10 +146,15 @@ pub trait EnvBackend {
     where
         R: scale::Encode;
 
-    /// todo: comment
+    /// Returns the *Solidity ABI encoded* value back to the caller of the executed
+    /// contract.
+    ///
+    /// # Note
+    ///
+    /// This function  stops the execution of the contract immediately.
     fn return_value_solidity<R>(&mut self, flags: ReturnFlags, return_value: &R) -> !
     where
-        R: for<'a> SolEncode<'a>;
+        R: for<'a> SolResultEncode<'a>;
 
     /// Conducts the crypto hash of the given input and stores the result in `output`.
     fn hash_bytes<H>(&mut self, input: &[u8], output: &mut <H as HashOutput>::Type)

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -151,7 +151,7 @@ pub trait EnvBackend {
     ///
     /// # Note
     ///
-    /// This function  stops the execution of the contract immediately.
+    /// This function stops the execution of the contract immediately.
     fn return_value_solidity<R>(&mut self, flags: ReturnFlags, return_value: &R) -> !
     where
         R: for<'a> SolResultEncode<'a>;

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -16,13 +16,13 @@ use ink_engine::ext::Engine;
 use ink_primitives::{
     Address,
     H256,
-    SolEncode,
     U256,
     abi::{
         AbiEncodeWith,
         Ink,
         Sol,
     },
+    sol::SolResultEncode,
     types::{
         AccountIdMapper,
         Environment,
@@ -429,7 +429,7 @@ impl EnvBackend for EnvInstance {
 
     fn return_value_solidity<R>(&mut self, _flags: ReturnFlags, _return_value: &R) -> !
     where
-        R: for<'a> SolEncode<'a>,
+        R: for<'a> SolResultEncode<'a>,
     {
         unimplemented!("the off-chain env does not implement `return_value_solidity`")
     }

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -15,13 +15,13 @@
 use ink_primitives::{
     Address,
     H256,
-    SolEncode,
     U256,
     abi::{
         AbiEncodeWith,
         Ink,
         Sol,
     },
+    sol::SolResultEncode,
 };
 use ink_storage_traits::{
     Storable,
@@ -746,7 +746,7 @@ impl EnvBackend for EnvInstance {
 
     fn return_value_solidity<R>(&mut self, flags: ReturnFlags, return_value: &R) -> !
     where
-        R: for<'a> SolEncode<'a>,
+        R: for<'a> SolResultEncode<'a>,
     {
         let encoded = return_value.encode();
         ext::return_value(flags, &encoded[..]);

--- a/crates/ink/codegen/src/generator/sol/utils.rs
+++ b/crates/ink/codegen/src/generator/sol/utils.rs
@@ -41,11 +41,11 @@ pub fn sol_type(ty: &Type) -> TokenStream2 {
 /// # Note
 ///
 /// Use this function (instead of [`sol_type`]) when return type may be `Result<T, E>`,
-/// because `Result<T, E>` implements `ink::SolEncode` but doesn't implement
-/// `ink::SolDecode`.
+/// because `Result<T, E>` doesn't implement `ink::SolEncode` nor `ink::SolDecode`,
+/// but instead implements `ink::sol::SolResultEncode` and `ink::sol::SolResultDecode`.
 pub fn sol_return_type(ty: &Type) -> TokenStream2 {
     quote! {
-        <#ty as ::ink::SolEncode>::SOL_NAME
+        <#ty as ::ink::sol::SolResultEncode>::SOL_NAME
     }
 }
 

--- a/crates/ink/src/codegen/dispatch/type_check.rs
+++ b/crates/ink/src/codegen/dispatch/type_check.rs
@@ -14,7 +14,7 @@
 
 use ink_primitives::{
     SolDecode,
-    SolEncode,
+    sol::SolResultEncode,
 };
 
 /// Used to check if `T` is allowed as ink! input parameter type.
@@ -105,8 +105,9 @@ where
 ///
 /// # Note
 ///
-/// An ink! input parameter type must implement [`ink::SolEncode`][crate::SolEncode]
-/// and must have a `'static` lifetime.
+/// An ink! input parameter type must implement
+/// [`ink::sol::SolResultEncode`][crate::sol::SolResultEncode] and must have a `'static`
+/// lifetime.
 ///
 /// # Example
 ///
@@ -127,4 +128,4 @@ where
 /// ```
 pub struct DispatchOutputSol<T>(T)
 where
-    T: for<'a> SolEncode<'a> + 'static;
+    T: for<'a> SolResultEncode<'a> + 'static;

--- a/crates/ink/tests/ui/abi/sol/pass/message-return-type.rs
+++ b/crates/ink/tests/ui/abi/sol/pass/message-return-type.rs
@@ -1,6 +1,6 @@
 #![allow(unexpected_cfgs)]
 
-#[derive(ink::SolErrorDecode, ink::SolErrorEncode)]
+#[ink::error]
 pub struct Error;
 
 #[ink::contract]

--- a/crates/primitives/src/sol.rs
+++ b/crates/primitives/src/sol.rs
@@ -62,6 +62,7 @@ pub use self::{
     result::{
         SolResultDecode,
         SolResultDecodeError,
+        SolResultEncode,
     },
     types::{
         SolTopicEncode,


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/ink/pull/2543
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

https://github.com/use-ink/ink/pull/2543 introduced a `SolResultDecode` trait to "describe how to decode Solidity ABI encoded data into an arbitrary Rust type depending on whether the data is for a normal/successful return or a revert".

However, in that PR no complementary `SolResultEncode` trait was introduced, instead `SolEncode` was implemented for `Result<T, E>` where `T: SolEncode` and `E: SolErrorEncode`. That `SolEncode` implementation for `Result<T, E>` is misleading because it gives the appearance of composability when the actual implementation is not actually composable (i.e. Solidity ABI encoding for `Result` types is only supported for `Result` types in the return position of ink! messages and constructors, not in compositions of arbitrarily complex types - [see details](https://use.ink/docs/v6/background/solidity-metamask-compatibility/#handling-the-resultt-e-type)).

This PR introduces the complementary `SolResultEncode` trait, and removes the misleading implementation of `SolEncode` for `Result<T, E>` such that:
- `SolResultEncode` is generically implemented for all `T: SolEncode`
- `SolResultEncode` is also implemented for `Result<T, E>` where `T: SolEncode` and `E: SolErrorDecode`

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
