### PR TITLE
chore: Error on message and constructor `selector` overrides in Solidity ABI mode

### DIFF
--- a/crates/ink/ir/src/ir/item_impl/constructor.rs
+++ b/crates/ink/ir/src/ir/item_impl/constructor.rs
@@ -173,6 +173,16 @@ impl TryFrom<syn::ImplItemFn> for Constructor {
         let is_default = ink_attrs.is_default();
         let selector = ink_attrs.selector();
         let name = ink_attrs.name();
+        #[cfg(ink_abi = "sol")]
+        if selector.is_some() {
+            let selector_span = ink_attrs.args().find_map(|arg| {
+                matches!(arg.kind(), ir::AttributeArg::Selector(_)).then_some(arg.span())
+            });
+            return Err(format_err!(
+                selector_span.unwrap_or_else(|| method_item.span()),
+                "constructor `selector` attributes are not supported in Solidity ABI compatibility mode",
+            ));
+        }
         Ok(Constructor {
             selector,
             is_payable,

--- a/crates/ink/ir/src/ir/item_impl/message.rs
+++ b/crates/ink/ir/src/ir/item_impl/message.rs
@@ -227,6 +227,16 @@ impl TryFrom<syn::ImplItemFn> for Message {
                 "ink! messages with a `payable` attribute argument must have a `&mut self` receiver",
             ));
         }
+        #[cfg(ink_abi = "sol")]
+        if selector.is_some() {
+            let selector_span = ink_attrs.args().find_map(|arg| {
+                matches!(arg.kind(), ir::AttributeArg::Selector(_)).then_some(arg.span())
+            });
+            return Err(format_err!(
+                selector_span.unwrap_or_else(|| method_item.span()),
+                "message `selector` attributes are not supported in Solidity ABI compatibility mode",
+            ));
+        }
         Ok(Self {
             is_payable,
             is_default,

--- a/crates/ink/tests/ui/abi/all/pass/message-selector-encoding-args.rs
+++ b/crates/ink/tests/ui/abi/all/pass/message-selector-encoding-args.rs
@@ -16,10 +16,10 @@ mod contract {
         #[ink(message)]
         pub fn message_0(&self, _input_1: bool) {}
 
-        #[ink(message)]
+        #[ink(message, selector = 1)]
         pub fn message_1(&self, _input_1: u8) {}
 
-        #[ink(message)]
+        #[ink(message, selector = 0xC0DE_CAFE)]
         pub fn message_2(&self, _input_1: ink::sol::FixedBytes<32>) {}
 
         #[ink(message)]
@@ -28,12 +28,12 @@ mod contract {
 
     #[ink::trait_definition]
     pub trait Messages {
-        #[ink(message)]
+        #[ink(message, selector = 0x12345678)]
         fn message_4(&self, _input_1: ink::sol::DynBytes);
     }
 
     impl Messages for Contract {
-        #[ink(message)]
+        #[ink(message, selector = 0x12345678)]
         fn message_4(&self, _input_1: ink::sol::DynBytes) {}
     }
 
@@ -59,42 +59,77 @@ mod contract {
 }
 
 fn main() {
+    // ink! inherent `blake2bx256(message_0)` == `0x5a6ac15d`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x5a6ac15d_u32>>::SELECTOR,
+        [0x5a, 0x6a, 0xc1, 0x5d],
+    );
     // `keccak256("message_0(bool)")` == `0xc58b7175`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0xc58b7175_u32>>::SELECTOR,
         [0xc5, 0x8b, 0x71, 0x75],
     );
 
+    // ink! `message_1` user-provided
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<1_u32>>::SELECTOR,
+        1_u32.to_be_bytes(),
+    );
     // `keccak256("message_1(uint8)")` == `0xe4634c56`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0xe4634c56_u32>>::SELECTOR,
         [0xe4, 0x63, 0x4c, 0x56],
     );
 
+    // ink! `message_2` user-provided
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xC0DE_CAFE_u32>>::SELECTOR,
+        0xC0DE_CAFE_u32.to_be_bytes(),
+    );
     // `keccak256("message_2(bytes32)")` == `0x468f916c`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x468f916c_u32>>::SELECTOR,
         [0x46, 0x8f, 0x91, 0x6c],
     );
 
