### PR TITLE
fix: command parsing so it actually runs the right thing

### DIFF
--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -52,8 +52,6 @@ EXAMPLES
 EOF
 }
 
-command=( "${@:2}" )
-
 options=$(getopt -o p:o:i:q --long path:,output:,ignore:,quiet,partition: -- "$@")
 [ $? -eq 0 ] || {
     >&2 echo "Incorrect option provided"
@@ -99,7 +97,7 @@ while true; do
     shift
 done
 
-command=("${@}")
+command=("$@")
 
 if ([ "$partitioning" = true ] && \
   (! [[ "$m" =~ ^[0-9]+$ ]] || ! [[ "$n" =~ ^[0-9]+$ ]] || [ "$m" -gt "$n" ] || [ "$m" -le 0 ] || [ "$n" -le 0 ])) || \
@@ -203,7 +201,7 @@ for (( i = start; i <= end; i++ )); do
     >&2 echo Running: "${command[@]}"
   fi
   echo "evaluating command" ${command[@]} >&2
-  eval "${command[@]}" >> "$output"
+  "${command[@]}" >> "$output"
 
   if [ $? -eq 0 ]; then
     successes+=("$manifest_path")


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
- 
## Description
turns out the command array was being built too early - before the args were parsed, so it sometimes grabbed junk or ended up empty.

dropped

```bash
command=( "${@:2}" )
```

and now build it **after** parsing:

```bash
command=("$@")
```

that way it only includes what comes after `--`, like it should.

also stopped using `eval` — now it just runs

```bash
"${command[@]}"
```

which is safer and doesn’t break on spaces.

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
