### PR TITLE
chore: ui tests for disallowing selector overrides in Solidity ABI mode

### DIFF
--- a/crates/ink/tests/ui/abi/sol/fail/constructor-selector-overrides.rs
+++ b/crates/ink/tests/ui/abi/sol/fail/constructor-selector-overrides.rs
@@ -1,0 +1,19 @@
+#![allow(unexpected_cfgs)]
+
+#[ink::contract]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor, selector = 1)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/abi/sol/fail/constructor-selector-overrides.stderr
+++ b/crates/ink/tests/ui/abi/sol/fail/constructor-selector-overrides.stderr
@@ -1,0 +1,5 @@
+error: constructor `selector` attributes are not supported in Solidity ABI compatibility mode
+ --> tests/ui/abi/sol/fail/constructor-selector-overrides.rs:9:28
+  |
+9 |         #[ink(constructor, selector = 1)]
+  |                            ^^^^^^^^^^^^

--- a/crates/ink/tests/ui/abi/sol/fail/message-selector-overrides.rs
+++ b/crates/ink/tests/ui/abi/sol/fail/message-selector-overrides.rs
@@ -1,0 +1,19 @@
+#![allow(unexpected_cfgs)]
+
+#[ink::contract]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message, selector = 1)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/abi/sol/fail/message-selector-overrides.stderr
+++ b/crates/ink/tests/ui/abi/sol/fail/message-selector-overrides.stderr
@@ -1,0 +1,5 @@
+error: message `selector` attributes are not supported in Solidity ABI compatibility mode
+  --> tests/ui/abi/sol/fail/message-selector-overrides.rs:14:24
+   |
+14 |         #[ink(message, selector = 1)]
+   |                        ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/ink/pull/2638
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
Adds missed UI tests

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
