### PR TITLE
Correctify panic behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add integration test for arithmetic overflow checks - [#2631](https://github.com/use-ink/ink/pull/2631)
 - E2E: Misc quality of life improvements, new API functions, better debuggability ‒ [2634](https://github.com/use-ink/ink/pull/2634)
 
+### Fixed
+- Bring intended panic handler behavior back ‒ [2636](https://github.com/use-ink/ink/pull/2636)
+
 ## Version 6.0.0-alpha.3
 
 Compatibility of this release:

--- a/crates/env/src/engine/on_chain/pallet_revive.rs
+++ b/crates/env/src/engine/on_chain/pallet_revive.rs
@@ -737,7 +737,11 @@ impl EnvBackend for EnvInstance {
         let mut scope = EncodeScope::from(&mut self.buffer[..]);
         return_value.encode_to(&mut scope);
         let len = scope.len();
-        ext::return_value(flags, &self.buffer[..][..len]);
+        if len == 0 {
+            ext::return_value(flags, &[]);
+        } else {
+            ext::return_value(flags, &self.buffer[..][..len]);
+        }
     }
 
     fn return_value_solidity<R>(&mut self, flags: ReturnFlags, return_value: &R) -> !

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -55,27 +55,20 @@ pub const BUFFER_SIZE: usize = 16384;
 #[cfg(target_arch = "riscv64")]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    // todo
-    //#[cfg(any(feature = "ink-debug", feature = "std"))]
+    // In case the contract is build in debug-mode, we return the
+    // panic message as a payload by triggering a contract revert.
+    #[cfg(any(feature = "ink-debug", feature = "std"))]
     self::return_value(
         ReturnFlags::REVERT,
         &ink_prelude::format!("{}", info.message()).as_bytes(),
     );
 
-    /*
-    #[cfg(not(any(feature = "ink-debug", feature = "std")))]
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "riscv64")] {
-            // Safety: The unimp instruction is guaranteed to trap
-            unsafe {
-                core::arch::asm!("unimp");
-                core::hint::unreachable_unchecked();
-            }
-        } else {
-            core::compile_error!("ink! only supports riscv64");
-        }
-    }
-    */
+    // If contract is compiled with `cargo contract --release`, it will
+    // for efficiency reasons be build with `panic_immediate_abort`.
+    // This panic handler will thus never be invoked.
+    unreachable!(
+        "contract in non-debug/non-std mode needs to be build with `panic_immediate_abort`"
+    );
 }
 
 // This extern crate definition is required since otherwise rustc


### PR DESCRIPTION
Makes sure that the panic message is only written to the revert buffer when the contract is compiled in debug mode.

Debug mode is the default when building via `cargo contract build`. Release builds are done via `cargo contract build --release`; for efficiency reasons they contain only what is strictly necessary.

Escalated from https://github.com/use-ink/cargo-contract/issues/2105.