+    // ink! inherent `blake2bx256(message_3)` == `0xB6C32749`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0xB6C32749_u32>>::SELECTOR,
+        [0xB6, 0xC3, 0x27, 0x49],
+    );
     // `keccak256("message_3(bool,int8)")` == `0xf4bf21e5`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0xf4bf21e5_u32>>::SELECTOR,
         [0xf4, 0xbf, 0x21, 0xe5],
     );
 
+    // ink! `message_4` user-provided
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x12345678_u32>>::SELECTOR,
+        0x12345678_u32.to_be_bytes(),
+    );
     // `keccak256("message_4(bytes)")` == `0x0e59eb1b`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x0e59eb1b_u32>>::SELECTOR,
         [0x0e, 0x59, 0xeb, 0x1b],
     );
 
+    // ink! inherent `blake2bx256(message_5)` == `0x9d94584e`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x9d94584e_u32>>::SELECTOR,
+        [0x9d, 0x94, 0x58, 0x4e],
+    );
     // `keccak256("message_5(string)")` == `0x596379bc`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0x596379bc_u32>>::SELECTOR,
         [0x59, 0x63, 0x79, 0xbc],
     );
 
+    // ink! inherent `blake2bx256(message_6)` == `0x5ac7babb`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x5ac7babb_u32>>::SELECTOR,
+        [0x5a, 0xc7, 0xba, 0xbb],
+    );
     // `keccak256("message_6(bool,string,bytes32,bytes,uint8[4],uint8[])")` ==
     // `0xc02c314c`
     assert_eq!(
@@ -102,6 +137,11 @@ fn main() {
         [0xc0, 0x2c, 0x31, 0x4c],
     );
 
+    // ink! inherent `blake2bx256(message_7)` == `0x09caadd8`
+    assert_eq!(
+        <Contract as ::ink::reflect::DispatchableMessageInfo<0x09caadd8_u32>>::SELECTOR,
+        [0x09, 0xca, 0xad, 0xd8],
+    );
     // `keccak256("message_7(bytes32,bytes32,address)")` == `0xee34840f`
     assert_eq!(
         <Contract as ::ink::reflect::DispatchableMessageInfo<0xee34840f_u32>>::SELECTOR,

--- a/crates/ink/tests/ui/abi/sol/pass/message-selector-encoding.rs
+++ b/crates/ink/tests/ui/abi/sol/pass/message-selector-encoding.rs
@@ -12,7 +12,7 @@ mod contract {
         #[ink(message)]
         fn message_0(&self);
 
-        #[ink(message, selector = 1)]
+        #[ink(message)]
         fn message_1(&self);
     }
 
@@ -20,7 +20,7 @@ mod contract {
         #[ink(message)]
         fn message_0(&self) {}
 
-        #[ink(message, selector = 1)]
+        #[ink(message)]
         fn message_1(&self) {}
     }
 
@@ -30,7 +30,7 @@ mod contract {
             Self {}
         }
 
-        #[ink(message, selector = 0xC0DE_CAFE)]
+        #[ink(message)]
         pub fn message_2(&self) {}
 
         #[ink(message)]
@@ -39,12 +39,12 @@ mod contract {
 
     #[ink::trait_definition]
     pub trait Messages2 {
-        #[ink(message, selector = 0x12345678)]
+        #[ink(message)]
         fn message_4(&self);
     }
 
     impl Messages2 for Contract {
-        #[ink(message, selector = 0x12345678)]
+        #[ink(message)]
         fn message_4(&self) {}
     }
 }


### PR DESCRIPTION
## Summary
Closes https://github.com/use-ink/ink/issues/2620
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
