### PR TITLE
fix: Always `const` eval selector bytes in codegen

### DIFF
--- a/crates/ink/codegen/src/generator/trait_def/message_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/message_builder.rs
@@ -216,7 +216,11 @@ impl MessageBuilder<'_> {
                             let signature =
                                 sol::utils::call_signature(name, message.inputs());
                             (
-                                quote!(::ink::codegen::sol::selector_bytes(#signature)),
+                                quote! {
+                                    const {
+                                        ::ink::codegen::sol::selector_bytes(#signature)
+                                    }
+                                },
                                 quote!(::ink::abi::Sol),
                             )
                         }

--- a/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/ink/codegen/src/generator/trait_def/trait_registry.rs
@@ -357,7 +357,9 @@ impl TraitRegistry<'_> {
                     let name = message.normalized_name();
                     let signature = sol::utils::call_signature(name, message.inputs());
                     let selector_bytes = quote! {
-                        ::ink::codegen::sol::selector_bytes(#signature)
+                        const {
+                            ::ink::codegen::sol::selector_bytes(#signature)
+                        }
                     };
                     let selector_id = quote!(
                         {


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on a specific version of `cargo-contract` or `pallet-revive`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
