### PR TITLE
chore: remove unused Default derive

### DIFF
--- a/integration-tests/internal/call-builder-return-value/lib.rs
+++ b/integration-tests/internal/call-builder-return-value/lib.rs
@@ -23,7 +23,6 @@ mod call_builder {
     };
 
     #[ink(storage)]
-    #[derive(Default)]
     pub struct CallBuilderReturnValue {
         /// Since we're going to `DelegateCall` into the `incrementer` contract, we need
         /// to make sure our storage layout matches.


### PR DESCRIPTION
The Default derive on the storage struct is not used and not required. Removing it simplifies the code without affecting behavior.
