### PR TITLE
Use `#[ink::error]` in integration tests

### DIFF
--- a/integration-tests/public/dns/lib.rs
+++ b/integration-tests/public/dns/lib.rs
@@ -82,7 +82,7 @@ mod dns {
 
     /// Errors that can occur upon calling this contract.
     #[derive(Debug, PartialEq, Eq)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         /// Returned if the name already exists upon registration.
         NameAlreadyExists,

--- a/integration-tests/public/erc1155/lib.rs
+++ b/integration-tests/public/erc1155/lib.rs
@@ -28,7 +28,7 @@ pub type TokenId = u128;
 
 // The ERC-1155 error types.
 #[derive(Debug, PartialEq, Eq)]
-#[ink::scale_derive(Encode, Decode, TypeInfo)]
+#[ink::error]
 pub enum Error {
     /// This token ID has not yet been created by the contract.
     UnexistentToken,

--- a/integration-tests/public/erc20/lib.rs
+++ b/integration-tests/public/erc20/lib.rs
@@ -43,7 +43,7 @@ mod erc20 {
 
     /// The ERC-20 error types.
     #[derive(Debug, PartialEq, Eq)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         /// Returned if not enough balance to fulfill a request is available.
         InsufficientBalance,

--- a/integration-tests/public/erc721/lib.rs
+++ b/integration-tests/public/erc721/lib.rs
@@ -73,7 +73,7 @@ mod erc721 {
     }
 
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         NotOwner,
         NotApproved,

--- a/integration-tests/public/multisig/lib.rs
+++ b/integration-tests/public/multisig/lib.rs
@@ -137,7 +137,7 @@ mod multisig {
 
     /// Errors that can occur upon calling this contract.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         /// Returned if the call failed.
         TransactionFailed,

--- a/integration-tests/public/payment-channel/lib.rs
+++ b/integration-tests/public/payment-channel/lib.rs
@@ -65,7 +65,7 @@ mod payment_channel {
 
     /// Errors that can occur upon calling this contract.
     #[derive(Debug, PartialEq, Eq)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         /// Returned if caller is not the `sender` while required to.
         CallerIsNotSender,

--- a/integration-tests/public/trait-erc20/lib.rs
+++ b/integration-tests/public/trait-erc20/lib.rs
@@ -9,7 +9,7 @@ mod erc20 {
 
     /// The ERC-20 error types.
     #[derive(Debug, PartialEq, Eq)]
-    #[ink::scale_derive(Encode, Decode, TypeInfo)]
+    #[ink::error]
     pub enum Error {
         /// Returned if not enough balance to fulfill a request is available.
         InsufficientBalance,


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

- Allows to easily change the ABI in CI for integration tests

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
