### PR TITLE
Fix typo in ARCHITECTURE.md: "Ann" to "An"

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,7 +108,7 @@ recommend using our build tool [`cargo-contract`](https://github.com/use-ink/car
 It automatically compiles for the correct PolkaVM target
 architecture and uses an optimal set of compiler flags.
 
-Ann approximation of the build command it will execute is:
+An approximation of the build command it will execute is:
 
 ```bash
 cd ink/integration-tests/public/flipper/


### PR DESCRIPTION
I found a slight typo in this line: "Ann approximation of the build command it will execute is:" It should be "An approximation of the build command it will execute is:"

## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [x] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
