### PR TITLE
fix: Support `name` attribute in trait definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bring intended panic handler behavior back ‒ [2636](https://github.com/use-ink/ink/pull/2636)
+- Support `name` attribute in trait definitions - [#2644](https://github.com/use-ink/ink/pull/2644)
 
 ## Version 6.0.0-alpha.3
 

--- a/crates/ink/ir/src/ir/trait_def/item/trait_item.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/trait_item.rs
@@ -97,7 +97,8 @@ impl<'a> InkTraitMessage<'a> {
                     ir::AttributeArg::Message
                     | ir::AttributeArg::Payable
                     | ir::AttributeArg::Default
-                    | ir::AttributeArg::Selector(_) => Ok(()),
+                    | ir::AttributeArg::Selector(_)
+                    | ir::AttributeArg::Name(_) => Ok(()),
                     _ => Err(None),
                 }
             },

--- a/crates/ink/ir/src/ir/trait_def/tests.rs
+++ b/crates/ink/ir/src/ir/trait_def/tests.rs
@@ -382,6 +382,19 @@ fn trait_def_with_payable_ok() {
 }
 
 #[test]
+fn trait_def_with_name_override_ok() {
+    assert!(
+        <InkItemTrait as TryFrom<syn::ItemTrait>>::try_from(syn::parse_quote! {
+            pub trait MyTrait {
+                #[ink(message, name = "myMessage")]
+                fn my_message(&self);
+            }
+        })
+        .is_ok()
+    )
+}
+
+#[test]
 fn trait_def_with_everything_combined_ok() {
     assert!(
         <InkItemTrait as TryFrom<syn::ItemTrait>>::try_from(syn::parse_quote! {
@@ -391,12 +404,20 @@ fn trait_def_with_everything_combined_ok() {
                 fn my_message_1(&self);
                 #[ink(message, selector = 0xDEADBEEF)]
                 fn my_message_2(&self);
+                #[ink(message, name = "myMessage3")]
+                fn my_message_3(&self);
+                #[ink(message, selector = 0xDEADC0DE, name = "myMessage4")]
+                fn my_message_4(&self);
                 #[ink(message)]
                 fn my_message_mut_1(&mut self);
                 #[ink(message, payable)]
                 fn my_message_mut_2(&mut self);
                 #[ink(message, payable, selector = 0xC0DEBEEF)]
                 fn my_message_mut_3(&mut self);
+                #[ink(message, payable, name = "myMessageMut4")]
+                fn my_message_mut_4(&mut self);
+                #[ink(message, payable, selector = 0xC0DECAFE, name = "myMessageMut5")]
+                fn my_message_mut_5(&mut self);
             }
         })
         .is_ok()

--- a/crates/ink/tests/ui/trait_def/pass/message-name-override-namespace.rs
+++ b/crates/ink/tests/ui/trait_def/pass/message-name-override-namespace.rs
@@ -1,0 +1,32 @@
+use ink::{
+    reflect::{
+        TraitDefinitionRegistry,
+        TraitMessageInfo,
+    },
+    selector_bytes,
+    selector_id,
+};
+use ink_env::DefaultEnvironment;
+
+#[ink::trait_definition(namespace = "foo")]
+pub trait TraitDefinition {
+    #[ink(message, name = "myMessage")]
+    fn message(&self);
+}
+
+fn main() {
+    macro_rules! assert_selector_eq {
+        ( $message_id:literal, $expected_selector:expr $(,)? ) => {
+            assert_eq!(
+                <<TraitDefinitionRegistry<DefaultEnvironment> as TraitDefinition>::__ink_TraitInfo
+                    as TraitMessageInfo<{selector_id!($message_id)}>>::SELECTOR,
+                    $expected_selector
+            );
+        }
+    }
+
+    assert_selector_eq!(
+        "message",
+        selector_bytes!("foo::TraitDefinition::myMessage"),
+    );
+}

--- a/crates/ink/tests/ui/trait_def/pass/message-name-override.rs
+++ b/crates/ink/tests/ui/trait_def/pass/message-name-override.rs
@@ -25,8 +25,5 @@ fn main() {
         }
     }
 
-    assert_selector_eq!(
-        "message",
-        selector_bytes!("TraitDefinition::myMessage"),
-    );
+    assert_selector_eq!("message", selector_bytes!("TraitDefinition::myMessage"),);
 }

--- a/crates/ink/tests/ui/trait_def/pass/message-name-override.rs
+++ b/crates/ink/tests/ui/trait_def/pass/message-name-override.rs
@@ -1,0 +1,32 @@
+use ink::{
+    reflect::{
+        TraitDefinitionRegistry,
+        TraitMessageInfo,
+    },
+    selector_bytes,
+    selector_id,
+};
+use ink_env::DefaultEnvironment;
+
+#[ink::trait_definition]
+pub trait TraitDefinition {
+    #[ink(message, name = "myMessage")]
+    fn message(&self);
+}
+
+fn main() {
+    macro_rules! assert_selector_eq {
+        ( $message_id:literal, $expected_selector:expr $(,)? ) => {
+            assert_eq!(
+                <<TraitDefinitionRegistry<DefaultEnvironment> as TraitDefinition>::__ink_TraitInfo
+                    as TraitMessageInfo<{selector_id!($message_id)}>>::SELECTOR,
+                    $expected_selector
+            );
+        }
+    }
+
+    assert_selector_eq!(
+        "message",
+        selector_bytes!("TraitDefinition::myMessage"),
+    );
+}

--- a/crates/ink/tests/ui/trait_def/pass/message-selector-precedence.rs
+++ b/crates/ink/tests/ui/trait_def/pass/message-selector-precedence.rs
@@ -1,0 +1,28 @@
+use ink::{
+    reflect::{
+        TraitDefinitionRegistry,
+        TraitMessageInfo,
+    },
+    selector_id,
+};
+use ink_env::DefaultEnvironment;
+
+#[ink::trait_definition]
+pub trait TraitDefinition {
+    #[ink(message, name = "myMessage", selector = 1)]
+    fn message(&self);
+}
+
+fn main() {
+    macro_rules! assert_selector_eq {
+        ( $message_id:literal, $expected_selector:expr $(,)? ) => {
+            assert_eq!(
+                <<TraitDefinitionRegistry<DefaultEnvironment> as TraitDefinition>::__ink_TraitInfo
+                    as TraitMessageInfo<{selector_id!($message_id)}>>::SELECTOR,
+                    $expected_selector
+            );
+        }
+    }
+
+    assert_selector_eq!("message", [0, 0, 0, 1]);
+}


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/ink/pull/2577

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
