### PR TITLE
linting: Update target toolchain and `dylint` version

### DIFF
--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "4.1.0"
+dylint_linting = "5.0.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
@@ -25,7 +25,7 @@ ink_linting_utils = { workspace = true }
 ink_env = { version = "=6.0.0-beta.1", path = "../../crates/env" }
 
 [dev-dependencies]
-dylint_testing = "4.1.0"
+dylint_testing = "5.0.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
 # library with `--default-features=std` (see the `features` section below).

--- a/linting/extra/src/non_fallible_api.rs
+++ b/linting/extra/src/non_fallible_api.rs
@@ -303,8 +303,8 @@ impl<'tcx> LateLintPass<'tcx> for NonFallibleAPI {
             let contract_impl = cx.tcx.hir_item(contract_impl_id);
             if let ItemKind::Impl(contract_impl) = contract_impl.kind;
             then {
-                contract_impl.items.iter().for_each(|impl_item| {
-                    let impl_item = cx.tcx.hir_impl_item(impl_item.id);
+                contract_impl.items.iter().for_each(|impl_item_id| {
+                    let impl_item = cx.tcx.hir_impl_item(*impl_item_id);
                     if let ImplItemKind::Fn(..) = impl_item.kind {
                         let mut visitor = APIUsageChecker::new(cx);
                         visitor.visit_impl_item(impl_item);

--- a/linting/extra/src/storage_never_freed.rs
+++ b/linting/extra/src/storage_never_freed.rs
@@ -187,7 +187,7 @@ fn find_collection_def_id(
 fn find_collection_fields(cx: &LateContext, storage_struct_id: ItemId) -> FieldsMap {
     let mut result = FieldsMap::new();
     let item = cx.tcx.hir_item(storage_struct_id);
-    if let ItemKind::Struct(_, var_data, _) = item.kind {
+    if let ItemKind::Struct(_, _, var_data) = item.kind {
         var_data.fields().iter().for_each(|field_def| {
             if_chain! {
                 // Collection fields of the storage are expanded like this:
@@ -322,8 +322,8 @@ impl<'tcx> LateLintPass<'tcx> for StorageNeverFreed {
             let contract_impl = cx.tcx.hir_item(contract_impl_id);
             if let ItemKind::Impl(contract_impl) = contract_impl.kind;
             then {
-                contract_impl.items.iter().for_each(|impl_item| {
-                    let impl_item = cx.tcx.hir_impl_item(impl_item.id);
+                contract_impl.items.iter().for_each(|impl_item_id| {
+                    let impl_item = cx.tcx.hir_impl_item(*impl_item_id);
                     if let ImplItemKind::Fn(_, fn_body_id) = impl_item.kind {
                         let mut visitor = InsertRemoveCollector::new(&mut fields);
                         walk_body(&mut visitor, cx.tcx.hir_body(fn_body_id));

--- a/linting/extra/src/strict_balance_equality.rs
+++ b/linting/extra/src/strict_balance_equality.rs
@@ -23,7 +23,7 @@ use ink_linting_utils::{
 use rustc_errors::Applicability;
 use rustc_hir::{
     self as hir,
-    AssocItemKind,
+    ImplItemKind,
     ItemKind,
     def_id::DefId,
 };
@@ -535,13 +535,14 @@ impl<'tcx> LateLintPass<'tcx> for StrictBalanceEquality {
             if let ItemKind::Impl(contract_impl) = contract_impl.kind;
             then {
                 let mut fun_cache = VisitedFunctionsCache::new();
-                contract_impl.items.iter().for_each(|impl_item| {
-                    if let AssocItemKind::Fn { .. } = impl_item.kind {
+                contract_impl.items.iter().for_each(|impl_item_id| {
+                    let impl_item = cx.tcx.hir_impl_item(*impl_item_id);
+                    if let ImplItemKind::Fn(..) = impl_item.kind {
                         self.check_contract_fun(
                             cx,
                             &mut fun_cache,
                             impl_item.span,
-                            impl_item.id.owner_id.to_def_id(),
+                            impl_item_id.owner_id.to_def_id(),
                         )
                     }
                 })

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -17,14 +17,14 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "4.1.0"
+dylint_linting = "5.0.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
 
 [dev-dependencies]
-dylint_testing = "4.1.0"
+dylint_testing = "5.0.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
 # library with `--default-features=std` (see the `features` section below).

--- a/linting/rust-toolchain.toml
+++ b/linting/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://github.com/trailofbits/dylint/blob/master/internal/template/rust-toolchain
 
 [toolchain]
-channel = "nightly-2025-05-14"
+channel = "nightly-2025-09-18"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -18,8 +18,8 @@ if_chain = "1.0.2"
 
 # The following `rev` is taken from the examples of the
 # dylint version that we use:
-# https://github.com/trailofbits/dylint/blob/v4.1.0/examples/supplementary/Cargo.toml#L40
-ink_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "0450db33a5d8587f7c1d4b6d233dac963605766b" }
+# https://github.com/trailofbits/dylint/blob/v5.0.0/examples/supplementary/Cargo.toml#L44
+ink_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/linting/utils/src/lib.rs
+++ b/linting/utils/src/lib.rs
@@ -68,7 +68,7 @@ use rustc_span::Symbol;
 /// to express that a type satisfies some property.
 ///
 /// [rust-markers]: https://doc.rust-lang.org/std/marker/index.html
-fn storage_marker_trait(tcx: TyCtxt) -> Option<&DefId> {
+fn storage_marker_trait(tcx: TyCtxt<'_>) -> Option<&DefId> {
     tcx.traits(LOCAL_CRATE).iter().find(|trait_def_id| {
         tcx.item_name(**trait_def_id).as_str() == "__ink_StorageMarker"
     })
@@ -110,7 +110,7 @@ fn has_storage_attr(cx: &LateContext, hir: HirId) -> bool {
 /// Returns `DefId` of the `struct` annotated with `#[ink(storage)]` (if any).
 ///
 /// See [`storage_marker_trait`].
-pub fn find_storage_struct_def(tcx: TyCtxt) -> Option<&DefId> {
+pub fn find_storage_struct_def(tcx: TyCtxt<'_>) -> Option<&DefId> {
     let storage_marker_trait_id = storage_marker_trait(tcx)?;
     let storage_marker_impls = tcx
         .trait_impls_of(storage_marker_trait_id)
@@ -164,7 +164,7 @@ pub fn find_storage_struct(cx: &LateContext, item_ids: &[ItemId]) -> Option<Item
 /// implementations of a contract.
 fn items_in_unnamed_const(cx: &LateContext<'_>, id: &ItemId) -> Vec<ItemId> {
     if_chain! {
-        if let ItemKind::Const(_, ty, _, body_id) = cx.tcx.hir_item(*id).kind;
+        if let ItemKind::Const(_, _, ty, body_id) = cx.tcx.hir_item(*id).kind;
         if let TyKind::Tup([]) = ty.kind;
         let body = cx.tcx.hir_body(body_id);
         if let ExprKind::Block(block, _) = body.value.kind;


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Fixes linting infra compilation errors caused by `zero-copy >= "0.8.30"` (see https://github.com/use-ink/ink/actions/runs/19660618569/job/56310237609#step:4:661)

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
